### PR TITLE
fix(git) (and others)

### DIFF
--- a/projects/curl.se/package.yml
+++ b/projects/curl.se/package.yml
@@ -8,6 +8,7 @@ versions:
 
 dependencies:
   openssl.org: ^1.1
+  curl.se/ca-certs: '*'
 
 build:
   dependencies:

--- a/projects/git-scm.org/package.yml
+++ b/projects/git-scm.org/package.yml
@@ -5,10 +5,15 @@ distributable:
 versions:
   github: git/git/tags
 
+env:
+  runtime:
+    GIT_SSL_CAINFO: ${{deps.curl.se/ca-certs.prefix}}/ssl/cert.pem
+
 dependencies:
   zlib.net: 1
   gnu.org/gettext: ^0.21
   curl.se: '>=5'
+  curl.se/ca-certs: '*'
   perl.org: '*'
   libexpat.github.io: ~2
 


### PR DESCRIPTION
curl.se should depend on curl.se/ca-certs

Currently, curl gets ca-certs as a transitory dependency from openssl (and git likewise), but I don't think we should depend on that chaining. Moreover, git needs to know where to _find_ ca-certs, since it doesn't look like it uses the `SSL_CERT_FILE` envvar.

Requesting review for changing deps (cascade risk).