### PR TITLE
replace hardcoded versions (mostly)

### DIFF
--- a/projects/aomedia.googlesource.com/aom/package.yml
+++ b/projects/aomedia.googlesource.com/aom/package.yml
@@ -2,7 +2,11 @@ distributable:
   url: https://aomedia.googlesource.com/aom/+archive/v{{version}}.tar.gz
 
 versions:
-  - 3.5.0
+  url: https://aomedia.googlesource.com/aom/+refs
+  match: /refs\/tags\/v\d+\.\d+\.\d+"/
+  strip:
+    - /refs\/tags\/v/
+    - /"/
 
 build:
   dependencies:

--- a/projects/apache.org/subversion/package.yml
+++ b/projects/apache.org/subversion/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://dlcdn.apache.org/subversion/subversion-{{version}}.tar.bz2
+  url: https://archive.apache.org/dist/subversion/subversion-{{version}}.tar.bz2
   strip-components: 1
 
 versions:
-  - 1.14.2
+  url: https://archive.apache.org/dist/subversion/
+  match: /subversion-(\d+\.\d+\.\d+)\.tar\.bz2/
+  strip:
+    - /subversion-/
+    - /.tar.bz2/
 
 dependencies:
   gnu.org/gettext: ^0.21

--- a/projects/bytereef.org/mpdecimal/package.yml
+++ b/projects/bytereef.org/mpdecimal/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.5.1
+  url: https://www.bytereef.org/mpdecimal/download.html
+  match: /mpdecimal-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /mpdecimal-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/c-ares.org/package.yml
+++ b/projects/c-ares.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.19.0
+  url: https://c-ares.org/download
+  match: /c-ares-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /c-ares-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/cairographics.org/package.yml
+++ b/projects/cairographics.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.16.0
+  url: https://cairographics.org/releases/
+  match: /cairo-\d+\.\d+(\.\d+)?\.tar\.xz/
+  strip:
+    - /cairo-/
+    - /.tar.xz/
 
 dependencies:
   tea.xyz/gx/cc: c99

--- a/projects/catb.org/wumpus/package.yml
+++ b/projects/catb.org/wumpus/package.yml
@@ -3,11 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.com/api/v4/projects/361625/repository/tags
-  match: /"name":"\d+\.\d+"/
-  strip:
-    - /"name":"/
-    - /"/
+  gitlab: esr/wumpus/tags
 
 provides:
   - bin/wumpus

--- a/projects/catb.org/wumpus/package.yml
+++ b/projects/catb.org/wumpus/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.9
+  url: https://gitlab.com/api/v4/projects/361625/repository/tags
+  match: /"name":"\d+\.\d+"/
+  strip:
+    - /"name":"/
+    - /"/
 
 provides:
   - bin/wumpus

--- a/projects/code.videolan.org/rist/librist/package.yml
+++ b/projects/code.videolan.org/rist/librist/package.yml
@@ -3,14 +3,16 @@ distributable:
   strip-components: 1
 
 versions:
-  - 0.2.7
+  url: https://code.videolan.org/api/v4/projects/816/releases
+  match: /librist-v\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /librist-v/
+    - /\.tar\.gz/
 
 build:
   dependencies:
     tea.xyz/gx/cc: c99
-    # FIXME: https://github.com/teaxyz/cli/issues/535
-    # mesonbuild.com: '>=0.47<1'
-    mesonbuild.com: '>=0.47'
+    mesonbuild.com: '>=0.47<1'
     ninja-build.org: 1
   working-directory:
     build

--- a/projects/code.videolan.org/rist/librist/package.yml
+++ b/projects/code.videolan.org/rist/librist/package.yml
@@ -3,11 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://code.videolan.org/api/v4/projects/816/releases
-  match: /librist-v\d+\.\d+\.\d+\.tar\.gz/
-  strip:
-    - /librist-v/
-    - /\.tar\.gz/
+  gitlab: code.videolan.org:rist/librist
 
 build:
   dependencies:

--- a/projects/code.videolan.org/videolan/dav1d/package.yml
+++ b/projects/code.videolan.org/videolan/dav1d/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.0.0
+  url: https://code.videolan.org/api/v4/projects/198/releases
+  match: /dav1d-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /dav1d-/
+    - /\.tar\.gz/
 
 build:
   dependencies:

--- a/projects/code.videolan.org/videolan/dav1d/package.yml
+++ b/projects/code.videolan.org/videolan/dav1d/package.yml
@@ -3,11 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://code.videolan.org/api/v4/projects/198/releases
-  match: /dav1d-\d+\.\d+\.\d+\.tar\.gz/
-  strip:
-    - /dav1d-/
-    - /\.tar\.gz/
+  gitlab: code.videolan.org:videolan/dav1d
 
 build:
   dependencies:

--- a/projects/crates.io/bpb/package.yml
+++ b/projects/crates.io/bpb/package.yml
@@ -6,6 +6,9 @@ distributable:
   url: https://github.com/withoutboats/bpb/tarball/b1ef5ca1d2dea0e2ec0b1616f087f110ea17adfa
   # repo has no tags, presumably we can get the tags from crates.io, but not
   # sure how to do that at this time
+  # we can find the versions here: https://github.com/rust-lang/crates.io-index/blob/master/3/b/bpb
+  # but converting those to a downloadable URL is a different story.
+  # https://crates.io/api/v1/crates/bpb/1.1.0/download is one lead, but it downloads a .crate file
   strip-components: 1
 
 provides:

--- a/projects/darwinsys.com/file/package.yml
+++ b/projects/darwinsys.com/file/package.yml
@@ -4,8 +4,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 5.43
-  #TODO github: file/file/tags (has an awful format :/)
+  url: https://astron.com/pub/file/
+  match: /file-\d+\.\d+\.tar\.gz/
+  strip:
+    - /file-/
+    - /.tar.gz/
 
 dependencies:
   zlib.net: 1  #FIXME this is actually an optional dep

--- a/projects/dev.yorhel.nl/ncdu/package.yml
+++ b/projects/dev.yorhel.nl/ncdu/package.yml
@@ -6,7 +6,11 @@ provides:
   - bin/ncdu
 
 versions:
-  - 1.18.1
+  url: https://dev.yorhel.nl/download/
+  match: /ncdu-1\.\d+(\.\d+)?\.tar\.gz/  # v2 is `zig`, which is a whole thing
+  strip:
+    - /ncdu-/
+    - /.tar.gz/
 
 dependencies:
   invisible-island.net/ncurses: '*'

--- a/projects/docutils.org/package.yml
+++ b/projects/docutils.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 0.19.0
+  url: https://sourceforge.net/projects/docutils/files/docutils/
+  match: /docutils\/\d+\.\d+(\.\d+)?\/"/
+  strip:
+    - /docutils\//
+    - /\/"/
 
 dependencies:
   python.org: 3.11

--- a/projects/doxygen.nl/package.yml
+++ b/projects/doxygen.nl/package.yml
@@ -4,7 +4,8 @@ distributable:
    strip-components: 1
 
 versions:
-  - 1.9.6 # FIXME: the versions are "Release_1_9_6" but no idea how I can parse this without regex
+  github: doxygen/doxygen/releases
+  strip: /Doxygen release /
 
 build:
   dependencies:
@@ -17,13 +18,12 @@ build:
   working-directory: build
   script: |
     cmake $ARGS -G "Unix Makefiles" ..
-    make --jobs {{ hw.concurrency }} 
+    make --jobs {{ hw.concurrency }}
     make install
   env:
     ARGS:
       - -DCMAKE_INSTALL_PREFIX="{{prefix}}"
       - -DCMAKE_BUILD_TYPE=Release
-    
 
 provides:
   - bin/doxygen

--- a/projects/eigen.tuxfamily.org/package.yml
+++ b/projects/eigen.tuxfamily.org/package.yml
@@ -3,11 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.com/api/v4/projects/15462818/repository/tags
-  match: /"name":"(\d+\.\d+\.\d+)"/
-  strip:
-    - /"name":"/
-    - /"/
+  gitlab: libeigen/eigen/tags
 
 build:
   working-directory: build

--- a/projects/eigen.tuxfamily.org/package.yml
+++ b/projects/eigen.tuxfamily.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 3.4.0
+  url: https://gitlab.com/api/v4/projects/15462818/repository/tags
+  match: /"name":"(\d+\.\d+\.\d+)"/
+  strip:
+    - /"name":"/
+    - /"/
 
 build:
   working-directory: build

--- a/projects/ffmpeg.org/package.yml
+++ b/projects/ffmpeg.org/package.yml
@@ -1,13 +1,16 @@
 distributable:
-  url: https://ffmpeg.org/releases/ffmpeg-{{version}}.tar.xz
+  url: https://ffmpeg.org/releases/ffmpeg-{{version.raw}}.tar.gz
   sig: ${{url}}.asc
   strip-components: 1
 
 # docs: https://trac.ffmpeg.org/wiki/CompilationGuide
 
 versions:
-  - 5.1.2
-  # TODO they have their own git repo we can grab tags from
+  url: https://ffmpeg.org/releases/
+  match: /ffmpeg-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /ffmpeg-/
+    - /.tar.gz/
 
 provides:
   - bin/ffmpeg

--- a/projects/freedesktop.org/shared-mime-info/package.yml
+++ b/projects/freedesktop.org/shared-mime-info/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.2
+  url: https://gitlab.freedesktop.org/api/v4/projects/1205/repository/tags
+  match: /name":"\d+\.\d+(\.\d+)?"/
+  strip:
+    - /name":"/
+    - /"/
 
 dependencies:
   gnome.org/glib: 2

--- a/projects/freedesktop.org/shared-mime-info/package.yml
+++ b/projects/freedesktop.org/shared-mime-info/package.yml
@@ -3,11 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.freedesktop.org/api/v4/projects/1205/repository/tags
-  match: /name":"\d+\.\d+(\.\d+)?"/
-  strip:
-    - /name":"/
-    - /"/
+  gitlab: gitlab.freedesktop.org:xdg/shared-mime-info/tags
 
 dependencies:
   gnome.org/glib: 2

--- a/projects/freedesktop.org/slirp/package.yml
+++ b/projects/freedesktop.org/slirp/package.yml
@@ -3,11 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.freedesktop.org/api/v4/projects/2767/releases
-  match: /libslirp-v\d+\.\d+\.\d+\.tar\.gz/
-  strip:
-    - /libslirp-v/
-    - /\.tar\.gz/
+  gitlab: gitlab.freedesktop.org:slirp/libslirp
 
 dependencies:
   gnome.org/glib: ^2

--- a/projects/freedesktop.org/slirp/package.yml
+++ b/projects/freedesktop.org/slirp/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 4.7.0
+  url: https://gitlab.freedesktop.org/api/v4/projects/2767/releases
+  match: /libslirp-v\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /libslirp-v/
+    - /\.tar\.gz/
 
 dependencies:
   gnome.org/glib: ^2

--- a/projects/freetype.org/package.yml
+++ b/projects/freetype.org/package.yml
@@ -1,11 +1,15 @@
 distributable:
-  url: https://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.xz
+  url: https://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
   #FIXME our linux docker image TLS doesn’t like this URL
-  # url: https://downloads.sourceforge.net/project/freetype/freetype{{ version.major }}/{{ version }}/freetype-{{ version }}.tar.xz
+  # url: https://downloads.sourceforge.net/project/freetype/freetype{{ version.major }}/{{ version }}/freetype-{{ version }}.tar.gz
   strip-components: 1
 
 versions:
-  - 2.12.1
+  url: https://download.savannah.gnu.org/releases/freetype/
+  match: /freetype-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /freetype-/
+    - /.tar.gz/
 
 dependencies:
   libpng.org: 1

--- a/projects/gaia-gis.it/fossil/freexl/package.yml
+++ b/projects/gaia-gis.it/fossil/freexl/package.yml
@@ -2,9 +2,12 @@ distributable:
   url: https://www.gaia-gis.it/gaia-sins/freexl-sources/freexl-{{version}}.tar.gz
   strip-components: 1
 
-# if there’s a github then we can parse the versions
 versions:
-  - 1.0.6
+  url: https://www.gaia-gis.it/gaia-sins/freexl-sources/
+  match: /freexl-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /freexl-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/giflib.sourceforge.io/package.yml
+++ b/projects/giflib.sourceforge.io/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 5.2.1
+  url: https://sourceforge.net/projects/giflib/files
+  match: /giflib-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /giflib-/
+    - /\.tar\.gz/
 
 build:
   dependencies:

--- a/projects/gitlab.com/OldManProgrammer/unix-tree/package.yml
+++ b/projects/gitlab.com/OldManProgrammer/unix-tree/package.yml
@@ -3,11 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.com/api/v4/projects/34709077/repository/tags
-  match: /"name":"\d+\.\d+\.\d+"/
-  strip:
-    - /"name":"/
-    - /"/
+  gitlab: OldManProgrammer/unix-tree/tags
 
 build:
   dependencies:

--- a/projects/gitlab.com/OldManProgrammer/unix-tree/package.yml
+++ b/projects/gitlab.com/OldManProgrammer/unix-tree/package.yml
@@ -1,12 +1,13 @@
-# Tree is a recursive directory listing command that produces a depth indented listing of files, which is colorized
-# brew formula: https://formulae.brew.sh/formula/tree
-
 distributable:
   url: https://gitlab.com/OldManProgrammer/unix-tree/-/archive/{{version}}/unix-tree-{{version}}.tar.gz
   strip-components: 1
 
 versions:
-  - 2.1.0
+  url: https://gitlab.com/api/v4/projects/34709077/repository/tags
+  match: /"name":"\d+\.\d+\.\d+"/
+  strip:
+    - /"name":"/
+    - /"/
 
 build:
   dependencies:

--- a/projects/gitlab.com/gitlab-org/cli/package.yml
+++ b/projects/gitlab.com/gitlab-org/cli/package.yml
@@ -3,11 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.com/api/v4/projects/34675721/repository/tags
-  match: /"name":"v\d+\.\d+\.\d+"/
-  strip:
-    - /"name":"v/
-    - /"/
+  gitlab: gitlab-org/cli/tags
 
 provides:
   - bin/glab

--- a/projects/gitlab.com/gitlab-org/cli/package.yml
+++ b/projects/gitlab.com/gitlab-org/cli/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.26.0
+  url: https://gitlab.com/api/v4/projects/34675721/repository/tags
+  match: /"name":"v\d+\.\d+\.\d+"/
+  strip:
+    - /"name":"v/
+    - /"/
 
 provides:
   - bin/glab

--- a/projects/gitlab.com/procps-ng/watch/package.yml
+++ b/projects/gitlab.com/procps-ng/watch/package.yml
@@ -3,9 +3,12 @@ distributable:
   strip-components: 1
 
 versions:
-  - 4.0.3
+  url: https://gitlab.com/api/v4/projects/procps-ng%2Fprocps/repository/tags
+  match: /v\d+\.\d+\.\d+/
+  strip:
+    - /v/
 
-# Watch is broken out seperately from the rest of procps.  While procps provides other 
+# Watch is broken out seperately from the rest of procps.  While procps provides other
 # useful tools they do not build on OSX and are part of almost every base distro already
 provides:
   - bin/watch

--- a/projects/gitlab.com/procps-ng/watch/package.yml
+++ b/projects/gitlab.com/procps-ng/watch/package.yml
@@ -3,10 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.com/api/v4/projects/procps-ng%2Fprocps/repository/tags
-  match: /v\d+\.\d+\.\d+/
-  strip:
-    - /v/
+  gitlab: procps-ng/procps/tags
 
 # Watch is broken out seperately from the rest of procps.  While procps provides other
 # useful tools they do not build on OSX and are part of almost every base distro already

--- a/projects/gnome.org/gdk-pixbuf/package.yml
+++ b/projects/gnome.org/gdk-pixbuf/package.yml
@@ -1,13 +1,10 @@
 distributable:
-  url: https://download.gnome.org/sources/gdk-pixbuf/{{version.major}}.{{version.minor}}/gdk-pixbuf-{{ version }}.tar.gz
+  url: https://download.gnome.org/sources/gdk-pixbuf/{{version.major}}.{{version.minor}}/gdk-pixbuf-{{ version }}.tar.xz
   strip-components: 1
 
 versions:
-  url: https://gitlab.gnome.org/api/v4/projects/1548/repository/tags
-  match: /"name":"\d+\.\d+\.\d+"/
-  strip:
-    - /"name":"/
-    - /"/
+  gitlab: gitlab.gnome.org:GNOME/gdk-pixbuf
+  strip: [/^GdkPixbuf /, / \(stable\)/]
 
 dependencies:
   ijg.org: 9

--- a/projects/gnome.org/gdk-pixbuf/package.yml
+++ b/projects/gnome.org/gdk-pixbuf/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://download.gnome.org/sources/gdk-pixbuf/{{version.major}}.{{version.minor}}/gdk-pixbuf-{{ version }}.tar.xz
+  url: https://download.gnome.org/sources/gdk-pixbuf/{{version.major}}.{{version.minor}}/gdk-pixbuf-{{ version }}.tar.gz
   strip-components: 1
 
 versions:
-  - 2.42.8
+  url: https://gitlab.gnome.org/api/v4/projects/1548/repository/tags
+  match: /"name":"\d+\.\d+\.\d+"/
+  strip:
+    - /"name":"/
+    - /"/
 
 dependencies:
   ijg.org: 9

--- a/projects/gnome.org/gobject-introspection/package.yml
+++ b/projects/gnome.org/gobject-introspection/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.72.0
+  url: https://gitlab.gnome.org/api/v4/projects/659/repository/tags
+  match: /"name":"\d+\.\d+\.\d+"/
+  strip:
+    - /"name":"/
+    - /"/
 
 dependencies:
   gnome.org/glib: 2

--- a/projects/gnome.org/gobject-introspection/package.yml
+++ b/projects/gnome.org/gobject-introspection/package.yml
@@ -3,11 +3,8 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.gnome.org/api/v4/projects/659/repository/tags
-  match: /"name":"\d+\.\d+\.\d+"/
-  strip:
-    - /"name":"/
-    - /"/
+  gitlab: gitlab.gnome.org:gnome/gobject-introspection
+  strip: /^GObject-Introspection /
 
 dependencies:
   gnome.org/glib: 2

--- a/projects/gnu.org/autoconf/package.yml
+++ b/projects/gnu.org/autoconf/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/autoconf/autoconf-{{ version.raw }}.tar.xz
+  url: https://ftp.gnu.org/gnu/autoconf/autoconf-{{ version.raw }}.tar.gz
   strip-components: 1
 
 versions:
-  - 2.71
+  url: https://ftp.gnu.org/gnu/autoconf/
+  match: /autoconf-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /autoconf-/
+    - /.tar.gz/
 
 provides:
   - bin/autoconf

--- a/projects/gnu.org/automake/package.yml
+++ b/projects/gnu.org/automake/package.yml
@@ -1,10 +1,13 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/automake/automake-{{ version }}.tar.xz
+  url: https://ftp.gnu.org/gnu/automake/automake-{{ version }}.tar.gz
   strip-components: 1
 
-#FIXME: need to parse versions from someplace
 versions:
-  - 1.16.5
+  url: https://ftp.gnu.org/gnu/automake/
+  match: /automake-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /automake-/
+    - /.tar.gz/
 
 provides:
   - bin/aclocal

--- a/projects/gnu.org/coreutils/package.yml
+++ b/projects/gnu.org/coreutils/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 9.1
+  url: https://ftp.gnu.org/gnu/coreutils/
+  match: /coreutils-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /coreutils-/
+    - /.tar.gz/
 
 provides:
 - bin/[

--- a/projects/gnu.org/gmp/package.yml
+++ b/projects/gnu.org/gmp/package.yml
@@ -1,10 +1,13 @@
 distributable:
-  url: https://gmplib.org/download/gmp/gmp-{{ version }}.tar.xz
+  url: https://gmplib.org/download/gmp/gmp-{{ version }}.tar.bz2
   strip-components: 1
 
-#FIXME: need actual versions
 versions:
-  - 6.2.1
+  url: https://gmplib.org/download/gmp
+  match: /gmp-(\d+\.\d+\.\d+)\.tar\.bz2/
+  strip:
+    - /gmp-/
+    - /.tar.bz2/
 
 #TODO make by default runs test
 # disable that

--- a/projects/gnu.org/gperf/package.yml
+++ b/projects/gnu.org/gperf/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 3.1.0
+  url: https://ftp.gnu.org/gnu/gperf/
+  match: /gperf-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /gperf-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/gnu.org/grep/package.yml
+++ b/projects/gnu.org/grep/package.yml
@@ -1,9 +1,13 @@
 distributable:
-   url: https://ftp.gnu.org/gnu/grep/grep-{{version.raw}}.tar.xz
+   url: https://ftp.gnu.org/gnu/grep/grep-{{version.raw}}.tar.gz
    strip-components: 1
 
 versions:
-  - 3.8
+  url: https://ftp.gnu.org/gnu/grep/
+  match: /grep-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /grep-/
+    - /.tar.gz/
 
 dependencies:
   pcre.org/v2: '*'

--- a/projects/gnu.org/libiconv/package.yml
+++ b/projects/gnu.org/libiconv/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.17.0 # fix
+  url: https://ftp.gnu.org/gnu/libiconv/
+  match: /libiconv-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /libiconv-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/gnu.org/libidn/package.yml
+++ b/projects/gnu.org/libidn/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.41
+  url: https://ftp.gnu.org/gnu/libidn/
+  match: /libidn-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /libidn-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/gnu.org/libtasn1/package.yml
+++ b/projects/gnu.org/libtasn1/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 4.19.0
+  url: https://ftp.gnu.org/gnu/libtasn1/
+  match: /libtasn1-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /libtasn1-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/gnu.org/libtool/package.yml
+++ b/projects/gnu.org/libtool/package.yml
@@ -1,10 +1,13 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/libtool/libtool-{{ version }}.tar.xz
+  url: https://ftp.gnu.org/gnu/libtool/libtool-{{ version }}.tar.gz
   strip-components: 1
 
-#FIXME: need versions
 versions:
-  - 2.4.7
+  url: https://ftp.gnu.org/gnu/libtool/
+  match: /libtool-(\d+\.\d+\.\d+)\.tar\.gz/
+  strip:
+    - /libtool-/
+    - /.tar.gz/
 
 provides:
   - bin/libtool

--- a/projects/gnu.org/libunistring/package.yml
+++ b/projects/gnu.org/libunistring/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.1
+  url: https://ftp.gnu.org/gnu/libunistring/
+  match: /libunistring-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /libunistring-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/gnu.org/patch/package.yml
+++ b/projects/gnu.org/patch/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/patch/patch-{{version}}.tar.xz
+  url: https://ftp.gnu.org/gnu/patch/patch-{{version}}.tar.gz
   strip-components: 1
 
 versions:
-  - 2.7.6
+  url: https://ftp.gnu.org/gnu/patch/
+  match: /patch-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /patch-/
+    - /.tar.gz/
 
 provides:
   - bin/patch

--- a/projects/gnu.org/sed/package.yml
+++ b/projects/gnu.org/sed/package.yml
@@ -1,10 +1,13 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/sed/sed-{{version.raw}}.tar.xz
+  url: https://ftp.gnu.org/gnu/sed/sed-{{version.raw}}.tar.gz
   strip-components: 1
 
-# if there’s a github then we can parse the versions
 versions:
-  - 4.9
+  url: https://ftp.gnu.org/gnu/sed/
+  match: /sed-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /sed-/
+    - /.tar.gz/
 
 build:
   dependencies:
@@ -13,9 +16,7 @@ build:
   script: |
     ./configure $ARGS
     make --jobs {{ hw.concurrency }} install
-  # it’s extremely common for packages to require the above
   env:
-    # add any environment variables here
     ARGS:
       - --prefix="{{prefix}}"
       - --disable-debug

--- a/projects/gnu.org/stow/package.yml
+++ b/projects/gnu.org/stow/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.3.1
+  url: https://ftp.gnu.org/gnu/stow/
+  match: /stow-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /stow-/
+    - /.tar.gz/
 
 dependencies:
   perl.org: ^5.6.1

--- a/projects/gnu.org/tar/package.yml
+++ b/projects/gnu.org/tar/package.yml
@@ -3,8 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.34
-  #TODO scrape https://ftp.gnu.org/gnu/tar/
+  url: https://ftp.gnu.org/gnu/tar/
+  match: /tar-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /tar-/
+    - /.tar.gz/
 
 provides:
   - bin/tar

--- a/projects/gnu.org/wget/package.yml
+++ b/projects/gnu.org/wget/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.21.3
+  url: https://ftp.gnu.org/gnu/wget/
+  match: /wget-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /wget-/
+    - /.tar.gz/
 
 provides:
   - bin/wget

--- a/projects/gnupg.org/libassuan/package.yml
+++ b/projects/gnupg.org/libassuan/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.5.5
+  url: https://gnupg.org/ftp/gcrypt/libassuan/
+  match: /libassuan-(\d+\.\d+(\.\d+)?)\.tar\.bz2/
+  strip:
+    - /libassuan-/
+    - /.tar.bz2/
 
 provides:
   - bin/libassuan-config

--- a/projects/gnupg.org/libgcrypt/package.yml
+++ b/projects/gnupg.org/libgcrypt/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.10.1
+  url: https://gnupg.org/ftp/gcrypt/libgcrypt/
+  match: /libgcrypt-(\d+\.\d+(\.\d+)?)\.tar\.bz2/
+  strip:
+    - /libgcrypt-/
+    - /.tar.bz2/
 
 provides:
   - bin/dumpsexp

--- a/projects/gnupg.org/libgpg-error/package.yml
+++ b/projects/gnupg.org/libgpg-error/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-{{version.raw}}.tar.bz2
+  url: https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-{{version.raw}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.45
+  url: https://gnupg.org/ftp/gcrypt/libgpg-error/
+  match: /libgpg-error-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /libgpg-error-/
+    - /.tar.gz/
 
 provides:
   - bin/gpg-error

--- a/projects/gnupg.org/libksba/package.yml
+++ b/projects/gnupg.org/libksba/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.6.1
+  url: https://gnupg.org/ftp/gcrypt/libksba/
+  match: /libksba-(\d+\.\d+(\.\d+)?)\.tar\.bz2/
+  strip:
+    - /libksba-/
+    - /.tar.bz2/
 
 provides:
   - bin/ksba-config

--- a/projects/gnupg.org/npth/package.yml
+++ b/projects/gnupg.org/npth/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.6
+  url: https://gnupg.org/ftp/gcrypt/npth/
+  match: /npth-(\d+\.\d+(\.\d+)?)\.tar\.bz2/
+  strip:
+    - /npth-/
+    - /.tar.bz2/
 
 provides:
   - bin/npth-config

--- a/projects/gnupg.org/package.yml
+++ b/projects/gnupg.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.3.7
+  url: https://gnupg.org/ftp/gcrypt/gnupg/
+  match: /gnupg-(\d+\.\d+(\.\d+)?)\.tar\.bz2/
+  strip:
+    - /gnupg-/
+    - /.tar.bz2/
 
 provides:
   - bin/gpg

--- a/projects/gnuplot.info/package.yml
+++ b/projects/gnuplot.info/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 5.4.6
+  url: https://sourceforge.net/projects/gnuplot/files/gnuplot
+  match: /gnuplot\/\d+\.\d+\.\d+\//
+  strip:
+    - /gnuplot\//
+    - /\//
 
 dependencies:
   libgd.github.io: '*'
@@ -18,7 +22,6 @@ build:
     gnu.org/autoconf: '*'
     gnu.org/libtool: '*'
     freedesktop.org/pkg-config: '*'
-    
   script: |
     ./configure $ARGS
     make --jobs {{ hw.concurrency }} install
@@ -33,8 +36,9 @@ build:
       - --without-qt
       - --without-x
       - --without-latex
-  provides:
-    - bin/gnuplot
-  
+
+provides:
+  - bin/gnuplot
+
 test:
   gnuplot --version | grep {{ version.marketing }}

--- a/projects/google.com/fullycapable/package.yml
+++ b/projects/google.com/fullycapable/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.66
+  url: https://mirrors.edge.kernel.org/pub/linux/libs/security/linux-privs/libcap2
+  match: /libcap-\d+\.\d+\.tar\.xz/
+  strip:
+    - /libcap-/
+    - /\.tar\.xz/
 
 platforms: linux
 

--- a/projects/graphviz.org/package.yml
+++ b/projects/graphviz.org/package.yml
@@ -3,8 +3,11 @@ distributable:
    strip-components: 1
 
 versions:
-  - '7.1.0'
-  # gitlab: https://gitlab.com/graphviz/graphviz
+  url: https://gitlab.com/api/v4/projects/graphviz%2Fgraphviz/repository/tags
+  match: /"name":"\d+\.\d+\.\d+"/
+  strip:
+    - /"name":"/
+    - /"/
 
 dependencies:
   cairographics.org: '^1.1.10'
@@ -20,8 +23,7 @@ dependencies:
 
 build:
   dependencies:
-    # FIXME: '>=0.20<1'
-    freedesktop.org/pkg-config: '>=0.20'
+    freedesktop.org/pkg-config: '>=0.20<1'
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
   script: |

--- a/projects/graphviz.org/package.yml
+++ b/projects/graphviz.org/package.yml
@@ -3,11 +3,7 @@ distributable:
    strip-components: 1
 
 versions:
-  url: https://gitlab.com/api/v4/projects/graphviz%2Fgraphviz/repository/tags
-  match: /"name":"\d+\.\d+\.\d+"/
-  strip:
-    - /"name":"/
-    - /"/
+  gitlab: graphviz/graphviz/tags
 
 dependencies:
   cairographics.org: '^1.1.10'

--- a/projects/gts.sourceforge.net/package.yml
+++ b/projects/gts.sourceforge.net/package.yml
@@ -1,9 +1,13 @@
 distributable:
-   url: https://downloads.sourceforge.net/project/gts/gts/{{version}}/gts-{{version}}.tar.gz
+   url: https://downloads.sourceforge.net/project/gts/gts/{{version.raw}}/gts-{{version.raw}}.tar.gz
    strip-components: 1
 
 versions:
-  - '0.7.6'
+  url: https://sourceforge.net/projects/gts/files/gts/
+  match: /gts-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /gts-/
+    - /.tar.gz/
 
 dependencies:
   gnome.org/glib: '>=2.4.0'

--- a/projects/jbig2dec.com/package.yml
+++ b/projects/jbig2dec.com/package.yml
@@ -3,6 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
+  # FIXME: this is buried in a larger repo, separately versioned, and not present in every release.
   - 0.19
 
 build:

--- a/projects/joeyh.name/code/moreutils/package.yml
+++ b/projects/joeyh.name/code/moreutils/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 0.67
+  url: http://ftp.debian.org/debian/pool/main/m/moreutils/
+  match: /moreutils_(\d[\d.]*)\.orig\.tar\.gz/
+  strip:
+    - /moreutils_/
+    - /\.orig\.tar\.gz/
 
 dependencies:
   perl.org: '*'

--- a/projects/lame.sourceforge.io/package.yml
+++ b/projects/lame.sourceforge.io/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - '3.100'
+  url: https://sourceforge.net/projects/lame/files/lame/
+  match: /lame-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /lame-/
+    - /.tar.gz/
 
 provides:
   - bin/lame

--- a/projects/libisl.sourceforge.io/package.yml
+++ b/projects/libisl.sourceforge.io/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://libisl.sourceforge.io/isl-{{version.raw}}.tar.xz
+  url: https://libisl.sourceforge.io/isl-{{version.raw}}.tar.bz2
   strip-components: 1
 
 versions:
-  - 0.26
+  url: https://libisl.sourceforge.io
+  match: /isl-\d+\.\d+(\.\d+)?\.tar\.bz2/
+  strip:
+    - /isl-/
+    - /.tar.bz2/
 
 dependencies:
   gnu.org/gmp: ^6

--- a/projects/libsodium.org/package.yml
+++ b/projects/libsodium.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.0.18
+  url: https://download.libsodium.org/libsodium/releases/
+  match: /libsodium-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /libsodium-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/libssh.org/package.yml
+++ b/projects/libssh.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 0.10.4
+  url: https://git.libssh.org/projects/libssh.git/refs/tags
+  match: /libssh-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /libssh-/
+    - /.tar.gz/
 
 dependencies:
   openssl.org: ^1.1

--- a/projects/lua.org/package.yml
+++ b/projects/lua.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 5.4.4
+  url: http://www.lua.org/ftp/
+  match: /lua-(\d+\.\d+\.\d+)\.tar\.gz/
+  strip:
+    - /lua-/
+    - /.tar.gz/
 
 provides:
   - bin/lua

--- a/projects/mpg123.de/package.yml
+++ b/projects/mpg123.de/package.yml
@@ -2,9 +2,12 @@ distributable:
    url: https://www.mpg123.de/download/mpg123-{{version}}.tar.bz2
    strip-components: 1
 
-# if there’s a github then we can parse the versions
 versions:
-  - 1.31.2
+  url: https://www.mpg123.de/download/
+  match: /mpg123-(\d+\.\d+(\.\d+)?)\.tar\.bz2/
+  strip:
+    - /mpg123-/
+    - /.tar.bz2/
 
 build:
   dependencies:

--- a/projects/musl.libc.org/package.yml
+++ b/projects/musl.libc.org/package.yml
@@ -1,11 +1,17 @@
 distributable:
-  url: https://git.musl-libc.org/cgit/musl/snapshot/{{ version }}.tar.gz
+  url: https://git.musl-libc.org/cgit/musl/snapshot/musl-{{ version }}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.2.3
+  url: https://git.musl-libc.org/cgit/musl/refs/tags
+  match: /musl-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /musl-/
+    - /.tar.gz/
 
 relocatable: true
+
+platforms: linux
 
 provides:
   - bin/ld.musl-clang
@@ -18,22 +24,6 @@ build:
   dependencies:
     tea.xyz/gx/make: '*'
   script: |
-    # musl is linux only, so just make passthrough scripts on Darwin
-    if test {{ hw.platform }} != "linux"
-    then
-      mkdir -p "{{ prefix }}/bin"
-      cat > {{ prefix }}/bin/ld.musl-clang <<EOF
-    #!/bin/sh
-    exec ld "$@"
-    EOF
-    cat > {{ prefix }}/bin/musl-clang <<EOF
-    #!/bin/sh
-    exec cc "$@"
-    EOF
-      chmod +x {{ prefix }}/bin/ld.musl-clang {{ prefix }}/bin/musl-clang
-      exit
-    fi
-
     ./configure --prefix={{ prefix }} --syslibdir={{ prefix }}/lib
 
     make --jobs {{ hw.concurrency }}
@@ -62,13 +52,6 @@ test:
       return 0;
     }
   script: |
-    # musl is linux only
-    #FIXME? We don't sub our tokens in test scripts
-    if test $(uname) != "Linux"
-    then
-      exit
-    fi
-
     mv $FIXTURE $FIXTURE.c
     musl-clang $FIXTURE.c
     test "$(./a.out)" = "Hello World!"

--- a/projects/nano-editor.org/package.yml
+++ b/projects/nano-editor.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 7.2
+  url: https://mirrors.tripadvisor.com/gnu/nano/
+  match: /nano-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /nano-/
+    - /.tar.gz/
 
 dependencies:
   gnu.org/gettext: "*"

--- a/projects/nasm.us/package.yml
+++ b/projects/nasm.us/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.15.05  # the left-padded 05 is problematic for automating verison fetching
+  url: https://www.nasm.us/pub/nasm/releasebuilds/
+  match: /"\d+\.\d+(\.\d+)?\/"/
+  strip:
+    - /^"/
+    - /\/"$/
 
 build:
   dependencies:

--- a/projects/nmap.org/package.yml
+++ b/projects/nmap.org/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 7.93
+  url: https://nmap.org/dist/
+  match: /nmap-\d+\.\d+(\.\d+)?\.tgz/
+  strip:
+    - /nmap-/
+    - /.tgz/
 
 dependencies:
   openssl.org: '*'

--- a/projects/oberhumer.com/lzo/package.yml
+++ b/projects/oberhumer.com/lzo/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.10.0
+  url: https://www.oberhumer.com/opensource/lzo/download/
+  match: /lzo-\d+\.\d+\.tar\.gz/
+  strip:
+    - /lzo-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/pcre.org/package.yml
+++ b/projects/pcre.org/package.yml
@@ -9,7 +9,11 @@ distributable:
 # despite PCRE being unmaintained, most stuff still uses it, lol
 
 versions:
-  - 8.45
+  url: https://sourceforge.net/projects/pcre/files/pcre/
+  match: /pcre\/\d+(\.\d+)+\//
+  strip:
+    - /pcre\//
+    - /\//
 
 dependencies:
   sourceware.org/bzip2: 1

--- a/projects/poppler.freedesktop.org/poppler-data/package.yml
+++ b/projects/poppler.freedesktop.org/poppler-data/package.yml
@@ -3,9 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - '0.4.12'
-  # They have a github but don't update tags!
-  # gitlab: https://gitlab.freedesktop.org/poppler/poppler-data
+  url: https://gitlab.freedesktop.org/api/v4/projects/883/repository/tags
+  match: /"title":"\d+\.\d+\.\d+"/
+  strip:
+    - /^"title":"/
+    - /"$/
 
 build:
   dependencies:

--- a/projects/poppler.freedesktop.org/poppler-data/package.yml
+++ b/projects/poppler.freedesktop.org/poppler-data/package.yml
@@ -3,11 +3,8 @@ distributable:
   strip-components: 1
 
 versions:
-  url: https://gitlab.freedesktop.org/api/v4/projects/883/repository/tags
-  match: /"title":"\d+\.\d+\.\d+"/
-  strip:
-    - /^"title":"/
-    - /"$/
+  gitlab: gitlab.freedesktop.org:poppler/poppler-data/tags
+  strip: /^POPPLER_DATA_/
 
 build:
   dependencies:

--- a/projects/postgresql.org/package.yml
+++ b/projects/postgresql.org/package.yml
@@ -1,13 +1,13 @@
 distributable:
    url: https://github.com/postgres/postgres/archive/refs/tags/REL_{{version.major}}_{{version.minor}}.tar.gz
-
    strip-components: 1
+
 versions:
-  - 15.2 # need to hardcode this version, because no easy way to get the tag yet
-  - 14.7
-  - 13.10
-  - 12.14
-  - 11.19
+  url: https://www.postgresql.org/ftp/source/
+  match: /"v\d+\.\d+(\.\d+)?\/"/
+  strip:
+    - /"v/
+    - /\/"/
 
 dependencies:
   openssl.org: ^1.0.1

--- a/projects/simplesystems.org/libtiff/package.yml
+++ b/projects/simplesystems.org/libtiff/package.yml
@@ -3,7 +3,11 @@ distributable:
    strip-components: 1
 
 versions:
-  - 4.5.0
+  url: https://download.osgeo.org/libtiff/
+  match: /tiff-(\d+\.\d+\.\d+)\.tar\.gz/
+  strip:
+    - /tiff-/
+    - /.tar.gz/
 
 dependencies:
   facebook.com/zstd: ^1

--- a/projects/tcl-lang.org/expect/package.yml
+++ b/projects/tcl-lang.org/expect/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://cytranet.dl.sourceforge.net/project/expect/Expect/{{ version }}/expect{{ version }}.tar.gz
+  url: https://cytranet.dl.sourceforge.net/project/expect/Expect/{{ version.raw }}/expect{{ version.raw }}.tar.gz
   strip-components: 1
 
 versions:
-  - 5.45.4
+  url: https://sourceforge.net/projects/expect/files/Expect/
+  match: /Expect\/\d+(\.\d+)+\//
+  strip:
+    - /Expect\//
+    - /\//
 
 dependencies:
   tcl.tk/tcl: ^8

--- a/projects/thekelleys.org.uk/dnsmasq/package.yml
+++ b/projects/thekelleys.org.uk/dnsmasq/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.89
+  url: https://thekelleys.org.uk/dnsmasq/
+  match: /dnsmasq-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /dnsmasq-/
+    - /.tar.gz/
 
 provides:
   - sbin/dnsmasq

--- a/projects/tukaani.org/xz/package.yml
+++ b/projects/tukaani.org/xz/package.yml
@@ -3,8 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 5.2.7
-  - 5.2.5
+  url: https://tukaani.org/xz/
+  match: /xz-(\d+\.\d+(\.\d+)?)\.tar\.gz/
+  strip:
+    - /xz-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/unicode.org/package.yml
+++ b/projects/unicode.org/package.yml
@@ -3,8 +3,8 @@ distributable:
   strip-components: 1
 
 versions:
-  - 71.1.0
-#TODO ^^ unicode-org/icu but it's madness
+  github: unicode-org/icu/releases
+  strip: /^ICU /
 
 build:
   dependencies:

--- a/projects/vim.org/package.yml
+++ b/projects/vim.org/package.yml
@@ -3,7 +3,8 @@ distributable:
   strip-components: 1
 
 versions:
-  - 9.0.1294
+  # FIXME: so slow. 16k tags.
+  github: vim/vim/tags
 
 provides:
   - bin/vim

--- a/projects/x.org/exts/package.yml
+++ b/projects/x.org/exts/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.3.5
+  url: https://www.x.org/archive/individual/lib/
+  match: /libXext-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libXext-/
+    - /.tar.gz/
 
 dependencies:
   x.org/x11: ^1

--- a/projects/x.org/ice/package.yml
+++ b/projects/x.org/ice/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://www.x.org/archive/individual/lib/libICE-{{version}}.tar.xz
+  url: https://www.x.org/archive/individual/lib/libICE-{{version}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.1.1
+  url: https://www.x.org/archive/individual/lib/
+  match: /libICE-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libICE-/
+    - /.tar.gz/
 
 dependencies:
   x.org/protocol: '*'

--- a/projects/x.org/protocol/package.yml
+++ b/projects/x.org/protocol/package.yml
@@ -3,8 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2022.2
-  # https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/tags
+  url: https://xorg.freedesktop.org/archive/individual/proto/
+  match: /xorgproto-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /xorgproto-/
+    - /.tar.gz/
 
 dependencies:
   x.org/util-macros: '*'

--- a/projects/x.org/protocol/xcb/package.yml
+++ b/projects/x.org/protocol/xcb/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-{{version}}.tar.xz
+  url: https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-{{version.raw}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.15.2
+  url: https://xorg.freedesktop.org/archive/individual/proto/
+  match: /xcb-proto-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /xcb-proto-/
+    - /.tar.gz/
 
 build:
   dependencies:

--- a/projects/x.org/sm/package.yml
+++ b/projects/x.org/sm/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://www.x.org/archive/individual/lib/libSM-{{version}}.tar.xz
+  url: https://www.x.org/archive/individual/lib/libSM-{{version}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.2.4
+  url: https://www.x.org/archive/individual/lib/
+  match: /libSM-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libSM-/
+    - /.tar.gz/
 
 dependencies:
   x.org/ice: '*'

--- a/projects/x.org/util-macros/package.yml
+++ b/projects/x.org/util-macros/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://www.x.org/archive/individual/util/util-macros-{{version}}.tar.xz
+  url: https://www.x.org/archive/individual/util/util-macros-{{version.raw}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.20.0 # fix
+  url: https://www.x.org/archive/individual/util/
+  match: /util-macros-\d+\.\d+(\.\d+)?.tar.gz/
+  strip:
+    - /util-macros-/
+    - /.tar.gz/
 
 build:
   dependencies:
@@ -11,7 +15,7 @@ build:
     tea.xyz/gx/make: '*'
   script: |
     ./configure $ARGS
-    make --jobs {{ hw.concurrency }} 
+    make --jobs {{ hw.concurrency }}
     make install
   env:
     ARGS:

--- a/projects/x.org/x11/package.yml
+++ b/projects/x.org/x11/package.yml
@@ -4,7 +4,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.8.4
+  url: https://www.x.org/archive/individual/lib/
+  match: /libX11-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libX11-/
+    - /.tar.gz/
 
 dependencies:
   x.org/xcb: ^1

--- a/projects/x.org/xau/package.yml
+++ b/projects/x.org/xau/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://www.x.org/archive/individual/lib/libXau-{{version}}.tar.xz
+  url: https://www.x.org/archive/individual/lib/libXau-{{version}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.0.11
+  url: https://www.x.org/archive/individual/lib/
+  match: /libXau-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libXau-/
+    - /.tar.gz/
 
 dependencies:
   x.org/util-macros: '*'

--- a/projects/x.org/xaw/package.yml
+++ b/projects/x.org/xaw/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.0.15
+  url: https://www.x.org/archive/individual/lib/
+  match: /libXaw-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libXaw-/
+    - /.tar.gz/
 
 dependencies:
   x.org/x11: '*'

--- a/projects/x.org/xcb/package.yml
+++ b/projects/x.org/xcb/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.15
+  url: https://xcb.freedesktop.org/dist/
+  match: /libxcb-\d+\.\d+(\.\d+)?.tar.gz/
+  strip:
+    - /libxcb-/
+    - /.tar.gz/
 
 dependencies:
   x.org/xau: ^1

--- a/projects/x.org/xdmcp/package.yml
+++ b/projects/x.org/xdmcp/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://www.x.org/archive/individual/lib/libXdmcp-{{version}}.tar.xz
+  url: https://www.x.org/archive/individual/lib/libXdmcp-{{version}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.1.4
+  url: https://www.x.org/archive/individual/lib/
+  match: /libXdmcp-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libXdmcp-/
+    - /.tar.gz/
 
 dependencies:
   x.org/protocol: '*'

--- a/projects/x.org/xmu/package.yml
+++ b/projects/x.org/xmu/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://www.x.org/archive/individual/lib/libXmu-{{version}}.tar.xz
+  url: https://www.x.org/archive/individual/lib/libXmu-{{version}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.1.4
+  url: https://www.x.org/archive/individual/lib/
+  match: /libXmu-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libXmu-/
+    - /.tar.gz/
 
 dependencies:
   x.org/exts: '*'

--- a/projects/x.org/xpm/package.yml
+++ b/projects/x.org/xpm/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 3.5.15
+  url: https://www.x.org/archive/individual/lib/
+  match: /libXpm-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libXpm-/
+    - /.tar.gz/
 
 dependencies:
   x.org/x11: '*'

--- a/projects/x.org/xrender/package.yml
+++ b/projects/x.org/xrender/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 0.9.11
+  url: https://www.x.org/archive/individual/lib/
+  match: /libXrender-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libXrender-/
+    - /.tar.gz/
 
 dependencies:
   x.org/x11: ^1

--- a/projects/x.org/xt/package.yml
+++ b/projects/x.org/xt/package.yml
@@ -1,15 +1,18 @@
 distributable:
-  url: https://www.x.org/archive/individual/lib/libXt-{{version}}.tar.xz
+  url: https://www.x.org/archive/individual/lib/libXt-{{version}}.tar.gz
   strip-components: 1
 
 versions:
-  - 1.3.0
+  url: https://www.x.org/archive/individual/lib/
+  match: /libXt-\d+\.\d+\.\d+.tar.gz/
+  strip:
+    - /libXt-/
+    - /.tar.gz/
 
 dependencies:
   x.org/ice: '*'
   x.org/sm: '*'
   x.org/x11: '*'
-
 
 build:
   dependencies:

--- a/projects/x.org/xtrans/package.yml
+++ b/projects/x.org/xtrans/package.yml
@@ -1,9 +1,13 @@
 distributable:
-  url: https://www.x.org/archive/individual/lib/xtrans-1.4.0.tar.bz2
+  url: https://www.x.org/archive/individual/lib/xtrans-{{ version.raw }}.tar.bz2
   strip-components: 1
 
 versions:
-  - 1.4.0
+  url: https://www.x.org/archive/individual/lib/
+  match: /xtrans-\d+\.\d+(\.\d+)?.tar.bz2/
+  strip:
+    - /xtrans-/
+    - /.tar.bz2/
 
 dependencies:
   x.org/protocol: '*'

--- a/projects/xiph.org/ogg/package.yml
+++ b/projects/xiph.org/ogg/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.3.5 # fix
+  url: https://downloads.xiph.org/releases/ogg/
+  match: /libogg-(\d+\.\d+\.\d+)\.tar\.gz/
+  strip:
+    - /libogg-/
+    - /.tar.gz/
 
 build:
   dependencies:
@@ -11,7 +15,7 @@ build:
     tea.xyz/gx/make: '*'
   script: |
     ./configure $ARGS
-    make --jobs {{ hw.concurrency }} 
+    make --jobs {{ hw.concurrency }}
     make install
   env:
     ARGS:

--- a/projects/yasm.tortall.net/package.yml
+++ b/projects/yasm.tortall.net/package.yml
@@ -3,7 +3,11 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.3.0
+  url: https://www.tortall.net/projects/yasm/releases/
+  match: /yasm-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /yasm-/
+    - /.tar.gz/
 
 build:
   dependencies:


### PR DESCRIPTION
the following packages aren't obviously susceptible to fixing this way:
```sh
% rg -lU 'versions:\n  -' projects               
projects/docbook.org/package.yml
projects/bcrypt.sourceforge.net/package.yml
projects/github.com/nomic-ai/gpt4all/package.yml
projects/github.com/ggerganov/llama.cpp/package.yml
projects/github.com/mamba-org/mamba/package.yml
projects/github.com/antimatter15/alpaca.cpp/package.yml
projects/github.com/AUTOMATIC1111/stable-diffusion-webui/package.yml
projects/github.com/mop-tracker/mop/package.yml
projects/tea.xyz/gx/cc/package.yml
projects/oracle.com/berkeley-db/package.yml
projects/crates.io/bpb/package.yml
projects/surrealdb.com/package.yml
projects/ijg.org/package.yml
projects/info-zip.org/unzip/package.yml
projects/thrysoee.dk/editline/package.yml
```

~Big warning: if this is merged without coordinating the clearing of the known-version keys used by kettle for these packages, all of the old versions for all 91 packages will be submitted for building. That's over 16k versions for `vim` alone. DO NOT MERGE WITHOUT COORDINATION OR I KILL YOU.~

fixed in kettle; more than 5 new versions found in the last 5 minutes means we hit a version bomb; in that case, we just treat them like old versions and add them to the `seen` cache.

now requires https://github.com/teaxyz/brewkit/pull/96 for direct gitlab queries.