### PR TITLE
chore(rust): Install rust via rustup

### DIFF
--- a/projects/rust-lang.org/package.yml
+++ b/projects/rust-lang.org/package.yml
@@ -34,6 +34,10 @@ dependencies:
   #FIXME ^^ strictly rustc only needs a linker
   zlib.net: 1
 
+runtime:
+  env:
+    RUST_SRC_PATH: ${{prefix}}/lib/rustlib/src/rust/src
+
 build:
   dependencies:
     tea.xyz/gx/make: '*'  #FIXME surely we don’t need make AND ninja
@@ -62,6 +66,14 @@ build:
     for tool in $tools; do
       ./x.py install $tool
     done
+    
+    # place source for IDEs to use (normally installed via rustup)
+    # FIXME: this is fragile because directories can change, is there a better way?
+    mkdir -p {{prefix}}/lib/rustlib/src/rust
+    mv Cargo.lock {{prefix}}/lib/rustlib/src/rust
+    mv library {{prefix}}/lib/rustlib/src/rust
+    mkdir -p {{prefix}}/lib/rustlib/src/rust/src/llvm-project
+    mv src/llvm-project/libunwind {{prefix}}/lib/rustlib/src/rust/src/llvm-project
 
     rm -rf {{prefix}}/share/doc
   env:

--- a/projects/rust-lang.org/package.yml
+++ b/projects/rust-lang.org/package.yml
@@ -47,6 +47,7 @@ build:
     openssl.org: '*' # needed to build openssl-sys
     freedesktop.org/pkg-config: ^0.29
     crates.io/semverator: 0
+    rust-lang.org/rustup: '*'
   script: |-
     # --enable-optimize not available as of 1.63.0
     if semverator satisfies '<1.63' {{ version }}; then
@@ -67,14 +68,20 @@ build:
       ./x.py install $tool
     done
     
-    # place source for IDEs to use (normally installed via rustup)
-    # FIXME: this is fragile because directories can change, is there a better way?
-    mkdir -p {{prefix}}/lib/rustlib/src/rust
-    mv Cargo.lock {{prefix}}/lib/rustlib/src/rust
-    mv library {{prefix}}/lib/rustlib/src/rust
-    mkdir -p {{prefix}}/lib/rustlib/src/rust/src/llvm-project
-    mv src/llvm-project/libunwind {{prefix}}/lib/rustlib/src/rust/src/llvm-project
+#    # place source for IDEs to use (normally installed via rustup)
+#    # FIXME: this is fragile because directories can change, is there a better way?
+#    mkdir -p {{prefix}}/lib/rustlib/src/rust
+#    mv Cargo.lock {{prefix}}/lib/rustlib/src/rust
+#    mv library {{prefix}}/lib/rustlib/src/rust
+#    mkdir -p {{prefix}}/lib/rustlib/src/rust/src/llvm-project
+#    mv src/llvm-project/libunwind {{prefix}}/lib/rustlib/src/rust/src/llvm-project
 
+    # install src via rustup and copy component for IDEs to use
+    rustup default {{ version }}
+    rustup component add rust-src
+    rp -r ~/.rustup/toolchains/*/lib/rustlib/src {{prefix}}/lib/rustlib
+
+    # do cleanup
     rm -rf {{prefix}}/share/doc
   env:
     ARGS:

--- a/projects/rust-lang.org/package.yml
+++ b/projects/rust-lang.org/package.yml
@@ -31,8 +31,6 @@ options:
 
 dependencies:
   tea.xyz/gx/cc: c99
-  #FIXME ^^ strictly rustc only needs a linker
-  zlib.net: 1
 
 runtime:
   env:
@@ -40,60 +38,19 @@ runtime:
 
 build:
   dependencies:
-    tea.xyz/gx/make: '*'  #FIXME surely we don’t need make AND ninja
-    cmake.org: ^3.20
-    ninja-build.org: ^1.10
-    python.org: 3
-    openssl.org: '*' # needed to build openssl-sys
-    freedesktop.org/pkg-config: ^0.29
-    crates.io/semverator: 0
     rust-lang.org/rustup: '*'
   script: |-
-    # --enable-optimize not available as of 1.63.0
-    if semverator satisfies '<1.63' {{ version }}; then
-      export ARGS="$ARGS --enable-optimize"
-    fi
-
-    # 1.68.0 introduced a regression w.r.t. CI builds
-    # https://github.com/rust-lang/rust/issues/108959
-    if semverator satisfies '>=1.68<1.70' {{ version }}; then
-      sed -i.bak -e 's/CiEnv::is_ci()/CiEnv::is_ci() \&\& config.rust_info.is_managed_git_subrepository()/' src/bootstrap/native.rs
-      rm src/bootstrap/native.rs.bak
-    fi
-
-    ./configure $ARGS
-    make install
-
-    for tool in $tools; do
-      ./x.py install $tool
-    done
-    
-#    # place source for IDEs to use (normally installed via rustup)
-#    # FIXME: this is fragile because directories can change, is there a better way?
-#    mkdir -p {{prefix}}/lib/rustlib/src/rust
-#    mv Cargo.lock {{prefix}}/lib/rustlib/src/rust
-#    mv library {{prefix}}/lib/rustlib/src/rust
-#    mkdir -p {{prefix}}/lib/rustlib/src/rust/src/llvm-project
-#    mv src/llvm-project/libunwind {{prefix}}/lib/rustlib/src/rust/src/llvm-project
-
-    # install src via rustup and copy component for IDEs to use
     rustup default {{ version }}
+    rustup component add rust-analyzer
+    # used for type checking in IDEs
     rustup component add rust-src
-    rp -r ~/.rustup/toolchains/*/lib/rustlib/src {{prefix}}/lib/rustlib
+    
+    # copy installation
+    mkdir -p {{ prefix }}
+    cp -r ~/.rustup/toolchains/*/* {{prefix}}
 
     # do cleanup
     rm -rf {{prefix}}/share/doc
-  env:
-    ARGS:
-      - --enable-vendor
-      - --prefix={{ prefix }}
-      - --enable-ninja
-      - --disable-docs  # docs are online
-      - --tools=clippy,rustfmt,analysis
-    tools:
-      - clippy
-      - rustfmt
-      - rust-analyzer
 
 test:
   script: |


### PR DESCRIPTION
Initially meant to just add the src component so IDEs would work (https://github.com/teaxyz/cli/issues/685) but during the process of getting that installed (can only be installed via rustup) I found it easier to move the whole thing to be installed via rustup. This leads to faster build times on CI as well as the version not showing up as `x.x.x-dev` + it should allow more versatility in choosing what components to install.

This successfully fixes std definitions for me in IDEs (IntelliJ + VSCode) but does not yet lead to on the fly checks working on IntelliJ.. that will continue to be investigated. This PR already adds some benefit though and is a good first step.

_Edit: it looks like it might fix more issues in the IDE (including support for expanding macros) more details in the linked issue._