### PR TITLE
update(gcc12).more()

### DIFF
--- a/projects/gnu.org/gcc/package.yml
+++ b/projects/gnu.org/gcc/package.yml
@@ -25,6 +25,7 @@ build:
     perl.org: '^5.6.1'
     gnu.org/patch: '*'
     curl.se: '*'
+    github.com/westes/flex: '*'
   working-directory: build
   script:
     # If we have a patch, apply it


### PR DESCRIPTION
requires `flex` to build