### PR TITLE
+click -- Command Line Interactive Controller for Kubernetes

### DIFF
--- a/projects/crates.io/click/package.yml
+++ b/projects/crates.io/click/package.yml
@@ -1,0 +1,21 @@
+distributable:
+  url: https://github.com/databricks/click/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/click
+
+versions:
+  github: databricks/click
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.56'
+    rust-lang.org/cargo: '*'
+  script: |
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(click --version)" = "Click {{version}}"

--- a/projects/crates.io/click/package.yml
+++ b/projects/crates.io/click/package.yml
@@ -9,6 +9,9 @@ versions:
   github: databricks/click
   strip: /v/
 
+dependencies:
+  openssl.org: ^1.1
+
 build:
   dependencies:
     rust-lang.org: '>=1.56'

--- a/projects/crates.io/click/package.yml
+++ b/projects/crates.io/click/package.yml
@@ -16,7 +16,7 @@ build:
   dependencies:
     rust-lang.org: '>=1.56'
     rust-lang.org/cargo: '*'
-    freedesktop/org/pkg-config: ^0.29
+    freedesktop.org/pkg-config: ^0.29
   script: |
     cargo install --locked --path . --root {{prefix}}
 

--- a/projects/crates.io/click/package.yml
+++ b/projects/crates.io/click/package.yml
@@ -16,6 +16,7 @@ build:
   dependencies:
     rust-lang.org: '>=1.56'
     rust-lang.org/cargo: '*'
+    freedesktop/org/pkg-config: ^0.29
   script: |
     cargo install --locked --path . --root {{prefix}}
 


### PR DESCRIPTION
The "Command Line Interactive Controller for Kubernetes" 

https://github.com/databricks/click

> Click is a REPL. When running Click, there is a current active config which includes the current Kubernetes context, and optionally a namespace and Kubernetes object. Commands are then applied to the active config so it's not necessary to keep specifying what objects to target.

https://www.databricks.com/blog/2018/03/27/introducing-click-the-command-line-interactive-controller-for-kubernetes.html

> Click remembers the current Kubernetes "thing" (a "resource" in Kubernetes terms), making it easier for the operator to interact with that resource. This was motivated by a common pattern we noticed using, something like:
>
> 1.    kubectl get pods
> 1.   copy the name of the pod
> 1.   kubectl logs [pasted pod]
> 1.   ohh right forgot the container
> 1.   kubectl logs -c [container] [pasted pod]
> 1.   Then we want the events from the pod too, and so we have to paste again
> 1.   Rinse, repeat