### PR TITLE
fix librsvg

### DIFF
--- a/projects/gnome.org/librsvg/package.yml
+++ b/projects/gnome.org/librsvg/package.yml
@@ -4,6 +4,7 @@ distributable:
 
 versions:
   github: GNOME/librsvg/tags
+  ignore: [2.55.90] # https://gitlab.gnome.org/GNOME/librsvg/-/issues/923 - sigh
 
 dependencies:
   cairographics.org: 1
@@ -16,7 +17,8 @@ build:
   dependencies:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
-    rust-lang.org: 1
+    rust-lang.org/cargo: 0
+    rust-lang.org: ^1.63
     freedesktop.org/pkg-config: ^0.29
     gnome.org/gobject-introspection: 1
     python.org: 3


### PR DESCRIPTION
@mxcl this is a weird one. It appears to having issues with ${{deps.cairographics.org.prefix}}/lib/libcairo.la, which contains the build paths to the dependencies:

```
# Libraries that this one depends upon.
dependency_libs=' -L/opt/pixman.org/v0.40.0/lib/pkgconfig/../../lib /opt/pixman.org/v0.40.0/lib/libpixman-1.la -lm -L/opt/freedesktop.org/fontconfig/v2.14.0/lib/pkgconfig/../../lib -L/opt/freetype.org/v2.12.1/lib/pkgconfig/../../lib /opt/freedesktop.org/fontconfig/v2.14.0/lib/libfontconfig.la -L/opt/libexpat.github.io/v2.4.9/lib/pkgconfig/../../lib /opt/libexpat.github.io/v2.4.9/lib/libexpat.la -lfreetype -L/opt/libpng.org/v1.6.35/lib/pkgconfig/../../lib -L/opt/zlib.net/v1.2.13/lib/pkgconfig/../../lib /opt/libpng.org/v1.6.35/lib/libpng16.la -lz'
```

Obviously, we can fix this up on a per-*install* basis, but it seems like maybe the answer is to _kill all the .la files_:

https://www.linuxfromscratch.org/blfs/view/svn/introduction/la-files.html