### PR TITLE
+craftql — GraphQL schema to Graphviz export

### DIFF
--- a/projects/crates.io/craftql/package.yml
+++ b/projects/crates.io/craftql/package.yml
@@ -6,7 +6,7 @@ provides:
   - bin/craftql
 
 versions:
-  github: yamafaktory/craftql
+  github: yamafaktory/craftql/tags
   strip: /v/
 
 build:

--- a/projects/crates.io/craftql/package.yml
+++ b/projects/crates.io/craftql/package.yml
@@ -1,0 +1,21 @@
+distributable:
+  url: https://github.com/yamafaktory/craftql/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/craftql
+
+versions:
+  github: yamafaktory/craftql
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.56'
+    rust-lang.org/cargo: '*'
+  script: |
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(craftql --version)" = "craftql {{version}}"


### PR DESCRIPTION
A CLI tool to visualize GraphQL schemas and to output a graph data structure as a graphviz .dot format 

https://github.com/yamafaktory/craftql