### PR TITLE
update stripe version

### DIFF
--- a/projects/stripe.com/package.yml
+++ b/projects/stripe.com/package.yml
@@ -3,7 +3,8 @@ distributable:
   strip-components: 1
 
 versions:
-  github: stripe/stripe-cli
+  github: stripe/stripe-cli/releases/tags
+  strip: /^v/
 
 provides:
   - bin/stripe


### PR DESCRIPTION
update `github` key with `.../releases/tags` because latest version of stripe is out since 3 weeks but tea didn't have 