### PR TITLE
+bloomreach.com/s4cmd

### DIFF
--- a/projects/bloomreach.com/s4cmd/package.yml
+++ b/projects/bloomreach.com/s4cmd/package.yml
@@ -1,0 +1,18 @@
+distributable:
+  url: https://github.com/bloomreach/s4cmd/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: bloomreach/s4cmd/tags
+
+dependencies:
+  python.org: ^3
+
+build:
+  python-venv.sh {{prefix}}/bin/s4cmd
+
+provides:
+  - bin/s4cmd
+
+test:
+  s4cmd --help


### PR DESCRIPTION
S4cmd is a command-line utility for accessing [Amazon S3](http://en.wikipedia.org/wiki/Amazon_S3), inspired by [s3cmd](http://s3tools.org/s3cmd).