### PR TITLE
+lua.org

### DIFF
--- a/projects/lua.org/package.yml
+++ b/projects/lua.org/package.yml
@@ -16,6 +16,7 @@ build:
 
   script: |
     make all
+    mkdir {{prefix}}/{bin,lib}
     mv src/{lua,luac} {{prefix}}/bin
     mv src/liblua.a {{prefix}}/lib
 

--- a/projects/lua.org/package.yml
+++ b/projects/lua.org/package.yml
@@ -1,0 +1,25 @@
+distributable:
+  url: http://www.lua.org/ftp/lua-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  - 5.4.4
+
+provides:
+  - bin/lua
+  - bin/luac
+ 
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+
+  script: |
+    make all
+    mv src/{lua,luac} {{prefix}}/bin
+    mv src/liblua.a {{prefix}}/lib
+
+test:
+  script: |
+    make test
+  working-directory: build

--- a/projects/utah.edu/jctl/package.yml
+++ b/projects/utah.edu/jctl/package.yml
@@ -3,14 +3,13 @@ distributable:
   strip-components: 1
 
 versions:
-  github: univ-of-utah-marriott-library-apple/jctl/tags
+  - 1.1.18
 
 build:
   script: |
-    echo hi
-    touch jctl
+    touch "{{prefix}}"/test
 
 test:
   script: |
-    echo hi
+    ls -l
   working-directory: build

--- a/projects/utah.edu/jctl/package.yml
+++ b/projects/utah.edu/jctl/package.yml
@@ -1,0 +1,16 @@
+distributable:
+  url: https://github.com/univ-of-utah-marriott-library-apple/jctl/releases/download/{{version}}/jctl-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: univ-of-utah-marriott-library-apple/jctl/tags
+
+build:
+  script: |
+    echo hi
+    touch jctl
+
+test:
+  script: |
+    echo hi
+  working-directory: build


### PR DESCRIPTION
This package builds on macOS but not my Linux container (I'm assuming because it's a container). I've tried to set up a full VM but it's taking me too much time right now (I can do it later tonight or tomorrow). I'm hoping this is either working on full Linux or it's an easy fix that someone can help me with because it can't find string.h, which seems pretty silly to me.

This is the build error.

```
...
gcc -std=gnu99 -O2 -Wall -Wextra -DLUA_COMPAT_5_3 -DLUA_USE_LINUX    -c -o lapi.o lapi.c
lapi.c:15:10: fatal error: 'string.h' file not found
#include <string.h>
         ^~~~~~~~~~
1 error generated.
make[3]: *** [<builtin>: lapi.o] Error 1
make[3]: Leaving directory '/opt/tea/lua.org/src/v5.4.4/src'
make[2]: *** [Makefile:123: linux-noreadline] Error 2
make[2]: Leaving directory '/opt/tea/lua.org/src/v5.4.4/src'
make[1]: *** [Makefile:99: guess] Error 2
make[1]: Leaving directory '/opt/tea/lua.org/src/v5.4.4/src'
make: *** [Makefile:55: guess] Error 2
error: Uncaught (in promise) Error: cmd failed: 2: /opt/tea/lua.org/src/build.sh
    if (!exit.success) throw new RunError(exit.code, cmd)
                             ^
    at run (file:///opt/build/pantry.core/src/utils/index.ts:220:30)
    at async build (file:///opt/build/pantry.core/scripts/build/build.ts:113:5)
    at async __build (file:///opt/build/pantry.core/scripts/build/build.ts:35:24)
    at async _build (file:///opt/build/pantry.core/scripts/build/build.ts:22:12)
    at async file:///opt/build/pantry.core/scripts/build.ts:47:3
```