### PR TITLE
Update package.yml

### DIFF
--- a/projects/freedesktop.org/p11-kit/package.yml
+++ b/projects/freedesktop.org/p11-kit/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/p11-glue/p11-kit/releases/download/{{ version }}/p11-kit-{{ version }}.tar.xz
+  url: https://github.com/p11-glue/p11-kit/releases/download/{{version}}/p11-kit-{{version}}.tar.xz
   strip-components: 1
 
 versions:


### PR DESCRIPTION
Looks likes there are some extra spaces that cause my client code to fail get data from yaml : 

```wget --quiet  https://raw.githubusercontent.com/teaxyz/pantry/main/projects/zsh.sourceforge.io/package.yml -O manifests/317.yml
{'distributable': {'url': 'https://github.com/p11-glue/p11-kit/releases/download/{{ version }}/p11-kit-{{ version }}.tar.xz', 'strip-components': 1}, 'versions': {'github': 'p11-glue/p11-kit', 'strip': '/ \\(stable\\)$/'}, 'provides': ['bin/p11-kit', 'bin/trust'], 'dependencies': {'sourceware.org/libffi': '^3', 'curl.se/ca-certs': '*', 'gnu.org/gettext': '*'}, 'build': {'dependencies': {'tea.xyz/gx/cc': 'c99', 'tea.xyz/gx/make': '*', 'gnu.org/libtasn1': '^4', 'freedesktop.org/pkg-config': '*'}, 'script': './configure --prefix={{prefix}} --with-trust-paths={{deps.curl.se/ca-certs}}/ssl\nmake -j {{ hw.concurrency }} install'}, 'test': {'script': 'p11-kit list-modules'}}
```

![image](https://user-images.githubusercontent.com/5235127/227833899-ecf0a89c-a2ae-4556-af05-c0d7ecc35b0d.png)
