### PR TITLE
README: Fix link to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ $ pkg edit
 ```
 
 
-[wiki]: https://github.com/teaxyz/pantry/wiki
+[wiki]: https://github.com/teaxyz/pantry.extra/wiki
 [discussion]: https://github.com/orgs/teaxyz/discussions
 [IPFS]: https://ipfs.tech


### PR DESCRIPTION
The wiki link was pointing the wrong way, should be https://github.com/teaxyz/pantry.extra/wiki