### PR TITLE
Fix TERMINFO path

### DIFF
--- a/projects/invisible-island.net/ncurses/package.yml
+++ b/projects/invisible-island.net/ncurses/package.yml
@@ -46,7 +46,7 @@ build:
 
 runtime:
   env:
-    TERMINFO: /usr/share/terminfo:${{prefix}}/share/terminfo
+    TERMINFO: /usr/share/terminfo:{{prefix}}/share/terminfo
     # ^^ we delegate to the system first since they may apply platform specific info
 
 test:


### PR DESCRIPTION
I'm not familier with pantry format, but after I remove '$' from `${{prefix}}`, tmux works well in Linux.

```
$ docker run --rm -it teaxyz/cli
tea $ tmux -c ls
installed: ~/.tea/curl.se/ca-certs/v2023.1.10
installed: ~/.tea/openssl.org/v1.1.1t
installed: ~/.tea/libevent.org/v2.1.12
installed: ~/.tea/invisible-island.net/ncurses/v6.4.0
installed: ~/.tea/github.com/tmux/tmux/v3.3.0
missing or unsuitable terminal: xterm

tea $ sed -ie 's#/usr/share/terminfo:${{prefix}}/share/terminfo#/usr/share/terminfo:{{prefix}}/share/terminfo#' ~/.tea/tea.xyz/var/pantry/projects/invisible-island.net/ncurses/package.yml
tea $ tmux -c ls
bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
```

close: https://github.com/teaxyz/pantry/issues/1658