### PR TITLE
+apache.org/apr-util

### DIFF
--- a/projects/apache.org/apr-util/package.yml
+++ b/projects/apache.org/apr-util/package.yml
@@ -1,0 +1,30 @@
+distributable:
+  url: https://dlcdn.apache.org/apr/apr-util-{{ version }}.tar.bz2
+  strip-components: 1
+
+versions:
+  github: apache/apr-util/tags
+
+provides:
+  - bin/apu-{{ version.major }}-config
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+    apache.org/apr: '*'
+    openssl.org: '*'
+    libexpat.github.io: '*'
+    sqlite.org: '*'
+  script: |
+    ./configure $ARGS
+    make --jobs {{ hw.concurrency }}
+    make install
+  env:
+    ARGS:
+      - --prefix="{{ prefix }}"
+      - --with-apr="{{ deps.apache.org/apr.prefix }}"
+
+test:
+  script: |
+    test "$(apu-{{ version.major }}-config --version)" = "{{ version }}"


### PR DESCRIPTION
The homebrew formula has 3 dependencies this version doesn't have: libxcrypt and on linux, mawk and unixodbc.

The linux build is getting an error on my computer but I don't think this is the real error.

```
Makefile:50: /root/pantry/builds/apache.org∕apr-util-1.6.3+linux/build/rules.mk: No such file or directory
make: *** No rule to make target '/root/pantry/builds/apache.org∕apr-util-1.6.3+linux/build/rules.mk'.  Stop.
```

There is a configure error on Linux but not macOS. I think the configure error below is causing the make error above.

```
Applying apr-util hints file rules for aarch64-unknown-linux-gnu
checking for APR... yes
./configure: line 4640: cd: /root/.tea/apache.org/apr/v1.7.2/bin/apr-1-config//opt/apache.org/apr/v1.7.2/build-1: Not a directory
``` 

I'm specifying the path to apr with `- --with-apr="{{ deps.apache.org/apr.prefix }}"`

For some reason the Linux version isn't getting the right path, it's adding "/opt/apache.org/apr/v1.7.2/build-1" to the path. I tried to figure out why but couldn't. 

AI assisted.

https://github.com/teaxyz/pantry/issues/266