### PR TITLE
fix(gem)

### DIFF
--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -10,6 +10,10 @@ dependencies:
   pyyaml.org: ^0.2
   zlib.net: ^1
 
+runtime:
+  env:
+    GEM_PATH: ${{prefix}}/lib/ruby/gems/{{version.marketing}}.0/gems
+
 build:
   dependencies:
     freedesktop.org/pkg-config: ^0.29
@@ -64,6 +68,9 @@ build:
     rm -rf lib/ruby/site_ruby
     rm -rf lib/ruby/vendor_ruby
 
+    # mkmf.rb expects to find the include here.
+    ln -s ../../include lib/ruby/
+
     # weirdly files get put here and we can't figure out how to stop it
     mv lib/*-{{hw.platform}}*/* lib
     rmdir lib/*-{{hw.platform}}*
@@ -74,6 +81,7 @@ test:
     tea.xyz/gx/make: '*'
   script: |
     ruby -e 'puts "Hello World!"'
+    rake --version
 
 provides:
   - bin/erb

--- a/projects/rubygems.org/package.yml
+++ b/projects/rubygems.org/package.yml
@@ -8,6 +8,10 @@ versions:
 dependencies:
   ruby-lang.org: '>=2.3'
 
+runtime:
+  env:
+    RUBYLIB: ${{prefix}}/lib
+
 build:
   dependencies:
     gnu.org/patch: '*'


### PR DESCRIPTION
@mxcl, ~this seems to be a _sufficient_ change to repair the test~ correction: `rake` shipped by `ruby-lang.org` still doesn't function. Does this seem correct?

and it doesn't fix: https://github.com/teaxyz/pantry/actions/runs/4705143312/jobs/8345427954; even adding GEM_HOME to ruby-lang.org. so, it needs more thought/work.