### PR TITLE
fix(+python-poetry.org): use `version` variable in url

### DIFF
--- a/projects/python-poetry.org/package.yml
+++ b/projects/python-poetry.org/package.yml
@@ -12,11 +12,12 @@ build:
   dependencies:
     cmake.org: '*'
     linux/x86-64:
-      tea.xyz/gx/make: '*' # for ninja module
-      tea.xyz/gx/cc: c99   # ^^
+      tea.xyz/gx/make: '*'  # for ninja module
+      tea.xyz/gx/cc: c99    # ^^
     linux:
       rust-lang.org/cargo: '*' # for cryptographic bindings
-  script: python-venv.sh {{prefix}}/bin/poetry
+  script:
+    python-venv.sh {{prefix}}/bin/poetry
 
 test:
   script: |

--- a/projects/python-poetry.org/package.yml
+++ b/projects/python-poetry.org/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/python-poetry/poetry/releases/download/1.3.1/poetry-1.3.1.tar.gz
+  url: https://github.com/python-poetry/poetry/releases/download/{{version}}/poetry-{{version}}.tar.gz
   strip-components: 1
 
 versions:
@@ -10,14 +10,13 @@ dependencies:
 
 build:
   dependencies:
-    cmake.org: '*'
+    cmake.org: "*"
     linux/x86-64:
-      tea.xyz/gx/make: '*'  # for ninja module
-      tea.xyz/gx/cc: c99    # ^^
+      tea.xyz/gx/make: "*" # for ninja module
+      tea.xyz/gx/cc: c99 # ^^
     linux:
-      rust-lang.org/cargo: '*'  # for cryptographic bindings
-  script:
-    python-venv.sh {{prefix}}/bin/poetry
+      rust-lang.org/cargo: "*" # for cryptographic bindings
+  script: python-venv.sh {{prefix}}/bin/poetry
 
 test:
   script: |

--- a/projects/python-poetry.org/package.yml
+++ b/projects/python-poetry.org/package.yml
@@ -15,7 +15,7 @@ build:
       tea.xyz/gx/make: '*'  # for ninja module
       tea.xyz/gx/cc: c99    # ^^
     linux:
-      rust-lang.org/cargo: '*' # for cryptographic bindings
+      rust-lang.org/cargo: '*'  # for cryptographic bindings
   script:
     python-venv.sh {{prefix}}/bin/poetry
 

--- a/projects/python-poetry.org/package.yml
+++ b/projects/python-poetry.org/package.yml
@@ -10,12 +10,12 @@ dependencies:
 
 build:
   dependencies:
-    cmake.org: "*"
+    cmake.org: '*'
     linux/x86-64:
-      tea.xyz/gx/make: "*" # for ninja module
-      tea.xyz/gx/cc: c99 # ^^
+      tea.xyz/gx/make: '*' # for ninja module
+      tea.xyz/gx/cc: c99   # ^^
     linux:
-      rust-lang.org/cargo: "*" # for cryptographic bindings
+      rust-lang.org/cargo: '*' # for cryptographic bindings
   script: python-venv.sh {{prefix}}/bin/poetry
 
 test:


### PR DESCRIPTION
Currently the url is hardcoded which results in installing the same version (1.3.1) even if the cli is indicating that it's installing some other version.

The codespace also auto-formatted the yaml, hope that's okay.