### PR TITLE
evolution of prql

### DIFF
--- a/projects/prql-lang.org/package.yml
+++ b/projects/prql-lang.org/package.yml
@@ -8,9 +8,15 @@ versions:
 build:
   dependencies:
     rust-lang.org/cargo: '*'
+  working-directory: prql-compiler
   script: |
-    cd ./prql-compiler
-    cargo install --path . --root {{prefix}} --all-features
+    if test {{version.major}} -eq 0 -a {{version.minor}} -lt 4; then
+      cargo install --path . --root {{prefix}}
+    elif test "{{version}}" = "0.4.0"; then
+      cargo install --path . --root {{prefix}} --all-features
+    else
+      cargo install --path prqlc --root {{prefix}}
+    fi
 
     cd {{prefix}}/bin
 


### PR DESCRIPTION
I don't call this pretty, but this is life when build parameters drift.

@mxcl we should perhaps consider something like `package.$semverString.yml` to make different versions for anything other than $latest. Then you should be able to use semver.intersects() to quickly see if any of the package.ymls match.