### PR TITLE
+tectonic-typesetting.github.io

### DIFF
--- a/projects/harfbuzz.org/package.yml
+++ b/projects/harfbuzz.org/package.yml
@@ -9,6 +9,7 @@ dependencies:
   cairographics.org: 1
   freetype.org: 2
   gnome.org/glib: 2
+  graphite.sil.org: '*'
   unicode.org: '>=71'
 
 build:
@@ -33,6 +34,7 @@ build:
       - -Dcoretext=enabled
       - -Dfreetype=enabled
       - -Dglib=enabled
+      - -Dgraphite=enabled
       - -Dtests=disabled
     linux/x86-64:
       CFLAGS: -fPIC

--- a/projects/tectonic-typesetting.github.io/package.yml
+++ b/projects/tectonic-typesetting.github.io/package.yml
@@ -1,0 +1,33 @@
+distributable:
+  url: https://github.com/tectonic-typesetting/tectonic/archive/refs/tags/tectonic@{{ version }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: tectonic-typesetting/tectonic/releases/tags
+  strip: /^tectonic@/
+
+dependencies:
+  freetype.org: "*"
+  graphite.sil.org: "*"
+  harfbuzz.org: "*"
+  libpng.org: "*"
+  openssl.org: ^1.1
+  unicode.org: "*"
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: ^0.29
+    rust-lang.org: ">=1.48.0"
+    rust-lang.org/cargo: "*"
+  env:
+    OPENSSL_DIR: "{{ deps.openssl.org.prefix }}"
+  script: cargo install --features external-harfbuzz --locked --path . --root {{prefix}}
+
+provides:
+  - bin/tectonic
+
+test:
+  script: |
+    tectonic -X new
+    tectonic -X build
+    test -f build/default/default.pdf


### PR DESCRIPTION
Adds [tectonic](https://github.com/tectonic-typesetting/tectonic), which needs a harfbuzz built with graphite (another option is allowing tectonic to use a vendored version)
