### PR TITLE
fix(llvm<14)

### DIFF
--- a/projects/llvm.org/package.yml
+++ b/projects/llvm.org/package.yml
@@ -22,14 +22,20 @@ build:
     cmake.org: 3
     ninja-build.org: 1
     python.org: 3
+    crates.io/semverator: '*'
   working-directory: build
-  script: |-
-    cmake \
-      ../llvm \
-      -G Ninja \
-      $ARGS
-    ninja
-    ninja install
+  script:
+    # Building compiler-rt on darwin+aarch64 fails for versions less than
+    # 14 with the below configuration. FIXME if possible, of course.
+    - run: |
+        if test "{{hw.platform}}" = "linux" || \
+           test "{{hw.arch}}" = "x86-64" || \
+           semverator satisies '>=14'; then
+             ARGS="$ARGS -DLLVM_ENABLE_RUNTIMES='compiler-rt'"
+        fi
+    - cmake ../llvm -G Ninja $ARGS
+    - ninja
+    - ninja install
   receipt:
     - LLVMConfig.cmake
   env:
@@ -37,7 +43,6 @@ build:
       - -DCMAKE_INSTALL_PREFIX="{{ prefix }}"
       - -DCMAKE_BUILD_TYPE=Release
       - -DLLVM_ENABLE_PROJECTS='lld;clang'
-      - -DLLVM_ENABLE_RUNTIMES='compiler-rt'
       - -DLLVM_INCLUDE_DOCS=OFF
       - -DLLVM_INCLUDE_TESTS=OFF
     linux:

--- a/projects/llvm.org/package.yml
+++ b/projects/llvm.org/package.yml
@@ -84,11 +84,20 @@ test:
       printf("Hello World!\n");
       return 0;
     }
+  dependencies:
+    crates.io/semverator: '*'
   script:
+    # Building compiler-rt on darwin+aarch64 fails for versions less than
+    # 14 with the below configuration. FIXME if possible, of course.
+    - run: |
+        if test "{{hw.platform}}" = "linux" || \
+           test "{{hw.arch}}" = "x86-64" || \
+           semverator satisies '>=14'; then
+             ARGS="$ARGS -fsanitize=address,undefined"
+        fi
     - mv $FIXTURE $FIXTURE.c
     - clang $ARGS $FIXTURE.c
     - ./a.out
   env:
     ARGS:
-      - -fsanitize=address,undefined
       - -Wl,-rpath,$TEA_PREFIX


### PR DESCRIPTION
fixes builds on darwin+aarch64 for llvm 12 & 13 by excluding `compiler-rt` build. ref: https://github.com/teaxyz/pantry/issues/2294#issuecomment-1608516539

closes #2298 
closes #2299 

ref: ^12: https://github.com/teaxyz/pantry/actions/runs/5396438954
ref: ^13: https://github.com/teaxyz/pantry/actions/runs/5396798872

will cancel CI/CD to save resources.