### PR TITLE
fix baked in zsh search paths

### DIFF
--- a/projects/zsh.sourceforge.io/package.yml
+++ b/projects/zsh.sourceforge.io/package.yml
@@ -17,19 +17,25 @@ dependencies:
   invisible-island.net/ncurses: '*'
   pcre.org: '*'
 
+runtime:
+  env:
+    FPATH: ${{prefix}}/functions:$FPATH
+    MODULE_PATH: ${{prefix}}/lib/zsh/{{version.marketing}}
+
 build:
   dependencies:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
-  script: |
-    SHARE="{{tea.prefix}}/zsh.sourceforge.io"
+  script:
+    # We need to be able to set MODULE_PATH to the correct location, so we have
+    # to break a small piece of zsh security
+    - run: |
+        sed -i.bak -e 's/^\(IPDEF8("MODULE_PATH",.*\)PM_DONTIMPORT|\(.*\)$/\1\2/' params.c
+        rm params.c.bak
+      working-directory: Src
 
-    ./configure $ARGS \
-       --enable-site-fndir="$SHARE/share/zsh/site-functions" \
-      --enable-site-scriptdir="$SHARE/share/zsh/site-scripts"
-
-    make --jobs {{ hw.concurrency }} install
-
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }} install
   env:
     ARGS:
       - --prefix={{prefix}}
@@ -46,6 +52,7 @@ build:
       - --with-tcsetpgrp
       - DL_EXT=bundle
 
-test: |
-  test "$(zsh -c echo\ fancy-a-cuppa)" = 'fancy-a-cuppa'
-  zsh -c "printf -v hello -- '%s'"
+test:
+  - test "$(zsh -c echo\ fancy-a-cuppa)" = 'fancy-a-cuppa'
+  - zsh -c "printf -v hello -- '%s'"
+  - zsh -c "autoload -Uz compinit && compinit"


### PR DESCRIPTION
fix for https://github.com/teaxyz/cli/actions/runs/5205491199/jobs/9391004477?pr=608 hopefully

trying to work around this:

```
module_path <S> <Z> (MODULE_PATH <S>)
An array (colon-separated list) of directories that zmodload searches for dynamically loadable modules. This
is initialized to a standard pathname, usually ‘/usr/local/lib/zsh/$ZSH_VERSION’. (The
‘/usr/local/lib’ part varies from installation to installation.) For security reasons, any value set in
the environment when the shell is started will be ignored.

These parameters only exist if the installation supports dynamic module loading.
```