### PR TITLE
+gnu.org/glibc

### DIFF
--- a/projects/gnu.org/glibc/package.yml
+++ b/projects/gnu.org/glibc/package.yml
@@ -1,0 +1,114 @@
+distributable:
+  url: https://ftp.gnu.org/gnu/glibc/glibc-{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://ftp.gnu.org/gnu/glibc/
+  match: /glibc-[0-9]+(\.[0-9]+)+\.tar\.gz/
+  strip:
+    - /^glibc-/
+    - /\.tar\.gz$/
+
+platforms: linux
+
+build:
+  dependencies:
+    gnu.org/make: '>=3.79'
+    gnu.org/gawk: '>=3'
+    gnu.org/gcc: '*'
+    gnu.org/gettext: '*'
+    gnu.org/texinfo: '*'
+    gnu.org/bison: '*'
+    perl.org: '*'
+    python.org: ^3.13
+  working-directory: build
+  script:
+    - ../configure $ARGS
+    - make all
+    - make install
+
+    - run: for s in $SCRIPTS; do sed -i 's|{{prefix}}|"$(cd "$(dirname "$0")/.." \&\& pwd)"|' $s; done
+      working-directory: ${{prefix}}/bin
+
+    - run: ln -s ../lib/glibc/ld-{{ version.marketing }}.so ld.so
+      working-directory: ${{prefix}}/bin
+  test: make test
+  env:
+    SCRIPTS:
+      - catchsegv
+      - ldd
+      - mtrace
+      - sotruss
+      - tzselect
+      - xtrace
+    ARGS:
+      - --prefix={{ prefix }}
+      - --libdir={{ prefix }}/lib/glibc
+      - --disable-debug
+      - --disable-dependency-tracking
+      - --disable-silent-rules
+      - --disable-werror
+      - --enable-obsolete-rpc
+      - --without-gd
+      - --without-selinux
+      - --enable-kernel=2.6.0
+      - --with-binutils={{deps.gnu.org/binutils.prefix}}/bin
+      - --disable-multi-arch
+    CFLAGS: -O2 -fPIC
+    CXXFLAGS: -O2 -fPIC
+    LDFLAGS: -pie
+
+test:
+  dependencies:
+    gnu.org/gcc: '*'
+  env:
+    linux/x86-64:
+      ARCH: x86_64
+    linux/aarch64:
+      ARCH: aarch64
+  script:
+    - gcc -o test1 test.c -fPIC -pie
+    - ./test1
+
+    - gcc 
+      -nostdinc 
+      -nostdlib 
+      -I{{deps.gnu.org/gcc.prefix}}/lib/gcc/$ARCH-unknown-linux-gnu/{{deps.gnu.org/gcc.version}}/include 
+      -Wl,--rpath="{{prefix}}/lib/glibc" 
+      -Wl,--dynamic-linker={{prefix}}/lib/glibc/ld-{{version.marketing}}.so 
+      -std=c11 
+      -o test2 
+      -v 
+      $CFLAGS 
+      {{prefix}}/lib/glibc/crti.o 
+      {{prefix}}/lib/glibc/crt1.o 
+      {{prefix}}/lib/glibc/crtn.o 
+      test.c 
+      -fPIC 
+      -pie
+    - test "$(./test2)" = "gnu_get_libc_version() = {{version.marketing}}"
+
+provides:
+  - bin/catchsegv
+  - bin/gencat
+  - bin/getconf
+  - bin/getent
+  - bin/iconv
+  - bin/ldd
+  - bin/locale
+  - bin/localedef
+  - bin/makedb
+  - bin/mtrace
+  - bin/pcprofiledump
+  - bin/pldd
+  - bin/sotruss
+  - bin/sprof
+  - bin/tzselect
+  - bin/xtrace
+  - sbin/iconvconfig
+  - sbin/ldconfig
+  - sbin/nscd
+  - sbin/sln
+  - sbin/zdump
+  - sbin/zic
+

--- a/projects/gnu.org/glibc/test.c
+++ b/projects/gnu.org/glibc/test.c
@@ -1,0 +1,8 @@
+#define _GNU_SOURCE
+#include <gnu/libc-version.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    /* Basic library version check. */
+    printf("gnu_get_libc_version() = %s\n", gnu_get_libc_version());
+}


### PR DESCRIPTION
- [x] debootstrap binutils/gcc
- [x] build glibc
- [x] use glibc without segfault

@mxcl // @jonchang I'd love some eyes on this. Currently, things using the new glibc like to segfault. I'm guessing I need to runtime.env.$some_env_vars to make it first on the list of `libc`s looked for.