### PR TITLE
Add osxkeychain for macos

### DIFF
--- a/projects/git-scm.org/package.yml
+++ b/projects/git-scm.org/package.yml
@@ -34,6 +34,15 @@ build:
     cd contrib/subtree
     make
     make install
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+      cd "$SRCROOT/contrib/credential/osxkeychain"
+      make
+      mv git-credential-osxkeychain "{{prefix}}"/bin
+      make clean
+      cd "$SRCROOT/contrib/subtree"
+    fi
+
     mv git-subtree "{{prefix}}"/libexec
 
     cd "{{prefix}}"

--- a/projects/git-scm.org/package.yml
+++ b/projects/git-scm.org/package.yml
@@ -86,12 +86,20 @@ test: |
   git subtree add --prefix teaxyz-subtree https://github.com/teaxyz/white-paper main --squash
 
 provides:
-  - bin/git
-  - bin/git-cvsserver
-  - bin/git-receive-pack
-  - bin/git-shell
-  - bin/git-upload-archive
-  - bin/git-upload-pack
-  - bin/scalar
+  linux:
+    - bin/git
+    - bin/git-cvsserver
+    - bin/git-receive-pack
+    - bin/git-shell
+    - bin/git-upload-archive
+    - bin/git-upload-pack
+    - bin/scalar
   darwin:
+    - bin/git
+    - bin/git-cvsserver
+    - bin/git-receive-pack
+    - bin/git-shell
+    - bin/git-upload-archive
+    - bin/git-upload-pack
+    - bin/scalar
     - bin/git-credential-osxkeychain

--- a/projects/git-scm.org/package.yml
+++ b/projects/git-scm.org/package.yml
@@ -35,7 +35,7 @@ build:
     make
     make install
 
-    if [[ "$(uname)" == "Darwin" ]]; then
+    if test "{{ hw.platform }}" = "darwin"; then
       cd "$SRCROOT/contrib/credential/osxkeychain"
       make
       mv git-credential-osxkeychain "{{prefix}}"/bin
@@ -93,3 +93,5 @@ provides:
   - bin/git-upload-archive
   - bin/git-upload-pack
   - bin/scalar
+  darwin:
+    - bin/git-credential-osxkeychain


### PR DESCRIPTION
Added this:

```
    if [[ "$(uname)" == "Darwin" ]]; then
      cd "$SRCROOT/contrib/credential/osxkeychain"
      make
      mv git-credential-osxkeychain "{{prefix}}"/bin
      make clean
      cd "$SRCROOT/contrib/subtree"
    fi
```