### PR TITLE
+mergestat — Query Git repos with SQL

### DIFF
--- a/projects/mergestat.com/mergestat-lite/package.yml
+++ b/projects/mergestat.com/mergestat-lite/package.yml
@@ -12,10 +12,7 @@ provides:
 build:
   dependencies:
     go.dev: ^1.19
-    darwin:
-      tea.xyz/gx/cc: c99
-    linux:
-      gnu.org/gcc: '*'
+    tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
     cmake.org: '*'
     git-scm.org: '*'
@@ -33,11 +30,6 @@ build:
     GOPROXY: https://proxy.golang.org,direct
     GOSUMDB: sum.golang.org
     GO111MODULE: on
-    linux:
-      # or segmentation fault
-      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
-      LDFLAGS:
-      - -buildmode=pie
 
 test:
   # dependencies:

--- a/projects/mergestat.com/mergestat-lite/package.yml
+++ b/projects/mergestat.com/mergestat-lite/package.yml
@@ -19,6 +19,8 @@ build:
     libgit2.org: '*'
     openssl.org: '*'
     freedesktop.org/pkg-config: '*'
+    linux:
+      llvm.org: <16
   script:
     # required or cmake fails with an unhelpful error
     # this is why we need to build from a git checkout

--- a/projects/mergestat.com/mergestat-lite/package.yml
+++ b/projects/mergestat.com/mergestat-lite/package.yml
@@ -23,6 +23,11 @@ build:
     # required or cmake fails with an unhelpful error
     # this is why we need to build from a git checkout
     - git submodule update --init --recursive
+    # Prevents segfaults
+    - run: |
+        sed -i.bak -e 's/@go build -o $@ -tags="static"/@go build -o $@ -tags="static" -buildmode=pie/' Makefile
+        rm Makefile.bak
+      if: linux
     - make libgit2 all
     - mkdir -p "{{ prefix }}"/bin
     - mv .build/mergestat {{prefix}}/bin/mergestat

--- a/projects/mergestat.com/mergestat-lite/package.yml
+++ b/projects/mergestat.com/mergestat-lite/package.yml
@@ -22,8 +22,6 @@ build:
     libgit2.org: '*'
     openssl.org: '*'
     freedesktop.org/pkg-config: '*'
-    linux:
-      llvm.org: <16
   script:
     # required or cmake fails with an unhelpful error
     # this is why we need to build from a git checkout

--- a/projects/mergestat.com/mergestat-lite/package.yml
+++ b/projects/mergestat.com/mergestat-lite/package.yml
@@ -12,7 +12,10 @@ provides:
 build:
   dependencies:
     go.dev: ^1.19
-    tea.xyz/gx/cc: c99
+    darwin:
+      tea.xyz/gx/cc: c99
+    linux:
+      gnu.org/gcc: '*'
     tea.xyz/gx/make: '*'
     cmake.org: '*'
     git-scm.org: '*'

--- a/projects/mergestat.com/mergestat-lite/package.yml
+++ b/projects/mergestat.com/mergestat-lite/package.yml
@@ -37,7 +37,9 @@ build:
     GO111MODULE: on
 
 test:
-  # dependencies:
-    # git-scm.org: '*'
+  dependencies:
+    git-scm.org: '*'
   script:
-    - mergestat summarize commits --json --repo "https://github.com/kelseyhightower/nocode"
+    - git clone https://github.com/kelseyhightower/nocode
+    - run: mergestat summarize commits --json
+      working-directory: nocode

--- a/projects/mergestat.com/mergestat-lite/package.yml
+++ b/projects/mergestat.com/mergestat-lite/package.yml
@@ -16,22 +16,20 @@ build:
     tea.xyz/gx/make: '*'
     cmake.org: '*'
     git-scm.org: '*'
-    # libgit2.org: '*'
+    libgit2.org: '*'
+    openssl.org: '*'
+    freedesktop.org/pkg-config: '*'
   script:
     # required or cmake fails with an unhelpful error
     # this is why we need to build from a git checkout
     - git submodule update --init --recursive
-    - ls -la git2go
-    - make
+    - make libgit2 all
+    - mkdir -p "{{ prefix }}"/bin
+    - mv .build/mergestat {{prefix}}/bin/mergestat
   env:
     GOPROXY: https://proxy.golang.org,direct
     GOSUMDB: sum.golang.org
     GO111MODULE: on
-    CGO_ENABLED: 0
-    BUILDLOC: '{{prefix}}/bin/mergestat'
-    LDFLAGS:
-      - -s
-      - -w
     linux:
       # or segmentation fault
       # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
@@ -39,4 +37,7 @@ build:
       - -buildmode=pie
 
 test:
-  mergestat --version | grep {{version}}
+  # dependencies:
+    # git-scm.org: '*'
+  script:
+    - mergestat summarize commits --json --repo "https://github.com/kelseyhightower/nocode"

--- a/projects/mergestat.com/package.yml
+++ b/projects/mergestat.com/package.yml
@@ -1,0 +1,42 @@
+distributable:
+  url: git+https://github.com/mergestat/mergestat-lite
+  ref: v{{version}}
+  strip-components: 1
+
+versions:
+  github: mergestat/mergestat-lite
+
+provides:
+  - bin/mergestat
+
+build:
+  dependencies:
+    go.dev: ^1.19
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+    cmake.org: '*'
+    git-scm.org: '*'
+    # libgit2.org: '*'
+  script:
+    # required or cmake fails with an unhelpful error
+    # this is why we need to build from a git checkout
+    - git submodule update --init --recursive
+    - ls -la git2go
+    - make
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/mergestat'
+    LDFLAGS:
+      - -s
+      - -w
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  mergestat --version | grep {{version}}


### PR DESCRIPTION
> `mergestat-lite` is a command-line tool for running SQL queries on git repositories and related data sources. It's meant for ad-hoc querying of source-code on disk through a common interface (SQL), as an alternative to patching together various shell commands.

https://github.com/mergestat/mergestat-lite
https://www.mergestat.com/
https://docs.mergestat.com/
https://docs.mergestat.com/mergestat-lite/usage/