### PR TITLE
fix(pnpm)

### DIFF
--- a/projects/pnpm.io/package.yml
+++ b/projects/pnpm.io/package.yml
@@ -15,6 +15,7 @@ dependencies:
 
 build:
   script: |
+    mkdir -p "{{prefix}}"
     cp bin/pnpm.cjs bin/pnpm
     cp bin/pnpx.cjs bin/pnpx
     cp -r . {{prefix}}


### PR DESCRIPTION
we don't create "{{ prefix }}" by default any more.

fixes https://github.com/teaxyz/pantry.core/issues/562
fixes https://github.com/teaxyz/pantry.core/issues/563
fixes https://github.com/teaxyz/pantry.core/issues/564
fixes https://github.com/teaxyz/pantry.core/issues/565