### PR TITLE
+docbook.org

### DIFF
--- a/projects/docbook.org/package.yml
+++ b/projects/docbook.org/package.yml
@@ -1,0 +1,42 @@
+versions:
+  - 4.1.2
+  - 4.2
+  - 4.3
+  - 4.4
+  - 4.5
+  - 5.0
+  - 5.1
+
+build:
+  script: |
+    if [ -e "docbook" ]; then
+        rm -r docbook
+    fi
+    mkdir -p docbook/xml
+    VERSIONS=(4.1.2 4.2 4.3 4.4 4.5 5.0 5.1) #{{ versions }}
+    for VERSION in "${VERSIONS[@]}"; do
+        case $VERSION in
+        4.1.2)
+          URL=https://docbook.org/xml/${VERSION}/docbkx412.zip
+          ;;
+        4.*)
+          URL=https://docbook.org/xml/${VERSION}/docbook-xml-${VERSION}.zip
+          ;;
+        5.0)
+          URL=https://docbook.org/xml/${VERSION}/docbook-${VERSION}.zip
+          ;;
+        *)
+          URL=https://docbook.org/xml/${VERSION}/docbook-v${VERSION}-os.zip
+          ;;
+        esac
+        curl -o docbook-$VERSION.zip $URL
+        unzip -d docbook/xml/${VERSION} docbook-${VERSION}.zip
+        rm docbook-${VERSION}.zip
+    done
+    mv docbook/xml/5.0/docbook-5.0/* docbook/xml/5.0
+    rmdir docbook/xml/5.0/docbook-5.0
+    if [ "{{prefix}}" != "" -a -e "{{prefix}}" ]; then
+        rm -r {{prefix}}
+    fi
+    mkdir -p {{prefix}}
+    mv docbook {{prefix}}


### PR DESCRIPTION
I created this exactly the same way [Homebrew does](https://github.com/Homebrew/homebrew-core/blob/388cf58311b12654b7392950ec3f1e6082b38564/Formula/docbook.rb). I don't know enough about docbook to know if this is how it really should be done. Please advise if I need to change it. I packaged this so that I can package [xmlto](https://pagure.io/xmlto/), so that I can update the [wumpus](https://github.com/teaxyz/pantry/tree/main/projects/catb.org/wumpus) recipe to 1.9 and gitlab, because 1.9 requires xmlto to create the man page.