### PR TITLE
+minikube +go-bindata

### DIFF
--- a/projects/github.com/kevinburke/go-bindata/package.yml
+++ b/projects/github.com/kevinburke/go-bindata/package.yml
@@ -1,0 +1,39 @@
+distributable:
+  url: https://github.com/kevinburke/go-bindata/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: kevinburke/go-bindata
+
+provides:
+  - bin/go-bindata
+
+build:
+  dependencies:
+    go.dev: ^1.18
+    gnu.org/patch: '*'
+  script: |
+    patch -p1 <props/patch-go-modules.diff
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -ldflags="$LDFLAGS"  -o "{{ prefix }}"/bin/go-bindata ./go-bindata
+
+  env:
+    LDFLAGS:
+      [-s, -w, "-X=main.Version={{version}}"]
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script: |
+    output=$(go-bindata -version)
+    case $output in
+      *{{ version }}*)
+        echo "Version match"
+        ;;
+      *)
+        echo "Version mismatch"
+        ;;
+    esac

--- a/projects/github.com/kevinburke/go-bindata/patch-go-modules.diff
+++ b/projects/github.com/kevinburke/go-bindata/patch-go-modules.diff
@@ -1,0 +1,10 @@
+diff --git a/go.mod b/go.mod
+new file mode 100644
+index 0000000..ce4eba8
+--- /dev/null
++++ b/go.mod
+@@ -0,0 +1,3 @@
++module github.com/kevinburke/go-bindata
++
++go 1.19
+

--- a/projects/kubernetes.io/minikube/package.yml
+++ b/projects/kubernetes.io/minikube/package.yml
@@ -1,0 +1,26 @@
+distributable:
+  url: https://github.com/kubernetes/minikube/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: kubernetes/minikube/releases/tags
+
+provides:
+  - bin/minikube
+
+dependencies:
+  kubernetes.io/kubectl: '*'
+
+build:
+  dependencies:
+    tea.xyz/gx/make: '*'
+    go.dev: ^1.19
+    github.com/kevinburke/go-bindata: '*'
+  script: |
+    make
+    mkdir -p "{{ prefix }}"/bin
+    mv out/minikube "{{ prefix }}"/bin
+
+test: 
+  script: |
+    minikube version


### PR DESCRIPTION
This PR adds [minikube](https://github.com/kubernetes/minikube) and it's dependency [go-bindata](https://github.com/kevinburke/go-bindata/) to the pantry.

I had some issues getting `go-bindata` to compile in tea as it's latest release is not using go modules - which caused me further issues with `$GOROOT`, `$GOPATH` and name clashes 😅. I ended up patching in a `go.mod` file comparably to how it's done in the [nixpkgs](https://github.com/NixOS/nixpkgs/blob/9d18216aa3638f2f403cfeb2b45fc21ef822dc3c/pkgs/development/tools/go-bindata/default.nix#LL18) collection. Since the package doesn't have any external dependencies this ended up being simpler, lmk if there's a better way to work around this.

Resolves #331