### PR TITLE
+git-grab — opinionated git cloner

### DIFF
--- a/projects/crates.io/git-grab/package.yml
+++ b/projects/crates.io/git-grab/package.yml
@@ -1,0 +1,24 @@
+distributable:
+  url: https://github.com/wezm/git-grab/archive/refs/tags/{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/git-grab
+
+versions:
+  github: wezm/git-grab
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  dependencies:
+    git-scm.org: '*'
+  script:
+    - git grab https://github.com/kelseyhightower/nocode
+    - rm -rf nocode


### PR DESCRIPTION
> Clone a git repository into a standard location organised by domain and path. 

https://crates.io/crates/git-grab
https://github.com/wezm/git-grab