### PR TITLE
GitHub.com/rhash

### DIFF
--- a/projects/github.com/rhash/RHash/package.yml
+++ b/projects/github.com/rhash/RHash/package.yml
@@ -1,0 +1,34 @@
+distributable:
+  url: https://github.com/rhash/RHash/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: rhash/RHash/releases/tags
+
+provides:
+  - bin/whirlpool-hash
+  - bin/tiger-hash
+  - bin/tth-hash
+  - bin/rhash
+  - bin/sfv-hash
+  - bin/magnet-link
+  - bin/has160-hash
+  - bin/gost12-256-hash
+  - bin/gost12-512-hash
+  - bin/edonr512-hash
+  - bin/edonr256-hash
+  - bin/ed2k-link
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+  script: |
+    ./configure --prefix={{ prefix }}
+    make --jobs {{ hw.concurrency }}
+    make --jobs {{ hw.concurrency }} install
+    make test
+
+test:
+  script: |
+    rhash --version

--- a/projects/haskell.org/cabal/package.yml
+++ b/projects/haskell.org/cabal/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: http://hackage.haskell.org/packages/archive/cabal-install/{{ version }}.0/cabal-install-{{ version }}.0.tar.gz
+  url: https://hackage.haskell.org/packages/archive/cabal-install/{{ version }}.0/cabal-install-{{ version }}.0.tar.gz
   strip-components: 1
 
 versions:


### PR DESCRIPTION
I don't know anything about this software. It is a dependency for https://github.com/mikefarah/yq, which I'm trying to make. I'm sure this PR needs work. For starters, the url that I've got in my package.yml file doesn't work for me. See https://github.com/teaxyz/pantry.extra/issues/15. The url in package.yml is patterned after the package files in pantry.core and pantry.extra. This is the url that I used on my machine:

```
  url: https://codeload.github.com/rhash/RHash/tar.gz/refs/tags/v{{ version }}
```
