### PR TITLE
fix(npx)

### DIFF
--- a/projects/npmjs.com/package.yml
+++ b/projects/npmjs.com/package.yml
@@ -10,7 +10,10 @@ provides:
   - bin/npx
 
 dependencies:
-  nodejs.org: '>=14'
+  # 20.3.x causes a error on linux+aarch64 (technically docker)
+  # sh: 1: tldr: Text file busy
+  # https://github.com/nodejs/node/issues/48444
+  nodejs.org: '>=14<20.3'
 
 build:
   dependencies:


### PR DESCRIPTION
nodejs.org>=20.3 has started using a new filesystem call that Docker Desktop 4.20.1 (the newest at time of writing) doesn't support.

We're not alone.

https://github.com/nodejs/node/issues/48444