### PR TITLE
Add host memory requirement

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "hostRequirements": {
+    "memory": "8gb"
+  }
+}


### PR DESCRIPTION
Building packages requires 8GB of RAM at a minimum. Less than that and problems occur.

This will prevent creating a codespace with anything less.
![Screenshot 2023-04-13 at 4 24 53 PM](https://user-images.githubusercontent.com/128727/231874907-22f39be7-8bd4-410c-9928-d9b1ee42e04e.png)

Fixes teaxyz/cli#529.