### PR TITLE
fix(pnpm.io)

### DIFF
--- a/projects/pnpm.io/package.yml
+++ b/projects/pnpm.io/package.yml
@@ -10,7 +10,7 @@ provides:
   - bin/pnpm
 
 dependencies:
-  nodejs.org: '>=16'
+  nodejs.org: '^14,^16,^18'
 
 build:
   script: |


### PR DESCRIPTION
pnpm.io only shows support for even numbered node releases: https://pnpm.io/installation#compatibility

fixes https://github.com/teaxyz/pantry.core/issues/326
fixes https://github.com/teaxyz/pantry.core/issues/327