### PR TITLE
send packages that require QA through a forked upload process

### DIFF
--- a/.github/actions/request-qa/action.yml
+++ b/.github/actions/request-qa/action.yml
@@ -1,0 +1,22 @@
+name: tea/pantry/request-qa
+description: Requests QA for a new version of a project
+
+inputs:
+  project:
+    description: projects to request QA for
+    required: true
+  slack-webhook:
+    description: slack webhook to send message to
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: slackapi/slack-github-action@v1
+      with:
+        payload: |
+          {
+            "text": "# QA requested for ${{ inputs.project }}\n\n${{ inputs.project }} has a new version available. Please test it out and let us know if there are any issues.\n\n- `qa.ts ${{ inputs.project }} --test` to test it out\n- `qa.ts ${{ inputs.project }} --approve` to approve it for production.\n- `qa.ts ${{ inputs.project }} --reject` will reject it and delete the artifacts."
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook }}

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -17,6 +17,9 @@ on:
       pr:
         description: "The PR number"
         value: ${{ jobs.bottle.outputs.pr }}
+      qa-required:
+        description: "Whether QA is required"
+        value: ${{ jobs.upload.outputs.qa-required }}
 
 jobs:
   get-platform:
@@ -127,6 +130,8 @@ jobs:
     needs: [get-platform, bottle]
     if: ${{ !inputs.new-version || needs.get-platform.outputs.available != '' }}
     runs-on: ubuntu-latest
+    outputs:
+      qa-required: ${{ steps.upload.outputs.qa-required }}
     steps:
       - uses: teaxyz/brewkit/actions/setup-brewkit@v0
         with:
@@ -152,10 +157,12 @@ jobs:
           checksums: ${{ env.checksums }}
           signatures: ${{ env.signatures }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_S3_STAGING_BUCKET: ${{ secrets.AWS_S3_CACHE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - uses: chetan/invalidate-cloudfront-action@v2
+        if: ${{ steps.upload.outputs.cf-invalidation-paths != '' }}
         env:
           PATHS: ${{ steps.upload.outputs.cf-invalidation-paths }}
           DISTRIBUTION: ${{ secrets.AWS_CF_DISTRIBUTION_ID }}

--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -42,6 +42,19 @@ jobs:
       projects: ${{ inputs.projects }}
     secrets: inherit
 
+  request-qa:
+    needs: [bottle]
+    if: ${{ needs.bottle.outputs.qa-required != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: ${{ fromJson(needs.bottle.outputs.qa-required) }}
+    steps:
+      - uses: teaxyz/pantry/.github/actions/request-qa@v0
+        with:
+          project: ${{ matrix.project }}
+          slack-webhook: ${{ secrets.SLACK_QA_WEBHOOK }}
+
   complain:
     needs: [build, bottle]
     if: failure()


### PR DESCRIPTION
This requires https://github.com/teaxyz/brewkit/pull/126 as well as an internal ops script. If a package is annotated as `test.qa-required: true`, it will be staged and `tea` QA personnel notified.