### PR TITLE
feat(projects): add htop.dev package

### DIFF
--- a/projects/htop.dev/package.yml
+++ b/projects/htop.dev/package.yml
@@ -1,11 +1,9 @@
 distributable:
-  # url: https://github.com/htop-dev/htop/archive/refs/tags/{{version}}.tar.gz
   url: https://github.com/htop-dev/htop/releases/download/{{version}}/htop-{{version}}.tar.xz
   strip-components: 1
 
 versions:
   github: htop-dev/htop/tags
-  strip: /v/
 
 dependencies:
   invisible-island.net/ncurses: 6
@@ -21,6 +19,7 @@ build:
     ./autogen.sh && \
     ./configure --prefix={{prefix}} && \
     make
+    make install
   test:
     make test
 

--- a/projects/htop.dev/package.yml
+++ b/projects/htop.dev/package.yml
@@ -19,10 +19,11 @@ build:
     invisible-island.net/ncurses: 6
   script: |
     ./autogen.sh && \
-    ./configure --prefix=/.tea/htop.dev/ && \
+    ./configure --prefix={{prefix}} && \
     make
   test:
     make test
+
 
 test:
   script: |

--- a/projects/htop.dev/package.yml
+++ b/projects/htop.dev/package.yml
@@ -14,9 +14,7 @@ build:
     tea.xyz/gx/make: '*'
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
-    invisible-island.net/ncurses: 6
   script: |
-    ./autogen.sh && \
     ./configure --prefix={{prefix}} && \
     make
     make install

--- a/projects/htop.dev/package.yml
+++ b/projects/htop.dev/package.yml
@@ -15,7 +15,7 @@ build:
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
   script: |
-    ./configure --prefix={{prefix}} && \
+    ./configure --prefix={{prefix}}
     make
     make install
   test:

--- a/projects/htop.dev/package.yml
+++ b/projects/htop.dev/package.yml
@@ -1,0 +1,29 @@
+distributable:
+  # url: https://github.com/htop-dev/htop/archive/refs/tags/{{version}}.tar.gz
+  url: https://github.com/htop-dev/htop/releases/download/{{version}}/htop-{{version}}.tar.xz
+  strip-components: 1
+
+versions:
+  github: htop-dev/htop/tags
+  strip: /v/
+
+dependencies:
+  invisible-island.net/ncurses: 6
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
+    invisible-island.net/ncurses: 6
+  script: |
+    ./autogen.sh && \
+    ./configure --prefix=/.tea/htop.dev/ && \
+    make
+  test:
+    make test
+
+test:
+  script: |
+    htop -h


### PR DESCRIPTION
I have issues building this locally. 

```
configure: error: in `/Users/mfts/.tea/htop.dev/src/v3.2.1':
configure: error: C compiler cannot create executables
See `config.log' for more details
error: Uncaught (in promise) Error: cmd failed: 77: /Users/mfts/.tea/htop.dev/src/build.sh
```