### PR TITLE
swig expects to find `config.h` without arch prefixes

### DIFF
--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -20,7 +20,15 @@ build:
   script: |
     patch -p1 < props/mkconfig.rb.diff
 
-    ./configure --prefix="{{prefix}}" --enable-load-relative --disable-rubygems --without-gmp
+    ./configure \
+      --prefix="{{prefix}}" \
+      --enable-load-relative \
+      --disable-rubygems \
+      --without-gmp \
+      --with-rubyhdrdir={{prefix}}/include \
+      --with-rubyarchhdrdir={{prefix}}/include \
+      --with-rubyarchprefix={{prefix}}/lib
+
     make --jobs {{hw.concurrency}} install
 
     cd "{{prefix}}/bin"
@@ -35,7 +43,7 @@ build:
       rm $shim.bak
     done
 
-    cd ../lib/ruby/{{version.major}}.{{version.minor}}.0
+    cd ../lib/ruby/{{version.marketing}}.0
 
     # ruby itself provides the gems for these and we don’t want that
     # we want to pkg them ourselves as part of rubygems.org
@@ -47,6 +55,11 @@ build:
       fi
       ln -s ../../../../rubygems.org/v\*/lib/$x
     done
+
+    rm -rf {{prefix}}/share/ri
+    rm -rf {{prefix}}/share/doc
+    rmdir {{prefix}}/lib/ruby/site_ruby
+    rmdir {{prefix}}/lib/ruby/vendor_ruby
   env:
     shims:
       - erb

--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -25,23 +25,25 @@ build:
       --enable-load-relative \
       --disable-rubygems \
       --without-gmp \
+      --with-rubyarchprefix={{prefix}}/lib/ruby \
       --with-rubyhdrdir={{prefix}}/include \
       --with-rubyarchhdrdir={{prefix}}/include \
-      --with-rubyarchprefix={{prefix}}/lib
+      --with-vendordir=no \
+      --with-vendorarchdir=no \
+      --with-sitedir=no \
+      --with-sitearchdir=no \
+      --disable-multiarch
 
     make --jobs {{hw.concurrency}} install
 
     cd "{{prefix}}/bin"
 
     # we provide these as `rubygems.org`
-    for GEM in bundle bundler gem rake rbs rdbg typeprof; do
-      test -f $GEM && rm $GEM
+    for x in bundle bundler gem; do
+      test -f $x && rm $x
     done
 
-    for shim in $shims; do
-      sed -i.bak -e 's_#!{{prefix}}/bin/ruby_#!/usr/bin/env ruby_' $shim
-      rm $shim.bak
-    done
+    fix-shebangs.ts *
 
     cd ../lib/ruby/{{version.marketing}}.0
 
@@ -53,44 +55,37 @@ build:
       else
         rm $x
       fi
-      ln -s ../../../../rubygems.org/v\*/lib/$x
+      ln -s ../../../../../rubygems.org/v\*/lib/$x
     done
 
-    rm -rf {{prefix}}/share/ri
-    rm -rf {{prefix}}/share/doc
-    rmdir {{prefix}}/lib/ruby/site_ruby
-    rmdir {{prefix}}/lib/ruby/vendor_ruby
-  env:
-    shims:
-      - erb
-      - irb
-      - racc
-      - rdoc
-      - ri
+    cd {{prefix}}
+    rm -rf share/ri
+    rm -rf share/doc
+    rm -rf lib/ruby/site_ruby
+    rm -rf lib/ruby/vendor_ruby
+
+    # weirdly files get put here and we can't figure out how to stop it
+    mv lib/*-{{hw.platform}}*/* lib
+    rmdir lib/*-{{hw.platform}}*
 
 test:
   dependencies:
-    #NOTE rubygems.org depends on us… so it may be difficult to test this
-    # in a bootstrap scenario…
-    rubygems.org: '*'
     tea.xyz/gx/cc: c99  # for native extensions
     tea.xyz/gx/make: '*'
   script: |
     ruby -e 'puts "Hello World!"'
-    gem install hexapdf -v 0.28.0 --bindir=. --no-user-install
-    ./hexapdf version
-    test -d "{{tea.prefix}}"/ruby-lang.org/gems/{{version.major}}.{{version.minor}}.0/gems/hexapdf-0.28.0
-    gem install bundle
-    test -d ~/.gem/ruby/{{version.major}}.{{version.minor}}.0/gems/bundle-0.0.1
-    test -f ~/.local/bin/bundle
 
 provides:
   - bin/erb
   - bin/irb
   - bin/racc
+  - bin/rake
+  - bin/rbs
+  - bin/rdbg
   - bin/rdoc
   - bin/ri
   - bin/ruby
+  - bin/typeprof
 
 interprets:
   extensions: rb

--- a/projects/rubygems.org/fit-n-finish.patch
+++ b/projects/rubygems.org/fit-n-finish.patch
@@ -1,24 +1,3 @@
-diff --git a/lib/rubygems.rb b/lib/rubygems.rb
-index e42aca8..84128e1 100644
---- a/lib/rubygems.rb
-+++ b/lib/rubygems.rb
-@@ -297,10 +297,12 @@ def self.binary_mode
-   ##
-   # The path where gem executables are to be installed.
-
--  def self.bindir(install_dir=Gem.dir)
--    return File.join install_dir, "bin" unless
--      install_dir.to_s == Gem.default_dir.to_s
--    Gem.default_bindir
-+  def self.bindir(install_dir=nil)
-+    if install_dir
-+      File.join install_dir, "bin"
-+    else
-+      Gem.default_bindir
-+    end
-   end
-
-   ##
 diff --git a/lib/rubygems/config_file.rb b/lib/rubygems/config_file.rb
 index 4aa8b4d..8354c08 100644
 --- a/lib/rubygems/config_file.rb
@@ -38,7 +17,7 @@ index 4aa8b4d..8354c08 100644
    # :startdoc:
 
 diff --git a/lib/rubygems/defaults.rb b/lib/rubygems/defaults.rb
-index 8daff0b..1fab83c 100644
+index b186375..3835559 100644
 --- a/lib/rubygems/defaults.rb
 +++ b/lib/rubygems/defaults.rb
 @@ -20,13 +20,7 @@ def self.default_sources
@@ -61,7 +40,7 @@ index 8daff0b..1fab83c 100644
 
    def self.default_dir
 -    @default_dir ||= File.join(RbConfig::CONFIG["rubylibprefix"], "gems", RbConfig::CONFIG["ruby_version"])
-+    @default_dir ||= File.expand_path(File.join(__FILE__, "../../../../../ruby-lang.org/gems", RbConfig::CONFIG["ruby_version"]))
++    @default_dir ||= File.join("/usr/local/lib/ruby/gems", RbConfig::CONFIG["ruby_version"])
    end
 
    ##
@@ -107,7 +86,7 @@ index 8daff0b..1fab83c 100644
    end
 
    ##
-@@ -151,14 +143,18 @@ def self.cache_home
+@@ -151,7 +143,11 @@ def self.cache_home
    # The path to standard location of the user's data directory.
 
    def self.data_home
@@ -117,14 +96,6 @@ index 8daff0b..1fab83c 100644
 +    else
 +      File.join(Gem.user_home, ".gem")
 +    end
-   end
-
-   ##
-   # The path to standard location of the user's state directory.
-
-   def self.state_home
--    @data_home ||= (ENV["XDG_STATE_HOME"] || File.join(Gem.user_home, ".local", "state"))
-+    File.join(Gem.data_home, "state")
    end
 
    ##
@@ -172,20 +143,22 @@ index 8daff0b..1fab83c 100644
    def self.operating_system_defaults
 -    {}
 +    {
-+      'install' => '--no-rdoc --no-ri --env-shebang --user-install',
-+      'update' => '--no-rdoc --no-ri --env-shebang --user-install'
++      'install' => '--no-rdoc --no-ri --env-shebang',
++      'update' => '--no-rdoc --no-ri --env-shebang'
 +    }
    end
 
    ##
-
 diff --git a/lib/rubygems/installer.rb b/lib/rubygems/installer.rb
-index 9fbb282..8fa8bd9 100644
+index 9fbb282..3be62a6 100644
 --- a/lib/rubygems/installer.rb
 +++ b/lib/rubygems/installer.rb
-@@ -190,7 +190,7 @@ def initialize(package, options={})
+@@ -188,9 +188,9 @@ def initialize(package, options={})
+     @package.prog_mode = options[:prog_mode]
+     @package.data_mode = options[:data_mode]
 
-     if options[:user_install]
+-    if options[:user_install]
++    if options[:user_install] or options[:user_install].nil? and not File.writable? Gem.paths.home
        @gem_home = Gem.user_dir
 -      @bin_dir = Gem.bindir gem_home unless options[:bin_dir]
 +      @bin_dir = File.join(Gem.user_home, ".local/bin") unless options[:bin_dir]

--- a/projects/rubygems.org/package.yml
+++ b/projects/rubygems.org/package.yml
@@ -13,14 +13,27 @@ build:
     gnu.org/patch: '*'
   script: |
     ruby setup.rb --prefix={{prefix}} --env-shebang --no-ri --no-rdoc
+
+    mkdir {{prefix}}/shim
+    cp props/proxy {{prefix}}/shim
+
     cd "{{prefix}}"
     patch -p1 < "$SRCROOT"/props/fit-n-finish.patch
 
-runtime:
-  env:
-    # HACK that is only required for this ruby package
-    # since we cannot use `gem` to build `gem` itself
-    RUBYLIB: ${{prefix}}/lib
+    # these are provided by ruby-lang.org
+    # we don’t know why they turn up here too…
+    for x in rake rbs rdbg typeprof; do
+      rm {{prefix}}/bin/$x
+    done
+
+    # We’re not a “GEMHOME” since we *are* gem, so yeah instead
+    # we have a RUBYLIB hack via our proxy script
+    for x in bin/*; do
+      mv $x shim
+      ln shim/proxy $x
+    done
+
+    rmdir {{prefix}}/plugins
 
 test:
   dependencies:
@@ -31,9 +44,14 @@ test:
   script: |
     gem install awesome_print
     ruby -e 'require "rubygems"' -e 'require "awesome_print"' -e'ap $LOAD_PATH'
-    #TODO test -d ~/.gem/ruby/{{deps.ruby.version.major}}.{{deps.ruby.version.minor}}.0/gems/hexapdf-0.28.0
     gem install hexapdf
-    ~/.local/bin/hexapdf version
+    v="$(~/.local/bin/hexapdf version | cut -d' ' -f2)"
+    test -d ~/.gem/ruby/3.2.0/gems/hexapdf-$v  #FIXME ruby version
+
+    gem install bundle
+    test -d ~/.gem/ruby/{{version.marketing}}.0/gems/bundle-0.0.1
+    test -f ~/.local/bin/bundle
+    ~/.local/bin/bundle --version
 
 provides:
   - bin/bundle

--- a/projects/rubygems.org/proxy
+++ b/projects/rubygems.org/proxy
@@ -1,0 +1,4 @@
+#!/bin/sh
+d="$(cd "$(dirname $0)"/.. && pwd)"
+export RUBYLIB="$d/lib"
+$d/shim/$(basename $0) "$@"


### PR DESCRIPTION
And well, what are they for anyway?