### PR TITLE
fix(npm)

### DIFF
--- a/projects/npmjs.com/package.yml
+++ b/projects/npmjs.com/package.yml
@@ -21,6 +21,19 @@ build:
         ARGS="--install-links"
       fi
 
+    # 9.8.0 removed the references to these modules.
+    - run: |
+        for MOD in ../workspaces/*; do
+          b=$(basename $MOD)
+          if test "${b#lib}" = "$b"; then
+            ln -s ../$MOD @npmcli/$b
+          else
+            ln -s $MOD .
+          fi
+        done
+      working-directory: node_modules
+      if: '>=9.8.0'
+
     - node . install --global --prefix={{prefix}} $ARGS
 
     # configures npm to install to ~/.local


### PR DESCRIPTION
v9.8.0 removed the symlinks to the workspaces for the other @npmcli modules needed to install npm.

closes #2373