### PR TITLE
+gnu.org/inetutils

### DIFF
--- a/projects/gnu.org/inetutils/package.yml
+++ b/projects/gnu.org/inetutils/package.yml
@@ -6,38 +6,52 @@ versions:
   #TODO HTML listing: https://ftp.gnu.org/gnu/inetutils
   - 2.4
 
+dependencies:
+  gnu.org/libidn2: '*'
+
 build:
   dependencies:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
-    gnu.org/libidn2: '*'
   script: |
     ./configure $ARGS
     make SUIDMODE= install
+    cd "{{prefix}}"/libexec
+    mkdir "{{prefix}}"/sbin
+    for x in *; do ln -s ../$x ../sbin; done
   env:
     ARGS:
       - --prefix="{{prefix}}"
       - --disable-silent-rules
       - --with-idn
-      - --program-prefix=g
 
 provides:
-  - bin/gdnsdomainname
-  - bin/gftp
-  - bin/ghostname
-  - bin/gifconfig
-  - bin/glogger
-  - bin/gping
-  - bin/gping6
-  - bin/grcp
-  - bin/grexec
-  - bin/grlogin
-  - bin/grsh
-  - bin/gtalk
-  - bin/gtelnet
-  - bin/gtftp
-  - bin/gtraceroute
-  - bin/gwhois
+  - bin/dnsdomainname
+  - bin/ftp
+  - bin/hostname
+  - bin/ifconfig
+  - bin/logger
+  - bin/ping
+  - bin/ping6
+  - bin/rcp
+  - bin/rexec
+  - bin/rlogin
+  - bin/rsh
+  - bin/talk
+  - bin/telnet
+  - bin/tftp
+  - bin/traceroute
+  - bin/whois
+  - sbin/ftpd
+  - sbin/inetd
+  - sbin/rexecd
+  - sbin/rlogind
+  - sbin/rshd
+  - sbin/syslogd
+  - sbin/talkd
+  - sbin/telnetd
+  - sbin/tftpd
+  - sbin/uucpd
 
 test:
   dependencies:

--- a/projects/gnu.org/inetutils/package.yml
+++ b/projects/gnu.org/inetutils/package.yml
@@ -8,6 +8,7 @@ versions:
 
 dependencies:
   gnu.org/libidn2: '*'
+  invisible-island.net/ncurses: '*'
 
 build:
   dependencies:
@@ -24,6 +25,7 @@ build:
       - --prefix="{{prefix}}"
       - --disable-silent-rules
       - --with-idn
+      - --with-ncurses-include-dir="{{ deps.invisible-island.net/ncurses.prefix }}/include"
 
 provides:
   - bin/dnsdomainname

--- a/projects/gnu.org/inetutils/package.yml
+++ b/projects/gnu.org/inetutils/package.yml
@@ -1,0 +1,46 @@
+distributable:
+  url: https://ftp.gnu.org/gnu/inetutils/inetutils-{{version.marketing}}.tar.xz
+  strip-components: 1
+
+versions:
+  #TODO HTML listing: https://ftp.gnu.org/gnu/inetutils
+  - 2.4
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+    gnu.org/libidn2: '*'
+  script: |
+    ./configure $ARGS
+    make SUIDMODE= install
+  env:
+    ARGS:
+      - --prefix="{{prefix}}"
+      - --disable-silent-rules
+      - --with-idn
+      - --program-prefix=g
+
+provides:
+  - bin/gdnsdomainname
+  - bin/gftp
+  - bin/ghostname
+  - bin/gifconfig
+  - bin/glogger
+  - bin/gping
+  - bin/gping6
+  - bin/grcp
+  - bin/grexec
+  - bin/grlogin
+  - bin/grsh
+  - bin/gtalk
+  - bin/gtelnet
+  - bin/gtftp
+  - bin/gtraceroute
+  - bin/gwhois
+
+test:
+  dependencies:
+    tea.xyz/gx/cc: c99
+  script: |
+    test "$(gtelnet --version | head -n1)" = "telnet (GNU inetutils) {{version.marketing}}"

--- a/projects/gnu.org/inetutils/package.yml
+++ b/projects/gnu.org/inetutils/package.yml
@@ -16,9 +16,9 @@ build:
   script: |
     ./configure $ARGS
     make SUIDMODE= install
-    cd "{{prefix}}"/libexec
     mkdir "{{prefix}}"/sbin
-    for x in *; do ln -s ../$x ../sbin; done
+    cd "{{prefix}}"/libexec
+    for x in *; do ln -s ../libexec/$x ../sbin; done
   env:
     ARGS:
       - --prefix="{{prefix}}"
@@ -57,4 +57,5 @@ test:
   dependencies:
     tea.xyz/gx/cc: c99
   script: |
+    ls -al
     test "$(telnet --version | head -n1)" = "telnet (GNU inetutils) {{version.marketing}}"

--- a/projects/gnu.org/inetutils/package.yml
+++ b/projects/gnu.org/inetutils/package.yml
@@ -57,4 +57,4 @@ test:
   dependencies:
     tea.xyz/gx/cc: c99
   script: |
-    test "$(gtelnet --version | head -n1)" = "telnet (GNU inetutils) {{version.marketing}}"
+    test "$(telnet --version | head -n1)" = "telnet (GNU inetutils) {{version.marketing}}"


### PR DESCRIPTION
This creates:

  - bin/gdnsdomainname
  - bin/gftp
  - bin/ghostname
  - bin/gifconfig
  - bin/glogger
  - bin/gping
  - bin/gping6
  - bin/grcp
  - bin/grexec
  - bin/grlogin
  - bin/grsh
  - bin/gtalk
  - bin/gtelnet
  - bin/gtftp
  - bin/gtraceroute
  - bin/gwhois

It also creates some server daemons. The Homebrew formula creates a bunch of symlinks without the "^g". I could do that. It also called make with "SUIDMODE". I don't exactly know what that is supposed to do.  I'm not exactly an expert with make. I'd appreciate it if someone took a look at the build script just to make sure I did it right.