### PR TITLE
fix(nodejs)

### DIFF
--- a/projects/nodejs.org/package.yml
+++ b/projects/nodejs.org/package.yml
@@ -27,6 +27,13 @@ build:
     python.org: '>=3.7 <3.11'
     freedesktop.org/pkg-config: ^0.29
   script: |
+    # This is hacky, but it works.
+    # Knowing the precise versions to test is difficult, since
+    # nodejs develops multiple majors in sync.
+    if ./configure --help | grep -- --without-corepack; then
+      ARGS="$ARGS --without-corepack"
+    fi
+
     ./configure $ARGS
     make --jobs {{ hw.concurrency }} install
   env:
@@ -34,7 +41,6 @@ build:
     - --without-npm
     - --prefix={{ prefix }}
     # like, maybe we should include this?
-    - --without-corepack
     - --with-intl=system-icu
     - --shared-openssl
     - --shared-zlib


### PR DESCRIPTION
allows us to build ~16.11.1 and other older versions

closes #1367
closes #1368

~16.11.1 build: https://github.com/teaxyz/pantry/actions/runs/4704031384