### PR TITLE
fix(nodejs)

### DIFF
--- a/projects/nodejs.org/package.yml
+++ b/projects/nodejs.org/package.yml
@@ -27,6 +27,11 @@ build:
     python.org: '>=3.7 <3.11'
     freedesktop.org/pkg-config: ^0.29
   script: |
+    if test "{{ hw.platform }}" = "darwin"; then
+      # nodejs wants `dtrace` in the path.
+      export PATH="$PATH:/usr/sbin"
+    fi
+
     ./configure $ARGS
     make --jobs {{ hw.concurrency }} install
   env:


### PR DESCRIPTION
nodejs.org=16.20.0 requires being able to find dtrace. I assume the next releases of various other majors likely will as well, since there's a lot of parallelism between them over time.

closes #1003, closes #1004