### PR TITLE
fix bunx shx looking for node

### DIFF
--- a/projects/bun.sh/package.yml
+++ b/projects/bun.sh/package.yml
@@ -33,9 +33,18 @@ build:
     linux/aarch64:  {PLATFORM: linux-aarch64}
     linux/x86-64:   {PLATFORM: linux-x64}
 
-test: |
-  bun --help
-  bunx shx ls
+test:
+  script: |
+    bun --help
+    cp $FIXTURE cat.ts
+    bun run cat.ts cat.ts
+  fixture: |
+    import { resolve } from "path";
+    const { write, stdout, file } = Bun;
+    import { argv } from "process";
+
+    const path = resolve(argv.at(-1)!);
+    await write(stdout, file(path));
 
 provides:
   - bin/bun


### PR DESCRIPTION
```sh
bun: a fast bundler, transpiler, JavaScript Runtime and package manager for web software.

  run       ./my-script.ts        Run JavaScript with bun, a package.json script, or a bin
  x         bun-repl              Install and execute a package bin (bunx)

  init                            Start an empty Bun project from a blank template
  create    next ./app            Create a new project from a template (bun c)
  install                         Install dependencies for a package.json (bun i)
  add       @evan/duckdb          Add a dependency to package.json (bun a)
  link                            Link an npm package globally
  remove    is-array              Remove a dependency from package.json (bun rm)
  unlink                          Globally unlink an npm package
  pm                              More commands for managing packages

  dev       ./a.ts ./b.jsx        Start a bun (frontend) Dev Server
  bun       ./a.ts ./b.jsx        Bundle dependencies of input files into a .bun

  upgrade                         Get the latest version of bun
  completions                     Install shell completions for tab-completion
  discord                         Open bun's Discord server
  help                            Print this help menu
env: node: No such file or directory
error: "shx" exited with code 127
due to error, didn’t delete: ~/actions-runner/_work/pantry.core/pantry.core/tea.xyz/tmp/bun.sh=0.5.07054c4fc
error: Uncaught (in promise) Error: cmd failed: 127: /Users/builder/actions-runner/_work/pantry.core/pantry.core/tea.xyz/tmp/bun.sh=0.5.07054c4fc/test.sh
```