### PR TITLE
gnu.org/gcc add fortran

### DIFF
--- a/projects/gnu.org/gcc/package.yml
+++ b/projects/gnu.org/gcc/package.yml
@@ -60,7 +60,7 @@ build:
     ARGS:
       - --prefix={{ prefix }}
       - --libdir={{ prefix }}/lib
-      - --enable-languages=c,c++,objc,obj-c++
+      - --enable-languages=c,c++,objc,obj-c++,fortran
       - --with-bugurl="https://github.com/teaxyz/pantry/issues"
       - --disable-bootstrap
       - --disable-nls
@@ -90,6 +90,9 @@ test: |
   ./test1
   g++ -o test2 test.cc
   test "$(./test2)" = "Hello, world!"
+  gfortran -o test3 test.f90
+  test "$(./test3)" = "Hello, world!"
+
 
 provides:
   - bin/gc++ # we provide c++ in tea.xyz/gx/cc
@@ -102,4 +105,5 @@ provides:
   - bin/gcov
   - bin/gcov-dump
   - bin/gcov-tool
+  - bin/gfortran
   - bin/lto-dump

--- a/projects/gnu.org/gcc/test.f90
+++ b/projects/gnu.org/gcc/test.f90
@@ -1,0 +1,8 @@
+integer,parameter::m=10000
+real::a(m), b(m)
+real::fact=0.5
+do concurrent (i=1:m)
+  a(i) = a(i) + fact*b(i)
+end do
+write(*,"(A)") "Hello, world!"
+end


### PR DESCRIPTION
https://github.com/teaxyz/pantry/pull/1614 needs fortran. I added it to gcc, mimicking how homebrew does it.