### PR TITLE
fish: tests must specify they want tea in the PATH now

### DIFF
--- a/projects/fishshell.com/package.yml
+++ b/projects/fishshell.com/package.yml
@@ -3,7 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  github: fish-shell/fish-shell/tags
+  github: fish-shell/fish-shell/releases/tags
 
 dependencies:
   gnu.org/gettext: '*'
@@ -41,6 +41,8 @@ build:
       - -DCURSES_INCLUDE_PATH="{{deps.invisible-island.net/ncurses.prefix}}/include/ncursesw"
 
 test:
+  dependencies:
+    tea.xyz: '*'
   script:
     fish $FIXTURE | grep "variable1variable2variable3variable4variable5variable6variable7variable8variable9variable10go version go"
   fixture: |
@@ -52,9 +54,19 @@ test:
     end
 
     begin
+      if which go
+        exit 2
+      end
+
       set -lx SHELL fish
       tea --magic | source
       go version
+
+      go version > go.out
+
+      if ! grep go go.out
+        exit 3
+      end
     end
 
 provides:

--- a/projects/fishshell.com/package.yml
+++ b/projects/fishshell.com/package.yml
@@ -62,11 +62,12 @@ test:
       tea --magic | source
       go version
 
-      go version > go.out
+      #FIXME https://github.com/teaxyz/pantry/issues/861
+      # go version > go.out
 
-      if ! grep go go.out
-        exit 3
-      end
+      # if ! grep go go.out
+      #   exit 3
+      # end
     end
 
 provides:

--- a/projects/fishshell.com/package.yml
+++ b/projects/fishshell.com/package.yml
@@ -58,8 +58,7 @@ test:
         exit 2
       end
 
-      set -lx SHELL fish
-      tea --magic | source
+      tea --magic=fish | source
       go version
 
       #FIXME https://github.com/teaxyz/pantry/issues/861


### PR DESCRIPTION
This is more proper. One can imagine a future where tools alter their behavior if `tea` is available because we are useful. So one should opt into testing that.