### PR TITLE
+catb.org/wumpus

### DIFF
--- a/projects/catb.org/wumpus/package.yml
+++ b/projects/catb.org/wumpus/package.yml
@@ -1,0 +1,27 @@
+distributable:
+  url: http://www.catb.org/~esr/wumpus/wumpus-1.7.tar.gz
+  strip-components: 1
+
+# When https://gitlab.com/esr/wumpus/-/merge_requests/3 is merged, then switch to
+#   https://gitlab.com/esr/wumpus/-/archive/{{ version.raw }}/wumpus-{{ version.raw }}.tar.gz
+
+versions:
+  - 1.7
+
+# TODO: Is there a gitlab version provider?
+
+provides:
+  - bin/wumpus
+  - bin/superhack
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+
+  script: |
+    make
+    make prefix={{prefix}} install
+
+test:
+  script: echo no way to test this


### PR DESCRIPTION
This isn't the final formula. There's a 1.8 version on GitLab, but it isn't building correctly. I submitted a PR on GitLab to get that fixed. When it's merged then this formula can point to that version.

Also, is there a gitlab version provider?