### PR TITLE
+qrencode

### DIFF
--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -24,7 +24,7 @@ build:
   script: |
     ./autogen.sh
     ./configure --disable-dependency-tracking --prefix={{prefix}} $ARGS
-    make
+    VERSION={{version}} make
     make --jobs {{ hw.concurrency }} install
 
 test: |

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -16,12 +16,12 @@ build:
   dependencies:
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
+    gnu.org/coreutils: '*'
     gnu.org/libtool: '*'
     freedesktop.org/pkg-config: '*'
   script: |
-    mkdir -p {{prefix}}/bin
     ./autogen.sh
-    ./configure --disable-dependency-tracking --prefix={{prefix}}
+    ./configure --prefix={{prefix}}
     make
     make install
 

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -14,6 +14,7 @@ dependencies:
 
 build:
   dependencies:
+    cmake.org: '*'
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
     gnu.org/coreutils: '*'

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -24,7 +24,7 @@ build:
   script: |
     ./autogen.sh
     ./configure --disable-dependency-tracking --prefix={{prefix}} $ARGS
-    '#define VERSION "{{version}}"' >> config.h
+    echo '#define VERSION "{{version}}"' >> config.h
     make
     make --jobs {{ hw.concurrency }} install
 

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -24,7 +24,8 @@ build:
   script: |
     ./autogen.sh
     ./configure --disable-dependency-tracking --prefix={{prefix}} $ARGS
-    VERSION={{version}} make
+    '#define VERSION "{{version}}"' >> config.h
+    make
     make --jobs {{ hw.concurrency }} install
 
 test: |

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -14,16 +14,16 @@ dependencies:
 
 build:
   dependencies:
-    cmake.org: '*'
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
     gnu.org/coreutils: '*'
     gnu.org/libtool: '*'
     freedesktop.org/pkg-config: '*'
   script: |
-    mkdir -p {{prefix}}/bin
     ./autogen.sh
-    ./configure --prefix={{prefix}}
+    ./configure --disable-dependency-tracking --prefix={{prefix}}
     make
     make install
 

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -25,7 +25,6 @@ build:
     ./autogen.sh
     ./configure --disable-dependency-tracking --prefix={{prefix}} $ARGS
     echo '#define VERSION "{{version}}"' >> config.h
-    make
     make --jobs {{ hw.concurrency }} install
 
 test: |

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -19,7 +19,7 @@ build:
     gnu.org/libtool: '*'
     freedesktop.org/pkg-config: '*'
   script: |
-    mkdir {{prefix}}/bin
+    mkdir -p {{prefix}}/bin
     ./autogen.sh
     ./configure --disable-dependency-tracking --prefix={{prefix}}
     make

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -23,7 +23,7 @@ build:
     freedesktop.org/pkg-config: '*'
   script: |
     ./autogen.sh
-    ./configure --disable-dependency-tracking --prefix={{prefix}}
+    ./configure --disable-dependency-tracking --prefix={{prefix}} $ARGS
     make
     make --jobs {{ hw.concurrency }} install
 

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -25,7 +25,7 @@ build:
     ./autogen.sh
     ./configure --disable-dependency-tracking --prefix={{prefix}}
     make
-    make install
+    make --jobs {{ hw.concurrency }} install
 
 test: |
   qrencode 123456789 -o test.png

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -20,6 +20,7 @@ build:
     gnu.org/libtool: '*'
     freedesktop.org/pkg-config: '*'
   script: |
+    mkdir -p {{prefix}}/bin
     ./autogen.sh
     ./configure --prefix={{prefix}}
     make

--- a/projects/github.com/fukuchi/package.yml
+++ b/projects/github.com/fukuchi/package.yml
@@ -1,0 +1,29 @@
+distributable:
+  url: https://github.com/fukuchi/libqrencode/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: fukuchi/libqrencode/tags
+  strip: /v/
+
+provides:
+  - bin/qrencode
+
+dependencies:
+  libpng.org: '*'
+
+build:
+  dependencies:
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
+    gnu.org/libtool: '*'
+    freedesktop.org/pkg-config: '*'
+  script: |
+    mkdir {{prefix}}/bin
+    ./autogen.sh
+    ./configure --disable-dependency-tracking --prefix={{prefix}}
+    make
+    make install
+
+test: |
+  qrencode 123456789 -o test.png


### PR DESCRIPTION
I'm stuck trying to package this very useful tool: https://github.com/fukuchi/libqrencode

I've based the bottle off of the [brew recipe](https://github.com/Homebrew/homebrew-core/blob/master/Formula/qrencode.rb) and the [readme](https://github.com/fukuchi/libqrencode#compile--install) but no luck:

```
$ GITHUB_TOKEN=(tea gh auth token) TEA_PANTRY_PATH="$PWD" ../pantry.core/scripts/build.ts github.com/fukuchi
[...]
libtool: warning: library '/Users/davdroman/.tea/libpng.org/v1.6.39/lib/pkgconfig/../../lib/libpng16.la' was moved.
libtool: warning: library '/Users/davdroman/.tea/libpng.org/v1.6.39/lib/pkgconfig/../../lib/libpng16.la' was moved.
```

I'd appreciate any help you could give me as I'm a bit out of my depth on this.