### PR TITLE
fix(glib)

### DIFF
--- a/projects/gnome.org/glib/package.yml
+++ b/projects/gnome.org/glib/package.yml
@@ -3,19 +3,20 @@ distributable:
   strip-components: 1
 
 versions:
-  github: GNOME/glib/tags
-  ignore:
-    - /2\.73\.[2-9]/
-    - /2\.7[4-9]\.[0-9]+/
-    - /2.[8-9][0-9]\.[0-9]+/
-
-#FIXME 2.73.2 onwards depends on PCRE2 (10.x)
-# lol at bumping a dep in a *PATCH* release, semver is for the weak apparently
+  gitlab: gitlab.gnome.org:GNOME/glib
 
 dependencies:
   gnu.org/gettext: ^0.21
   sourceware.org/libffi: 3
+  # FIXME: this isn't great, but we need to bump to build new glibs.
+  # versioned dependencies would be needed to fix this, which could break
+  # any number of things in the version solver. However, this shouldn't be
+  # too dangerous, since they produce different libraries (libpcre vs libpcre2)
+  # glib bumped this in 2.73.2, after claiming for years they'd rather remove
+  # GRegex than bump the version. :(
+  # ref: https://gitlab.gnome.org/GNOME/glib/-/issues/1085
   pcre.org: 8
+  pcre.org/v2: 10
 
 build:
   dependencies:


### PR DESCRIPTION
if this works the way I think it will, it will dep both libpcre and libpcre2 to glib, regardless of version. slightly space inefficient, but since they're two different libraries, i'd be surprised if anyone gets confused.

this builds both our current bottle ([2.72.4](https://github.com/teaxyz/pantry/actions/runs/4866521026/jobs/8678145973)), and the current release (2.76.2), so i think it might be a winner. how much do you hate this, @mxcl ?