### PR TITLE
fix(python)

### DIFF
--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -100,7 +100,7 @@ build:
         if test "{{hw.platform}}" = "darwin"; then
           curl -L https://github.com/python/cpython/commit/8ea6353.patch | patch -p1
         fi
-      if: '>=3.8<3.8.4'
+      if: '>=3.8<3.8.4, >=3.7<3.7.8'
 
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -77,13 +77,23 @@ build:
         ARGS=${ARGS/--with-ensurepip/--without-ensurepip}
       if: '>=3<3.8'
 
-    # Older patches have a configure issue that isn't present in newer patches
+    # Older patches have configure issues that aren't present in newer patches
+    - run: |
+        if test "{{hw.platform}}" = "darwin"; then
+          sed -i.bak \
+              -e 's/ppc)/arm64)/g' \
+              -e 's/MACOSX_DEFAULT_ARCH="ppc.*$/MACOSX_DEFAULT_ARCH="arm64"/g' \
+              configure
+          rm configure.bak
+        fi
+      if: '=3.9.0'
+
     - run: |
         if test "{{hw.platform}}" = "darwin"; then
           sed -i.bak -e 's/^MULTIARCH=.*$/MULTIARCH=""/' configure
           rm configure.bak
         fi
-      if: '=3.10.0'
+      if: '=3.10.0, >=3.9<3.9.8'
 
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -4,6 +4,11 @@ distributable:
 
 versions:
   github: python/cpython/tags
+  # FIXME maybe? This is pretty good, and darwin+aarch64 support could be
+  # suspect even further back.
+  ignore:
+    - 3.2.[0-3]
+    - 3.[0-1].x
 
 companions:
   pip.pypa.io: '*'

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -86,21 +86,21 @@ build:
               configure
           rm configure.bak
         fi
-      if: '=3.9.0, >=3.8<3.8.10'
+      if: '>=3<3.9.1'
 
     - run: |
         if test "{{hw.platform}}" = "darwin"; then
           sed -i.bak -e 's/^MULTIARCH=.*$/MULTIARCH=""/' configure
           rm configure.bak
         fi
-      if: '=3.10.0, >=3.9<3.9.8'
+      if: '>=3<3.10.1'
 
       # Some old versions don't support macOS 11 and greater in their configures
     - run: |
         if test "{{hw.platform}}" = "darwin"; then
           curl -L https://github.com/python/cpython/commit/8ea6353.patch | patch -p1
         fi
-      if: '>=3.8<3.8.4, >=3.7<3.7.8'
+      if: '>=3.8<3.8.4 || >=3<3.7.8'
 
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -77,6 +77,10 @@ build:
         ARGS=${ARGS/--with-ensurepip/--without-ensurepip}
       if: '>=3<3.8'
 
+    # 3.5 and older don't append the platform to confdir on darwin
+    - run: confdir="${confdir%-{{hw.platform}}}"
+      if: '>=3<3.6'
+
     # Older patches have configure issues that aren't present in newer patches
     - run: |
         if test "{{hw.platform}}" = "darwin"; then
@@ -101,6 +105,25 @@ build:
           curl -L https://github.com/python/cpython/commit/8ea6353.patch | patch -p1
         fi
       if: '>=3.8<3.8.4 || >=3<3.7.8'
+
+    # Versions older than 3.5.3 have an include issue on darwin
+    - run: patch -p1 -l < $PROP
+      prop: |-
+        diff --git a/Python/random.c b/Python/random.c
+        index 93d300d..396041d 100644
+        --- a/Python/random.c
+        +++ b/Python/random.c
+        @@ -3,6 +3,9 @@
+         #  include <windows.h>
+         #else
+         #  include <fcntl.h>
+        +#  if defined(HAVE_GETRANDOM) || defined(HAVE_GETENTROPY)
+        +#    include <sys/random.h>
+        +#  endif
+         #  ifdef HAVE_SYS_STAT_H
+         #    include <sys/stat.h>
+         #  endif
+      if: '>=3<3.5.3'
 
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -233,7 +233,6 @@ build:
 test:
   dependencies:
     tea.xyz/gx/cc: c99
-    crates.io/semverator: '*'
   script:
     # Check if sqlite is ok, because we build with --enable-loadable-sqlite-extensions
     # and it can occur that building sqlite silently fails if OSX's sqlite is used.
@@ -251,8 +250,8 @@ test:
         python -v -c "import _ctypes"
         # python -c "import _decimal" #FIXME
         python -c "import zlib"
-      # FIXME: v2
-      if: ^3
+      # FIXME: v2, <=3.6.4
+      if: ^3.6.4
 
     - python -c "import pyexpat"
 
@@ -281,11 +280,10 @@ test:
         #include <Python.h>
         #include <python{{version.major}}.{{version.minor}}/Python.h>
 
-    - run: |
-        if semverator satisfies '>=3<3.8' {{ version }}; then
-          SUFFIX=m
-        fi
-        test $(python $FIXTURE) = {{prefix}}/include/python{{version.marketing}}$SUFFIX
+    - run: SUFFIX=m
+      if: '>=3<3.8'
+
+    - run: test $(python $FIXTURE) = {{prefix}}/include/python{{version.marketing}}$SUFFIX
       fixture: |
         import sysconfig
         include_path = sysconfig.get_paths()['include']

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -107,23 +107,12 @@ build:
       if: '>=3.8<3.8.4 || >=3<3.7.8'
 
     # Versions older than 3.5.3 have an include issue on darwin
-    - run: patch -p1 -l < $PROP
-      prop: |-
-        diff --git a/Python/random.c b/Python/random.c
-        index 93d300d..396041d 100644
-        --- a/Python/random.c
-        +++ b/Python/random.c
-        @@ -3,6 +3,9 @@
-         #  include <windows.h>
-         #else
-         #  include <fcntl.h>
-        +#  if defined(HAVE_GETRANDOM) || defined(HAVE_GETENTROPY)
-        +#    include <sys/random.h>
-        +#  endif
-         #  ifdef HAVE_SYS_STAT_H
-         #    include <sys/stat.h>
-         #  endif
-      if: '>=3<3.5.3'
+    - run: patch -p1 < props/patch3.5.diff
+      if: '>=3.5<3.5.3'
+
+    # Whitespace difference in 3.4...
+    - run: patch -p1 < props/patch3.4.diff
+      if: '~3.4.1'
 
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -86,7 +86,7 @@ build:
               configure
           rm configure.bak
         fi
-      if: '=3.9.0'
+      if: '=3.9.0, >=3.8<3.8.10'
 
     - run: |
         if test "{{hw.platform}}" = "darwin"; then
@@ -94,6 +94,13 @@ build:
           rm configure.bak
         fi
       if: '=3.10.0, >=3.9<3.9.8'
+
+      # Some old versions don't support macOS 11 and greater in their configures
+    - run: |
+        if test "{{hw.platform}}" = "darwin"; then
+          curl -L https://github.com/python/cpython/commit/8ea6353.patch | patch -p1
+        fi
+      if: '>=3.8<3.8.4'
 
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -77,6 +77,14 @@ build:
         ARGS=${ARGS/--with-ensurepip/--without-ensurepip}
       if: '>=3<3.8'
 
+    # Older patches have a configure issue that isn't present in newer patches
+    - run: |
+        if test "{{hw.platform}}" = "darwin"; then
+          sed -i.bak -e 's/^MULTIARCH=.*$/MULTIARCH=""/' configure
+          rm configure.bak
+        fi
+      if: '=3.10.0'
+
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}
     - make install

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -226,8 +226,8 @@ test:
     # Check if sqlite is ok, because we build with --enable-loadable-sqlite-extensions
     # and it can occur that building sqlite silently fails if OSX's sqlite is used.
     - run: python -c "import sqlite3"
-      # FIXME: v2
-      if: ^3
+      # FIXME: v2, <v3.7
+      if: ^3.7
 
     # check to see if we can create a venv
     # we can't ensurepip on 3.7 so, this won't work

--- a/projects/python.org/patch3.4.diff
+++ b/projects/python.org/patch3.4.diff
@@ -1,0 +1,14 @@
+diff --git a/Python/random.c b/Python/random.c
+index 93d300d..396041d 100644
+--- a/Python/random.c
++++ b/Python/random.c
+@@ -3,6 +3,9 @@
+ #include <windows.h>
+ #else
+ #include <fcntl.h>
++#if defined(HAVE_GETRANDOM) || defined(HAVE_GETENTROPY)
++#include <sys/random.h>
++#endif
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif

--- a/projects/python.org/patch3.5.diff
+++ b/projects/python.org/patch3.5.diff
@@ -1,0 +1,14 @@
+diff --git a/Python/random.c b/Python/random.c
+index 93d300d..396041d 100644
+--- a/Python/random.c
++++ b/Python/random.c
+@@ -3,6 +3,9 @@
+ #  include <windows.h>
+ #else
+ #  include <fcntl.h>
++#  if defined(HAVE_GETRANDOM) || defined(HAVE_GETENTROPY)
++#    include <sys/random.h>
++#  endif
+ #  ifdef HAVE_SYS_STAT_H
+ #    include <sys/stat.h>
+ #  endif


### PR DESCRIPTION
fixes older pythons. builds >=3.2.4. some tests limited on older versions. FIXMEs note this throughout.

closes #2438
closes #2437
closes #2436
closes #2434
closes #2432
closes #2430
closes #2426
closes #2425
closes #2423
closes #2421
closes #2418
closes #2417
closes #2416
closes #2415
closes #2414
closes #2413
closes #2410
closes #2404
closes #2402
closes #2401
closes #2400
closes #2399
closes #2398
closes #2397
closes #2396
closes #2394
closes #2388
closes #2387
closes #2386
closes #2385
closes #2384
closes #2383
closes #2382
closes #2381
closes #2379
closes #2377