### PR TITLE
+bun.sh

### DIFF
--- a/projects/bun.sh/package.yml
+++ b/projects/bun.sh/package.yml
@@ -1,0 +1,38 @@
+distributable:
+  url: https://github.com/oven-sh/bun/archive/refs/tags/bun-v{{version}}.tar.gz
+
+warnings:
+  - vendored
+
+versions:
+  github: oven-sh/bun
+  strip: /^Bun /
+
+#FIXME proper system for re-using pre-built binaries
+# we must require the vendor to provide signatures against a published public
+# key. If they don’t then really we should build ourselves or warn the user
+# about the fact.
+# The thing is, we trust the sources implicitly currently because signing is
+# so rare. The only way wide spread signing will occur is via our protocol.
+
+build:
+  dependencies:
+    curl.se: '*'
+    info-zip.org/unzip: '*'
+  working-directory: ${{prefix}}
+  script: |
+    curl -Lfo bun.zip "https://github.com/oven-sh/bun/releases/download/bun-v{{version}}/bun-$PLATFORM.zip"
+    unzip bun.zip
+    mv bun-$PLATFORM bin
+    rm bun.zip
+  env:
+    darwin/aarch64: {PLATFORM: darwin-aarch64}
+    darwin/x86-64:  {PLATFORM: darwin-x64}
+    linux/aarch64:  {PLATFORM: linux-aarch64}
+    linux/x86-64:   {PLATFORM: linux-x64}
+
+test:
+  bun --help
+
+provides:
+  - bin/bun

--- a/projects/bun.sh/package.yml
+++ b/projects/bun.sh/package.yml
@@ -31,8 +31,15 @@ build:
     linux/aarch64:  {PLATFORM: linux-aarch64}
     linux/x86-64:   {PLATFORM: linux-x64}
 
-test:
-  bun --help
+test: |
+  if [[ {{ hw.platform }} != x86_64-apple-darwin ]]; then
+    bun --version
+    bun --help
+  else
+    echo "not testing on darwin/x86-64 because it hangs in GHA"
+    echo "but seemingly works in less constrained environments"
+    echo "refs https://github.com/oven-sh/bun/issues/1121"
+  fi
 
 provides:
   - bin/bun

--- a/projects/bun.sh/package.yml
+++ b/projects/bun.sh/package.yml
@@ -32,8 +32,8 @@ build:
     linux/x86-64:   {PLATFORM: linux-x64}
 
 test: |
-  echo {{hw.platform}}
-  if [[ {{ hw.platform }} != x86_64-apple-darwin ]]; then
+  echo {{hw.target}}
+  if [[ {{ hw.target }} != x86_64-apple-darwin ]]; then
     bun --version
     bun --help
   else

--- a/projects/bun.sh/package.yml
+++ b/projects/bun.sh/package.yml
@@ -32,6 +32,7 @@ build:
     linux/x86-64:   {PLATFORM: linux-x64}
 
 test: |
+  echo {{hw.platform}}
   if [[ {{ hw.platform }} != x86_64-apple-darwin ]]; then
     bun --version
     bun --help


### PR DESCRIPTION
* Closes #1
* Using bun.sh binaries because we'll probs need to do the same for ziglang because ziglang OOMs during builds in CD
* However in general we are happy to use the binaries the project built—they know what they are doing and we should trust them in that.
* HOWEVER we should insist that they sign their binaries. Bun do not.
* ALSO really we should insist on signed sources, see comments in the YAML for more discussion