### PR TITLE
+lua.org

### DIFF
--- a/projects/lua.org/package.yml
+++ b/projects/lua.org/package.yml
@@ -1,0 +1,26 @@
+distributable:
+  url: http://www.lua.org/ftp/lua-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  - 5.4.4
+
+provides:
+  - bin/lua
+  - bin/luac
+ 
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+
+  script: |
+    make all
+    mkdir {{prefix}}/{bin,lib}
+    mv src/{lua,luac} {{prefix}}/bin
+    mv src/liblua.a {{prefix}}/lib
+
+test:
+  script: |
+    make test
+  working-directory: build

--- a/projects/lua.org/package.yml
+++ b/projects/lua.org/package.yml
@@ -15,12 +15,11 @@ build:
     tea.xyz/gx/make: '*'
 
   script: |
-    make all
-    mkdir {{prefix}}/{bin,lib}
-    mv src/{lua,luac} {{prefix}}/bin
-    mv src/liblua.a {{prefix}}/lib
+    make all INSTALL_TOP={{prefix}}
+    make install INSTALL_TOP={{prefix}}
+    make test
 
 test:
   script: |
-    make test
+    lua -v
   working-directory: build


### PR DESCRIPTION
This package builds on macOS but not my Linux container (I'm assuming because it's a container). I've tried to set up a full VM but it's taking me too much time right now (I can do it later tonight or tomorrow). I'm hoping this is either working on full Linux or it's an easy fix that someone can help me with because it can't find string.h, which seems pretty silly to me.

Here's the lua build instructions

https://www.lua.org/download.html
https://www.lua.org/faq.html#1.1

This is the build error I'm getting.

```
...
gcc -std=gnu99 -O2 -Wall -Wextra -DLUA_COMPAT_5_3 -DLUA_USE_LINUX    -c -o lapi.o lapi.c
lapi.c:15:10: fatal error: 'string.h' file not found
#include <string.h>
         ^~~~~~~~~~
1 error generated.
make[3]: *** [<builtin>: lapi.o] Error 1
make[3]: Leaving directory '/opt/tea/lua.org/src/v5.4.4/src'
make[2]: *** [Makefile:123: linux-noreadline] Error 2
make[2]: Leaving directory '/opt/tea/lua.org/src/v5.4.4/src'
make[1]: *** [Makefile:99: guess] Error 2
make[1]: Leaving directory '/opt/tea/lua.org/src/v5.4.4/src'
make: *** [Makefile:55: guess] Error 2
error: Uncaught (in promise) Error: cmd failed: 2: /opt/tea/lua.org/src/build.sh
    if (!exit.success) throw new RunError(exit.code, cmd)
                             ^
    at run (file:///opt/build/pantry.core/src/utils/index.ts:220:30)
    at async build (file:///opt/build/pantry.core/scripts/build/build.ts:113:5)
    at async __build (file:///opt/build/pantry.core/scripts/build/build.ts:35:24)
    at async _build (file:///opt/build/pantry.core/scripts/build/build.ts:22:12)
    at async file:///opt/build/pantry.core/scripts/build.ts:47:3
```