### PR TITLE
+golang-migrate — Database migrations CLI

### DIFF
--- a/projects/github.com/golang-migrate/migrate/package.yml
+++ b/projects/github.com/golang-migrate/migrate/package.yml
@@ -1,0 +1,66 @@
+distributable:
+  url: https://github.com/golang-migrate/migrate/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: golang-migrate/migrate
+
+provides:
+  - bin/migrate
+
+build:
+  dependencies:
+    go.dev: ^1.19
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -tags "$DATABASE $SOURCE" -o $BUILDLOC ./cmd/migrate
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/migrate'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.Version={{version}}
+      # - -extldflags "static"
+    SOURCE:
+      - file
+      - go_bindata
+      - github
+      - github_ee
+      - bitbucket
+      - aws_s3
+      - google_cloud_storage
+      - godoc_vfs
+      - gitlab
+    DATABASE:
+      - postgres
+      - mysql
+      - redshift
+      - cassandra
+      - spanner
+      - cockroachdb
+      - yugabytedb
+      - clickhouse
+      - mongodb
+      - sqlserver
+      - firebird
+      - neo4j
+      - pgx
+      - pgx5
+
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - migrate -version | grep {{version}}
+    # - test "$(migrate -version)" = "{{version}}"

--- a/projects/github.com/golang-migrate/migrate/package.yml
+++ b/projects/github.com/golang-migrate/migrate/package.yml
@@ -62,5 +62,4 @@ build:
 
 test:
   script:
-    - migrate -version | grep {{version}}
-    # - test "$(migrate -version)" = "{{version}}"
+    - test $(migrate -version 2>&1) = {{version}}


### PR DESCRIPTION
https://github.com/golang-migrate/migrate —  Database migrations. CLI and Golang library. 