### PR TITLE
+dprint.dev -- Pluggable formatting platform

### DIFF
--- a/projects/dprint.dev/package.yml
+++ b/projects/dprint.dev/package.yml
@@ -1,0 +1,22 @@
+distributable:
+  url: https://github.com/dprint/dprint/archive/refs/tags/{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/dprint
+
+versions:
+  github: dprint/dprint
+  strip: /v/
+
+build:
+  working-directory: crates/dprint
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(dprint --version)" = "dprint {{version}}"


### PR DESCRIPTION
Dprint is made up of Wasm and process plugins.

Currently supports TS, JS, JSON, Markdown, TOML, Dockerfiles.

https://github.com/dprint/dprint
https://dprint.dev