### PR TITLE
allow us to build pre-0.14 (C++17) versions

### DIFF
--- a/projects/nixos.org/patchelf/package.yml
+++ b/projects/nixos.org/patchelf/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/NixOS/patchelf/releases/download/{{version}}/patchelf-{{version}}.tar.bz2
+  url: https://github.com/NixOS/patchelf/archive/refs/tags/{{version.raw}}.tar.gz
   strip-components: 1
 
 versions:
@@ -10,7 +10,10 @@ build:
   dependencies:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
   script: |
+    test -f bootstrap.sh && ./bootstrap.sh
     ./configure --prefix={{prefix}}
     make --jobs {{hw.concurrency}} install
 


### PR DESCRIPTION
needed for debian:stretch-slim