### PR TITLE
+zsh-syntax-highlighting

### DIFF
--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/fixture.sh
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/fixture.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Receive the directory as the first command-line argument
+directory="$1"
+
+# Check if the directory is provided
+if [ -z "$directory" ]; then
+  echo "Directory parameter is missing."
+  exit 1
+fi
+
+# Change to the specified directory
+cd "$directory"
+
+output=$(zsh tests/test-highlighting.zsh main)
+lines=()
+
+# Read the lines of the test
+while IFS= read -r line; do
+  lines+=("$line")
+done <<< "$output"
+
+# If line has not ok, with no TODO --> fail
+for line in "${lines[@]}"; do
+  if [[ $line =~ ^(.*\bnot ok\b)(.*)$ && ! $line =~ "#TODO" ]]; then
+    echo "Fail"
+    # Exit the loop if a failure is found (optional)
+    exit 1
+  fi
+done
+
+echo "Pass"

--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/fixture.sh
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/fixture.sh
@@ -10,21 +10,19 @@ if [ -z "$directory" ]; then
 fi
 
 # Change to the specified directory
-cd "$directory"
+cd "$directory" || { echo "Failed to change to the specified directory."; exit 1; }
 
+# Run the test & read the lines
 output=$(zsh tests/test-highlighting.zsh main)
 lines=()
-
-# Read the lines of the test
 while IFS= read -r line; do
   lines+=("$line")
 done <<< "$output"
 
-# If line has not ok, with no TODO --> fail
+# If line has 'not ok', with no '#TODO' --> fail & exit
 for line in "${lines[@]}"; do
   if [[ $line =~ ^(.*\bnot ok\b)(.*)$ && ! $line =~ "#TODO" ]]; then
     echo "Fail"
-    # Exit the loop if a failure is found (optional)
     exit 1
   fi
 done

--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
@@ -5,19 +5,19 @@ distributable:
 versions:
   github: zsh-users/zsh-syntax-highlighting/tags
 
+provides:
+  # Made an executable to give the user installation instructions, in case they forgot :-)
+  - bin/zsh-syntax-highlighting
+
 build:
   dependencies:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
+    charm.sh/gum: '*'
   script: |
     make --jobs {{ hw.concurrency }} install
-    chmod +w /Users/sanch/.zshrc 
-    echo "source {{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> /Users/sanch/.zshrc
-  # TODO fix the /Users/sanch
+    export ZSH_HIGHLIGHTING={{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    gum format "# *Finish the install by running*"  '## `echo "source '$ZSH_HIGHLIGHTING'" >> $HOME/.zshrc`' | gum format
   env:
     ARGS:
       - --prefix="{{prefix}}"
-
-test:
-  script:
-    source {{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
@@ -9,7 +9,7 @@ build:
   dependencies:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
-    charm.sh/gum: '*'
+    #charm.sh/gum: '*'
   script: 
     - make --jobs {{ hw.concurrency }} install
     # Users need to source this in their zsh configs

--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
@@ -1,0 +1,23 @@
+distributable:
+  url: https://github.com/zsh-users/zsh-syntax-highlighting/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: zsh-users/zsh-syntax-highlighting/tags
+
+build:
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+  script: |
+    make --jobs {{ hw.concurrency }} install
+    chmod +w /Users/sanch/.zshrc 
+    echo "source {{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> /Users/sanch/.zshrc
+  # TODO fix the /Users/sanch
+  env:
+    ARGS:
+      - --prefix="{{prefix}}"
+
+test:
+  script:
+    source {{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
@@ -14,10 +14,19 @@ build:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
     charm.sh/gum: '*'
-  script: |
-    make --jobs {{ hw.concurrency }} install
-    export ZSH_HIGHLIGHTING={{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-    gum format "# *Finish the install by running*"  '## `echo "source '$ZSH_HIGHLIGHTING'" >> $HOME/.zshrc`' | gum format
+  script: 
+    - make --jobs {{ hw.concurrency }} install
+    - export ZSH_HIGHLIGHTING={{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    - gum format "# *Finish the install by running*"  '## `echo "source '$ZSH_HIGHLIGHTING'" >> $HOME/.zshrc`' | gum format
+
+    - |
+      mkdir {{prefix}}/share/zsh-syntax-highlighting/tests {{prefix}}/share/zsh-syntax-highlighting/highlighters/main/test-data
+      cp -r ./tests/* {{prefix}}/share/zsh-syntax-highlighting/tests 
+      cp ./highlighters/main/test-data/alias-basic.zsh {{prefix}}/share/zsh-syntax-highlighting/highlighters/main/test-data
   env:
     ARGS:
       - --prefix="{{prefix}}"
+
+test: |
+  chmod +x ./fixture.sh
+  ./fixture.sh {{prefix}}/share/zsh-syntax-highlighting

--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
@@ -5,10 +5,6 @@ distributable:
 versions:
   github: zsh-users/zsh-syntax-highlighting/tags
 
-provides:
-  # Made an executable to give the user installation instructions, in case they forgot :-)
-  - bin/zsh-syntax-highlighting
-
 build:
   dependencies:
     tea.xyz/gx/cc: c99

--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
@@ -13,8 +13,10 @@ build:
   script: 
     - make --jobs {{ hw.concurrency }} install
     - export ZSH_HIGHLIGHTING={{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    # TODO: #2008
     - gum format "# *Finish the install by running*"  '## `echo "source '$ZSH_HIGHLIGHTING'" >> $HOME/.zshrc`' | gum format
 
+    # Use tests provided by the highlighter for test
     - |
       mkdir {{prefix}}/share/zsh-syntax-highlighting/tests {{prefix}}/share/zsh-syntax-highlighting/highlighters/main/test-data
       cp -r ./tests/* {{prefix}}/share/zsh-syntax-highlighting/tests 

--- a/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
+++ b/projects/github.com/zsh-users/zsh-syntax-highlighting/package.yml
@@ -12,9 +12,10 @@ build:
     charm.sh/gum: '*'
   script: 
     - make --jobs {{ hw.concurrency }} install
-    - export ZSH_HIGHLIGHTING={{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    # Users need to source this in their zsh configs
+    # - export ZSH_HIGHLIGHTING={{prefix}}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
     # TODO: #2008
-    - gum format "# *Finish the install by running*"  '## `echo "source '$ZSH_HIGHLIGHTING'" >> $HOME/.zshrc`' | gum format
+    # - gum format "# *Finish the install by running*"  '## `echo "source '$ZSH_HIGHLIGHTING'" >> $HOME/.zshrc`' | gum format
 
     # Use tests provided by the highlighter for test
     - |


### PR DESCRIPTION
1. Need to replace `/Users/sanch` with `$HOME`, but `$HOME` refers to the build directory.  What's the shorthand to refer to `$HOME`, or specifically, wherever the users places their `.zshrc` file?
2. In the test, running that source line to refresh the open terminal window results in this error below.  If I open a new terminal, it seems to have installed correctly.  
```bash
+ source /Users/sanch/.tea/github.com/zsh-users/zsh-syntax-highlighting/v0.7.1/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+++ builtin alias -Lm '[^+]*'
/Users/sanch/.tea/github.com/zsh-users/zsh-syntax-highlighting/v0.7.1/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh: line 31: alias: -L: invalid option
alias: usage: alias [-p] [name[=value] ... ]
++ typeset zsh_highlight__aliases=
++ builtin unalias -m '[^+]*'
/Users/sanch/.tea/github.com/zsh-users/zsh-syntax-highlighting/v0.7.1/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh: line 36: unalias: -m: invalid option
unalias: usage: unalias [-a] name [name ...]
```