### PR TITLE
+crates.io/exa

### DIFF
--- a/projects/crates.io/exa/package.yml
+++ b/projects/crates.io/exa/package.yml
@@ -1,0 +1,25 @@
+distributable:
+  url: https://github.com/ogham/exa/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/exa
+
+versions:
+  github: ogham/exa/tags
+  strip: /^v/
+
+dependencies:
+  darwin:
+    zlib.net: ^1
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.60'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script: |
+    exa --version


### PR DESCRIPTION
Adds [exa](https://github.com/ogham/exa) a modern replacement for `ls`. 