### PR TITLE
+crates.io/ripgrep

### DIFF
--- a/projects/crates.io/ripgrep/package.yml
+++ b/projects/crates.io/ripgrep/package.yml
@@ -1,0 +1,22 @@
+distributable:
+  url: https://github.com/BurntSushi/ripgrep/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/rg
+
+versions:
+  github: BurntSushi/ripgrep/tags
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.34'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script: |
+    rg hello $FIXTURE
+  fixture: |
+    hello, world


### PR DESCRIPTION
Adding the beloved `grep` replacement.