### PR TITLE
fix(vault)

### DIFF
--- a/projects/vaultproject.io/package.yml
+++ b/projects/vaultproject.io/package.yml
@@ -13,7 +13,8 @@ build:
   dependencies:
     go.dev: '*'
     nodejs.org: ^18
-    python.org: ^3.11
+    # python 3.11 removes 'rU' mode which breaks node-gyp
+    python.org: ~3.10
     npmjs.com: '*'
     classic.yarnpkg.com: '*'
     tea.xyz/gx/cc: c99
@@ -22,13 +23,11 @@ build:
     # TODO: gox
   script: |
     make bootstrap static-dist dev-ui
-    
+
     mkdir -p {{prefix}}/bin
-    mv bin/vault {{prefix}}/bin/vault 
+    mv bin/vault {{prefix}}/bin/vault
 
 provides:
   - bin/vault
 
-test:
-  script:
-    vault --version 
+test: vault --version


### PR DESCRIPTION
python 3.11 removes universal newline mode, breaking node-gyp

closes #2249

