### PR TITLE
+encore.dev

### DIFF
--- a/projects/encore.dev/go/package.yml
+++ b/projects/encore.dev/go/package.yml
@@ -1,0 +1,55 @@
+distributable: ~
+
+versions:
+  github: encoredev/go
+  strip: /^encore-go/
+
+provides:
+  - bin/go
+
+interprets:
+  extensions: go
+  args: [go, run]
+
+dependencies:
+  curl.se/ca-certs: '*'
+
+companions:
+  tea.xyz/gx/cc: c99  # for `cgo`
+
+warnings:
+  - vendored
+
+runtime:
+  env:
+    ENCORE_GOROOT: ${{prefix}}
+
+build:
+  dependencies:
+    curl.se: '*'
+    gnu.org/tar: '*'
+  script:
+    - curl -L https://github.com/encoredev/go/releases/download/encore-go{{version}}/$TYPE.tar.gz | tar zxvf -
+    - run: cp -a $SRCROOT/encore-go/* .
+      working-directory: ${{prefix}}
+  env:
+    linux/x86-64:
+      TYPE: linux_x86-64
+    linux/aarch64:
+      TYPE: linux_arm64
+    darwin/x86-64:
+      TYPE: macos_x86-64
+    darwin/aarch64:
+      TYPE: macos_arm64
+
+test:
+  script: |
+    mv $FIXTURE $FIXTURE.go
+    OUTPUT=$(go run $FIXTURE.go)
+    test "Hello World" = "$OUTPUT"
+  fixture: |
+    package main
+    import "fmt"
+    func main() {
+      fmt.Println("Hello World")
+    }

--- a/projects/encore.dev/package.yml
+++ b/projects/encore.dev/package.yml
@@ -11,7 +11,7 @@ provides:
 build:
   script:
     - go mod download
-    - go build $ARGS -ldflags="$LDFLAGS" ./cmd/encore
+    - go build $ARGS -ldflags="$LDFLAGS" ./cli/cmd/encore
   dependencies:
     go.dev: ^1.21
   env:

--- a/projects/encore.dev/package.yml
+++ b/projects/encore.dev/package.yml
@@ -7,20 +7,26 @@ versions:
 
 provides:
   - bin/encore
+  - bin/git-remote-encore
+
+runtime:
+  env:
+    ENCORE_RUNTIME_PATH: ${{prefix}}/runtime
+
+dependencies:
+  encore.dev/go: ^1.21
 
 build:
   script:
     - go mod download
-    - go build $ARGS -ldflags="$LDFLAGS" ./cli/cmd/encore
-  dependencies:
-    go.dev: ^1.21
+    - go build $ARGS -ldflags="$LDFLAGS" -o "{{prefix}}"/bin/encore ./cli/cmd/encore
+    - go build $ARGS -ldflags="$LDFLAGS" -o "{{prefix}}"/bin/git-remote-encore ./cli/cmd/git-remote-encore
+    - cp -a runtime {{prefix}}
   env:
     GO111MODULE: on
-    CGO_ENABLED: 0
     ARGS:
       - -v
       - -trimpath
-      - -o "{{prefix}}"/bin/encore
     LDFLAGS:
       - -s
       - -w
@@ -31,5 +37,6 @@ build:
       LDFLAGS:
       - -buildmode=pie
 
-test: |
-  encore version | grep {{version}}
+test:
+  # test errors checking update api; looks like it still runs fine.
+  - (encore version || true) | grep {{version}}

--- a/projects/encore.dev/package.yml
+++ b/projects/encore.dev/package.yml
@@ -32,5 +32,4 @@ build:
       - -buildmode=pie
 
 test: |
-  encore version
   encore version | grep {{version}}

--- a/projects/encore.dev/package.yml
+++ b/projects/encore.dev/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/encoredev/encore/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: encoredev/encore
+
+provides:
+  - bin/encore
+
+build:
+  script:
+    - go mod download
+    - go build $ARGS -ldflags="$LDFLAGS" ./cmd/encore
+  dependencies:
+    go.dev: ^1.21
+  env:
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    ARGS:
+      - -v
+      - -trimpath
+      - -o "{{prefix}}"/bin/encore
+    LDFLAGS:
+      - -s
+      - -w
+      - -X 'encr.dev/internal/version.Version={{version}}'
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test: |
+  encore version
+  encore version | grep {{version}}


### PR DESCRIPTION
blocked by https://github.com/teaxyz/pantry/issues/2896

* they [use](https://github.com/encoredev/encore/blob/main/go.mod#L3C4-L3C10) go 1.21.0 to build
* [go 1.21 release](https://go.dev/doc/devel/release#go1.21.0)
  * released last week 2023-08-08
* [ldflags](https://github.com/encoredev/encore/blob/c1d73732588be18ebb43f64b9d7a565bd7ed790c/pkg/make-release/make-release.go#L73)