### PR TITLE
fix(protobuf)

### DIFF
--- a/projects/abseil.io/package.yml
+++ b/projects/abseil.io/package.yml
@@ -33,6 +33,12 @@ build:
       sed -i '' 's/-Xarch_x86_64 -Xarch_x86_64 -Xarch_arm64 //g' {{ prefix }}/lib/pkgconfig/absl_random_internal_randen_hwaes{_impl,}.pc
     fi
 
+    cd "{{prefix}}/lib/cmake/absl"
+    sed -i.bak \
+        -e "s:$(tea --prefix):\$\{CMAKE_CURRENT_LIST_DIR\}/../../../../..:g" \
+        abslTargets{,-release}.cmake
+    rm abslTargets{,-release}.cmake.bak
+
 test:
   dependencies:
     tea.xyz/gx/cc: c99

--- a/projects/protobuf.dev/package.yml
+++ b/projects/protobuf.dev/package.yml
@@ -1,14 +1,13 @@
 distributable:
-   url: https://github.com/protocolbuffers/protobuf/releases/download/v{{version.raw}}/protobuf-all-{{version.raw}}.tar.gz
+   url: https://github.com/protocolbuffers/protobuf/archive/refs/tags/v{{version.raw}}.tar.gz
    strip-components: 1
 
 versions:
-  github: protocolbuffers/protobuf/tags
-  # v22 requires bazel for builds and is quite different
-  ignore: v22.x
+  github: protocolbuffers/protobuf
 
 dependencies:
   zlib.net: ^1
+  abseil.io: '*'
 
 build:
   dependencies:
@@ -27,6 +26,8 @@ build:
       - -Dprotobuf_BUILD_TESTS=OFF
       - -DCMAKE_INSTALL_PREFIX={{prefix}}
       - -DCMAKE_BUILD_TYPE=Release
+      - -Dprotobuf_ABSL_PROVIDER=package
+      - -DCMAKE_PREFIX_PATH={{deps.abseil.io.prefix}}
 
 provides:
   - bin/protoc


### PR DESCRIPTION
newer versions require `abseil.io`. and `abeil.io` needed its `.cmake`s fixed. and I did it all without packaging `bazel`.