### PR TITLE
+melt

### DIFF
--- a/projects/charm.sh/melt/package.yml
+++ b/projects/charm.sh/melt/package.yml
@@ -1,0 +1,32 @@
+distributable:
+  url: https://github.com/charmbracelet/melt/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: charmbracelet/melt
+
+provides:
+  - bin/melt
+
+build:
+  script: |
+    go mod download
+    go build -v -ldflags="$LDFLAGS" ./cmd/melt
+    mkdir -p "{{ prefix }}"/bin
+    mv melt "{{ prefix }}"/bin
+  dependencies:
+    go.dev: ^1.18
+    #FIXME should be this but we didn’t build 1.17 yet
+    # go.dev: ~1.17
+  env:
+    GO111MODULE: on
+    LDFLAGS:
+      [-s, -w, "-X=main.Version={{version}}"]
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  melt --help


### PR DESCRIPTION
Adds the [melt](https://github.com/charmbracelet/melt) package. A tool to backup and restore Ed25519 SSH keys with seed words :ice_cube:.