### PR TITLE
Sourceware.org/valgrind

### DIFF
--- a/projects/sourceware.org/valgrind/package.yml
+++ b/projects/sourceware.org/valgrind/package.yml
@@ -3,7 +3,14 @@ distributable:
   strip-components: 1
 
 versions:
-  - 3.20.0
+  url: https://sourceware.org/pub/valgrind
+  match: /valgrind-\d+\.\d+\.\d+\.tar\.bz2/
+  strip:
+    - /^valgrind-/
+    - /\.tar\.bz2$/
+
+platforms:
+  - linux
 
 build:
   dependencies:
@@ -13,15 +20,10 @@ build:
     gnu.org/automake: '*'
     gnu.org/libtool: '*'
 
-  script: |
-    if test "{{hw.platform}}" != "linux"; then
-      echo "libbsd is only supported on Linux"
-      touch {{prefix}}/linux-only
-      exit 0
-    fi
-    ./autogen.sh
-    ./configure $ARGS
-    make --jobs {{ hw.concurrency }} install
+  script:
+    - ./autogen.sh
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }} install
   env:
     ARGS:
       - --prefix="{{prefix}}"
@@ -33,8 +35,5 @@ provides:
   - bin/valgrind
 
 test:
-  script: |
-    if test "{{hw.platform}}" = "linux"; then
-      #test "$(valgrind --version)" = {{version}}
-      valgrind --versoin
-    fi
+  script:
+    - valgrind --version

--- a/projects/sourceware.org/valgrind/package.yml
+++ b/projects/sourceware.org/valgrind/package.yml
@@ -35,9 +35,6 @@ provides:
 test:
   script: |
     if test "{{hw.platform}}" = "linux"; then
-      #test "$(valgrind --help)" = {{version}}
-      valgrind --help
+      #test "$(valgrind --version)" = {{version}}
+      valgrind --versoin
     fi
-    
-    
-#system "./autogen.sh" if build.head?

--- a/projects/sourceware.org/valgrind/package.yml
+++ b/projects/sourceware.org/valgrind/package.yml
@@ -1,0 +1,43 @@
+distributable:
+  url: https://sourceware.org/pub/valgrind/valgrind-{{version}}.tar.bz2
+  strip-components: 1
+
+versions:
+  - 3.20.0
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
+    gnu.org/libtool: '*'
+
+  script: |
+    if test "{{hw.platform}}" != "linux"; then
+      echo "libbsd is only supported on Linux"
+      touch {{prefix}}/linux-only
+      exit 0
+    fi
+    ./autogen.sh
+    ./configure $ARGS
+    make --jobs {{ hw.concurrency }} install
+  env:
+    ARGS:
+      - --prefix="{{prefix}}"
+      - --disable-dependency-tracking
+      - --enable-only64bit
+      - --without-mpicc
+
+provides:
+  - bin/valgrind
+
+test:
+  script: |
+    if test "{{hw.platform}}" = "linux"; then
+      #test "$(valgrind --help)" = {{version}}
+      valgrind --help
+    fi
+    
+    
+#system "./autogen.sh" if build.head?


### PR DESCRIPTION
This is Linux only. I basically try to make a formula instead of installing. I keep hoping it will be easy. But...

I have no idea why it gets this error (in docker):

```
gcc -DHAVE_CONFIG_H -I. -I..  -I.. -I../include -I../include -I../VEX/pub -I../VEX/pub -DVGA_arm64=1 -DVGO_linux=1 -DVGP_arm64_linux=1 -DVGPV_arm64_linux_vanilla=1  -I../coregrind -DVG_LIBDIR="\"/root/.tea/sourceware.org/valgrind/v3.20.0/libexec/valgrind"\" -DVG_PLATFORM="\"arm64-linux\""   -m64 -O2 -g -Wall -Wmissing-prototypes -Wshadow -Wpointer-arith -Wstrict-prototypes -Wmissing-declarations -Wcast-align -Wcast-qual -Wwrite-strings -Wempty-body -Wformat -Wformat-security -Wignored-qualifiers -Wenum-conversion -finline-functions -fno-stack-protector -fno-strict-aliasing -fno-builtin -Wno-cast-align -Wno-self-assign -Wno-tautological-compare  -DENABLE_LINUX_TICKET_LOCK -w  -c -o libcoregrind_arm64_linux_a-m_stacktrace.o `test -f 'm_stacktrace.c' || echo './'`m_stacktrace.c
m_machine.c:486:4: error: __builtin_longjmp is not supported for the current target
   VG_MINIMAL_LONGJMP(env_unsup_insn);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../include/pub_tool_libcsetjmp.h:134:35: note: expanded from macro 'VG_MINIMAL_LONGJMP'
#define VG_MINIMAL_LONGJMP(_env)  __builtin_longjmp((_env),1)
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
m_machine.c:1819:10: error: __builtin_setjmp is not supported for the current target
     if (VG_MINIMAL_SETJMP(env_unsup_insn))
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../include/pub_tool_libcsetjmp.h:133:44: note: expanded from macro 'VG_MINIMAL_SETJMP'
#define VG_MINIMAL_SETJMP(_env)   ((UWord)(__builtin_setjmp((_env))))
                                           ^~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
make[3]: *** [Makefile:5216: libcoregrind_arm64_linux_a-m_machine.o] Error 1
make[3]: *** Waiting for unfinished jobs....
m_signals.c:2163:7: error: __builtin_longjmp is not supported for the current target
      VG_MINIMAL_LONGJMP(tst->sched_jmpbuf);
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../include/pub_tool_libcsetjmp.h:134:35: note: expanded from macro 'VG_MINIMAL_LONGJMP'
#define VG_MINIMAL_LONGJMP(_env)  __builtin_longjmp((_env),1)
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[3]: *** [Makefile:5356: libcoregrind_arm64_linux_a-m_signals.o] Error 1
make[3]: Leaving directory '/pantry/builds/sourceware.org∕valgrind-3.20.0+linux/coregrind'
make[2]: *** [Makefile:9511: install] Error 2
make[2]: Leaving directory '/pantry/builds/sourceware.org∕valgrind-3.20.0+linux/coregrind'
make[1]: *** [Makefile:898: install-recursive] Error 1
make[1]: Leaving directory '/pantry/builds/sourceware.org∕valgrind-3.20.0+linux'
make: *** [Makefile:1205: install] Error 2
```