### PR TITLE
+stripe

### DIFF
--- a/projects/stripe.com/package.yml
+++ b/projects/stripe.com/package.yml
@@ -20,7 +20,7 @@ build:
 
   env:
     LDFLAGS:
-      [-s, -w, "-X=main.Version={{version}}"]
+      [-s, -w, "-X=main.Version={{ version }}", "-X=github.com/stripe/stripe-cli/pkg/version.Version={{ version }}"]
     linux:
       # or segmentation fault
       # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575

--- a/projects/stripe.com/package.yml
+++ b/projects/stripe.com/package.yml
@@ -1,0 +1,31 @@
+distributable:
+  url: https://github.com/stripe/stripe-cli/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: stripe/stripe-cli
+
+provides:
+  - bin/stripe
+
+build:
+  script: |
+    make setup
+    go build -v -ldflags="$LDFLAGS" -o stripe cmd/stripe/main.go
+    mkdir -p "{{ prefix }}"/bin
+    mv stripe "{{ prefix }}"/bin
+  dependencies:
+    go.dev: ^1.19
+    tea.xyz/gx/make: '*'
+
+  env:
+    LDFLAGS:
+      [-s, -w, "-X=main.Version={{version}}"]
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test: |
+  test "$(stripe --version)" == "stripe version {{version}}"


### PR DESCRIPTION
The reason why the tests fail is because running `stripe --version` will display `stripe version master` because of https://github.com/stripe/stripe-cli/blob/master/pkg/version/version.go#L19, but I'm not sure how to work around that.