### PR TITLE
+s3tools.org

### DIFF
--- a/projects/s3tools.org/package.yml
+++ b/projects/s3tools.org/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/s3tools/s3cmd/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: s3tools/s3cmd
+  strip: /^v/
+
+dependencies:
+  python.org: ^3
+
+build:
+  python-venv.sh {{prefix}}/bin/s3cmd
+
+provides:
+  - bin/s3cmd
+
+test:
+  s3cmd --help


### PR DESCRIPTION
S3cmd is a free command line tool and client for uploading, retrieving and managing data in Amazon S3 and other cloud storage service providers that use the S3 protocol, such as Google Cloud Storage or DreamHost DreamObjects.