### PR TITLE
+fizz

### DIFF
--- a/projects/facebook.com/folly/package.yml
+++ b/projects/facebook.com/folly/package.yml
@@ -36,6 +36,13 @@ build:
     mv $SRCROOT xyz.tea.srcs
     cmake $ARGS -S xyz.tea.srcs -B .
     make --jobs {{hw.concurrency}} install
+
+    sed -i.bak "s:$TEA_PREFIX:\$\{_IMPORT_PREFIX\}/../../..:g" "{{prefix}}"/lib/cmake/folly/folly-targets.cmake
+    rm "{{prefix}}"/lib/cmake/folly/folly-targets.cmake.bak
+
+    cd {{prefix}}/lib/pkgconfig
+    sed -i.bak -e 's/-I[^ ]* *//g' ./libfolly.pc
+    rm *.bak
   env:
     ARGS:
       - -DCMAKE_INSTALL_PREFIX={{prefix}}

--- a/projects/facebook.com/folly/package.yml
+++ b/projects/facebook.com/folly/package.yml
@@ -49,6 +49,11 @@ build:
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_TESTING=OFF
       - -DCMAKE_VERBOSE_MAKEFILE=ON
+    linux/aarch64:
+      ARGS:
+        - -DCMAKE_C_FLAGS=-fPIC
+        - -DCMAKE_CXX_FLAGS=-fPIC
+        - -DCMAKE_EXE_LINKER_FLAGS=-pie
 
 test:
   dependencies:

--- a/projects/fmt.dev/package.yml
+++ b/projects/fmt.dev/package.yml
@@ -13,8 +13,17 @@ build:
   working-directory:
     build
   script: |
-    cmake .. -DCMAKE_INSTALL_PREFIX="{{prefix}}" -DCMAKE_BUILD_TYPE=Release
+    cmake .. $ARGS
     make --jobs {{ hw.concurrency }} install
+  env:
+    ARGS:
+      - -DCMAKE_INSTALL_PREFIX="{{prefix}}"
+      - -DCMAKE_BUILD_TYPE=Release
+    linux/aarch64:
+      ARGS:
+        - -DCMAKE_C_FLAGS=-fPIC
+        - -DCMAKE_CXX_FLAGS=-fPIC
+        - -DCMAKE_EXE_LINKER_FLAGS=-pie
 
 test:
   dependencies:

--- a/projects/github.com/facebookincubator/fizz/package.yml
+++ b/projects/github.com/facebookincubator/fizz/package.yml
@@ -40,6 +40,11 @@ build:
       - -DBUILD_TESTS=OFF
       - -DBUILD_SHARED_LIBS=ON
       - -DCMAKE_INSTALL_RPATH="{{prefix}}"
+    linux/aarch64:
+      ARGS:
+        - -DCMAKE_C_FLAGS=-fPIC
+        - -DCMAKE_CXX_FLAGS=-fPIC
+        - -DCMAKE_EXE_LINKER_FLAGS=-pie
 
 test:
   dependencies:

--- a/projects/github.com/facebookincubator/fizz/package.yml
+++ b/projects/github.com/facebookincubator/fizz/package.yml
@@ -1,0 +1,58 @@
+distributable:
+  url: https://github.com/facebookincubator/fizz/archive/refs/tags/v{{version.raw}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: facebookincubator/fizz/releases/tags
+  strip: /^v/
+
+dependencies:
+  boost.org: '*'
+  google.com/double-conversion: ^3
+  fmt.dev: ^9
+  facebook.com/folly: '*'
+  gflags.github.io: '*'
+  google.com/glog: '*'
+  libevent.org: '*'
+  libsodium.org: '*'
+  lz4.org: 1
+  openssl.org: ^1.1
+  google.github.io/snappy: '*'
+  facebook.com/zstd: 1
+
+provides:
+  - bin/fizz
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    cmake.org: ^3
+    ninja-build.org: ^1
+  script: |
+    cmake -S fizz -B build $ARGS
+    cmake --build build
+    cmake --install build
+  env:
+    ARGS:
+      - -GNinja
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX="{{prefix}}"
+      - -DBUILD_TESTS=OFF
+      - -DBUILD_SHARED_LIBS=ON
+      - -DCMAKE_INSTALL_RPATH="{{prefix}}"
+
+test:
+  dependencies:
+    tea.xyz/gx/cc: c99
+  fixture: |
+    #include <fizz/client/AsyncFizzClient.h>
+    #include <iostream>
+
+    int main() {
+      auto context = fizz::client::FizzClientContext();
+      std::cout << toString(context.getSupportedVersions()[0]) << std::endl;
+    }
+  script: |
+    mv $FIXTURE test.cpp
+    c++ -std=c++14 test.cpp -lfizz -lfolly -lgflags -lglog -levent -lsodium -lcrypto -lssl -o fixture
+    test $(./fixture) = "TLS"


### PR DESCRIPTION
closes #262 

not working yet, I'm still learning how all this works so any guidance would be much appreciated. currently I'm getting this error locally during the build phase (arm64 macOS):

```
CMake Error in CMakeLists.txt:
  Imported target "Folly::folly" includes non-existent path

    "/opt/boost.org/v1.82.0/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```