### PR TITLE
fix(solidity)

### DIFF
--- a/projects/soliditylang.org/clang-error.diff
+++ b/projects/soliditylang.org/clang-error.diff
@@ -1,0 +1,12 @@
+diff --color=auto -ru a/libsolidity/lsp/DocumentHoverHandler.cpp b/libsolidity/lsp/DocumentHoverHandler.cpp
+--- a/libsolidity/lsp/DocumentHoverHandler.cpp	2023-02-01 17:33:07
++++ b/libsolidity/lsp/DocumentHoverHandler.cpp	2023-02-01 17:32:26
+@@ -63,7 +63,7 @@
+ 	auto const [sourceUnitName, lineColumn] = HandlerBase(*this).extractSourceUnitNameAndLineColumn(_args);
+ 	auto const [sourceNode, sourceOffset] = m_server.astNodeAndOffsetAtSourceLocation(sourceUnitName, lineColumn);
+ 
+-	MarkdownBuilder markdown{};
++ MarkdownBuilder markdown = {stringstream(ios_base::in)};
+ 	auto rangeToHighlight = toRange(sourceNode->location());
+ 
+ 	// Try getting the type definition of the underlying AST node, if available.

--- a/projects/soliditylang.org/package.yml
+++ b/projects/soliditylang.org/package.yml
@@ -24,8 +24,15 @@ build:
     freedesktop.org/pkg-config: ^0.29
     git-scm.org: 2
     crates.io/semverator: '*'
+    gnu.org/patch: '*'
   working-directory: build
   script: |
+    if semverator satisfies ^0.8.18 {{version}}; then
+      # New libsolidity/lsb/DocumentHoverHandler.cpp doesn't like some versions of clang
+      # (default argument issue)
+      patch -p1 -d.. <../props/clang-error.diff
+    fi
+
     cmake .. $ARGS
     make --jobs {{hw.concurrency}}
     make install

--- a/projects/soliditylang.org/package.yml
+++ b/projects/soliditylang.org/package.yml
@@ -23,12 +23,16 @@ build:
     cmake.org: 3
     freedesktop.org/pkg-config: ^0.29
     git-scm.org: 2
+    crates.io/semverator: '*'
   working-directory: build
   script: |
     cmake .. $ARGS
     make --jobs {{hw.concurrency}}
     make install
-    rm {{prefix}}/bin/solidity-upgrade
+
+    if semverator lt {{version}} 0.8.18; then
+      rm {{prefix}}/bin/solidity-upgrade
+    fi
   test:
     make test
   env:


### PR DESCRIPTION
v0.8.18 removes `solidity-upgrade`, which we were already removing.

fixes https://github.com/teaxyz/pantry.core/issues/150

patch is to fix [this](https://github.com/ethereum/solidity/issues/13854) error.