### PR TITLE
fix(zstd)

### DIFF
--- a/projects/facebook.com/zstd/package.yml
+++ b/projects/facebook.com/zstd/package.yml
@@ -40,6 +40,10 @@ build:
       - -DZSTD_ZLIB_SUPPORT=ON
       - -DZSTD_LZMA_SUPPORT=ON
       - -DZSTD_LZ4_SUPPORT=ON
+    darwin:
+      ARGS:
+        # Otherwise we get errors from clang
+        - -DCMAKE_CXX_FLAGS="-std=c++11"
 
 test: |
   export fixture="asdf123%!*"


### PR DESCRIPTION
darwin needs an explicit `-std=c++11` flag to compile as of the newest release.

fixes https://github.com/teaxyz/pantry.core/issues/245
fixes https://github.com/teaxyz/pantry.core/issues/246
