### PR TITLE
typst: fix versions

### DIFF
--- a/projects/typst.app/package.yml
+++ b/projects/typst.app/package.yml
@@ -1,27 +1,18 @@
 distributable:
-  url: https://github.com/typst/typst/archive/refs/tags/22-03-21-2.tar.gz
-  # url: https://github.com/typst/typst/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/typst/typst/archive/refs/tags/v{{ version }}.tar.gz
   strip-components: 1
 
 versions:
-  - 0.0.0
-  # FIXME: once they have releases
-  # github: typst/typst
+  github: typst/typst/releases/tags
 
 build:
   dependencies:
     rust-lang.org: ^1.61
     rust-lang.org/cargo: ^0.65
   script: |
-    # Currently, typst tries to use git-hash for the version
-    # which is not available in the tarball. It just sets the
-    # env var TYPST_HASH
-    rm cli/build.rs
-
     cargo install --path cli --locked --root {{prefix}}
   env:
-    # see above
-    TYPST_HASH: ${{ version }}-tea
+    TYPST_VERSION: ${{ version }}
 
 provides:
   - bin/typst
@@ -34,5 +25,5 @@ test:
       sum_(i=0)^nabla Q_i / 2 $
   script: |
     cp $FIXTURE test.typ
-    typst test.typ
+    typst compile test.typ
     test -s test.pdf


### PR DESCRIPTION
Now has several [releases](https://github.com/typst/typst/releases)
