### PR TITLE
feat(projects): add rustls

### DIFF
--- a/projects/crates.io/rustls/package.yml
+++ b/projects/crates.io/rustls/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://codeload.github.com/rustls/rustls/tar.gz/refs/tags/v/{{version}}
+  strip-components: 1
+
+provides:
+  - bin/rustls
+
+versions:
+  github: rustls/rustls/tags
+  strip: /v\//
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script: |
+    cargo build --release --package rustls --lib --out-dir {{prefix}} -Z unstable-options
+
+test:
+  script: true #FIXME


### PR DESCRIPTION
Rustls is a library that builds to a `.rlib` file; currently not sure how we'd consume it. 

`curl` can use `rustls` with their C-bindings here: https://github.com/rustls/rustls-ffi 

