### PR TITLE
+crates.io/fd-find

### DIFF
--- a/projects/crates.io/fd-find/package.yml
+++ b/projects/crates.io/fd-find/package.yml
@@ -1,0 +1,23 @@
+distributable:
+  url: https://github.com/sharkdp/fd/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/fd
+
+versions:
+  github: sharkdp/fd/tags
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.60'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script: |
+    mv $FIXTURE test.cpp
+    fd -e cpp test
+  fixture: |
+    hello, world

--- a/projects/crates.io/fd-find/package.yml
+++ b/projects/crates.io/fd-find/package.yml
@@ -10,6 +10,7 @@ versions:
 
 build:
   dependencies:
+    tea.xyz/gx/make: '*'
     rust-lang.org: '>=1.60'
     rust-lang.org/cargo: '*'
   script:


### PR DESCRIPTION
Adding the very useful [fd](https://github.com/sharkdp/fd) utility, a replacement for `find`.