### PR TITLE
Updated github.com/ggerganov/llama.cpp to 2023.04.11 8b67998

### DIFF
--- a/projects/github.com/ggerganov/llama.cpp/package.yml
+++ b/projects/github.com/ggerganov/llama.cpp/package.yml
@@ -1,9 +1,9 @@
 distributable:
-  url: https://github.com/ggerganov/llama.cpp/archive/refs/tags/master-3cd8dde.tar.gz
+  url: https://github.com/ggerganov/llama.cpp/archive/refs/tags/master-8b67998.tar.gz
   strip-components: 1
 
 versions:
-  - 2023.03.23
+  - 2023.04.11
 
 provides:
   - bin/llama.cpp
@@ -24,6 +24,9 @@ build:
 
     mv props/llama-fetch {{prefix}}/tbin
     mv $SRCROOT/prompts {{prefix}}/share
+
+    mv $SRCROOT/*.py  {{prefix}}/tbin
+    mv quantize {{prefix}}/tbin/quantize
 
     wget \
       --no-check-certificate \


### PR DESCRIPTION
And I'm copying quantize and python files to tbin, which should probably be bin... I haven't figured out how to use those tools yet.