### PR TITLE
fix ruby irb

### DIFF
--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -22,61 +22,53 @@ build:
     linux:
       ruby-lang.org: ~3.1  # ruby requires ruby to build
       # ^^ only linux because we got issues on darwin currently
-  script: |
-    patch -p1 < props/mkconfig.rb.diff
+  env:
+    ARGS:
+    - --prefix="{{prefix}}"
+    - --enable-load-relative  # makes us relocatable
+    - --disable-rubygems      # we provide rubygems.org
+    - --without-gmp
+    - --with-rubyarchprefix={{prefix}}/lib/ruby  # no need for architecture specific crap
+    - --with-rubyhdrdir={{prefix}}/include       # ^^
+    - --with-rubyarchhdrdir={{prefix}}/include   # ^^
+    - --disable-multiarch                        # ^^
+    - --with-vendordir=no      # is empty so don’t pollute
+    - --with-vendorarchdir=no  # ^^
+    - --with-sitedir=no        # ^^
+    - --with-sitearchdir=no    # ^^
+  script:
+    - patch -p1 < props/mkconfig.rb.diff
 
-    ./configure \
-      --prefix="{{prefix}}" \
-      --enable-load-relative \
-      --disable-rubygems \
-      --without-gmp \
-      --with-rubyarchprefix={{prefix}}/lib/ruby \
-      --with-rubyhdrdir={{prefix}}/include \
-      --with-rubyarchhdrdir={{prefix}}/include \
-      --with-vendordir=no \
-      --with-vendorarchdir=no \
-      --with-sitedir=no \
-      --with-sitearchdir=no \
-      --disable-multiarch
-
-    make --jobs {{hw.concurrency}} install
-
-    cd "{{prefix}}/bin"
+    - ./configure $ARGS
+    - make --jobs {{hw.concurrency}} install
 
     # we provide these as `rubygems.org`
-    for x in bundle bundler gem; do
-      test -f $x && rm $x
-    done
+    - run: rm bundle bundler gem
+      working-directory: ${{prefix}}/bin
 
-    fix-shebangs.ts *
+    - fix-shebangs.ts ${{prefix}}/bin/*
 
-    cd ../lib/ruby/{{version.marketing}}.0
-
-    # ruby itself provides the gems for these and we don’t want that
-    # we want to pkg them ourselves as part of rubygems.org
-    for x in bundler rubygems bundler.rb rubygems.rb; do
-      if test -d $x; then
-        rm -rf $x
-      else
-        rm $x
-      fi
-      ln -s ../../../../../rubygems.org/v\*/lib/$x
-    done
-
-    cd {{prefix}}
-    rm -rf share/ri
-    rm -rf share/doc
-    rm -rf lib/ruby/site_ruby
-    rm -rf lib/ruby/vendor_ruby
+    - run: |
+        rm -rf share/ri
+        rm -rf share/doc
+        rm -rf lib/ruby/site_ruby
+        rm -rf lib/ruby/vendor_ruby
+      working-directory:
+        ${{prefix}}
 
     # weirdly files get put here and we can't figure out how to stop it
-    mv lib/*-{{hw.platform}}*/* lib
-    rmdir lib/*-{{hw.platform}}*
+    - run: |
+        mv *-{{hw.platform}}*/* .
+        rmdir *-{{hw.platform}}*
+      working-directory:
+        ${{prefix}}/lib
 
-    sed -i.bak \
-      -e 's|$(DESTDIR){{prefix}}|$(topdir)|g' \
-      -e 's|CONFIG\["topdir"\] = .*|CONFIG\["topdir"\] = TOPDIR|g' \
-      {{prefix}}/lib/ruby/{{version.marketing}}.0/rbconfig.rb
+    - run: sed -i.bak
+        -e 's|$(DESTDIR){{prefix}}|$(topdir)|g'
+        -e 's|CONFIG\["topdir"\] = .*|CONFIG\["topdir"\] = TOPDIR|g'
+        rbconfig.rb
+      working-directory:
+        ${{prefix}}/lib/ruby/{{version.marketing}}.0
 
 test:
   dependencies:
@@ -84,6 +76,7 @@ test:
     tea.xyz/gx/make: '*'
   script: |
     ruby -e 'puts "Hello World!"'
+    echo 'puts 1' | irb
 
 provides:
   - bin/erb


### PR DESCRIPTION
This means we stop linking the rubygems library to the rubygems pkg. Which means our ruby may have an older rubygems gem installed than the rubygems pkg and this is problematic.

at this time I dunno what a solution is since I could not otherwise get irb to work.

Requires a deeper dive but RN I have too many things to fix.