### PR TITLE
add bcrypt

### DIFF
--- a/projects/bcrypt.sourceforge.net/package.yml
+++ b/projects/bcrypt.sourceforge.net/package.yml
@@ -1,0 +1,32 @@
+distributable:
+  url: https://bcrypt.sourceforge.net/bcrypt-{{version.marketing}}.tar.gz
+  strip-components: 1
+
+# if there’s a github then we can parse the versions
+versions:
+  - 1.1.0
+
+dependencies:
+  zlib.net: '*'
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+  script: |
+    make LDFLAGS=$LDFLAGS PREFIX={{prefix}} install
+  env:
+    ARGS:
+      - --prefix="{{prefix}}"
+
+provides:
+  - bin/bcrypt
+
+test:
+  script: |
+    echo "Hello World!" > test.txt
+    printf '12345678\n12345678\n' | bcrypt -r test.txt
+    mv test.txt.bfe test.out.txt.bfe
+    printf '12345678\n' | bcrypt -r test.out.txt.bfe
+    cat test.out.txt
+

--- a/projects/bcrypt.sourceforge.net/package.yml
+++ b/projects/bcrypt.sourceforge.net/package.yml
@@ -2,7 +2,6 @@ distributable:
   url: https://bcrypt.sourceforge.net/bcrypt-{{version.marketing}}.tar.gz
   strip-components: 1
 
-# if there’s a github then we can parse the versions
 versions:
   - 1.1.0
 
@@ -14,10 +13,7 @@ build:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
   script: |
-    make LDFLAGS=$LDFLAGS PREFIX={{prefix}} install
-  env:
-    ARGS:
-      - --prefix="{{prefix}}"
+    make LDFLAGS=-lz PREFIX={{prefix}} install
 
 provides:
   - bin/bcrypt


### PR DESCRIPTION
building this because `libxcrypt` throws test errors on linux. https://github.com/teaxyz/pantry.extra/actions/runs/4432685158/jobs/7777001117#step:9:56

according to gpt-4, 
> If the `crypt()` function is causing errors on both Linux aarch64 and x86_64 systems, it's possible that the `crypt()` function on these systems does not support the use of the "`$2b$`" prefix for the bcrypt algorithm.

so i wanna build `libxcrypt` with bcrypt support but i'm not so sure this is the right approach. 

worst case another package added