### PR TITLE
Gitignore `.DS_Store`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Bottling on macOS without gitignoring `.DS_Store` is a bit of a nightmare.

<img width="386" alt="CleanShot 2023-01-27 at 20 58 47@2x" src="https://user-images.githubusercontent.com/2538074/215196348-ffa138c4-21aa-48bb-a11d-5b56f93e44f3.png">

This should help alleviate things.

As a side note, maybe this should also be done on pantry.core and pantry.zero.