### PR TITLE
+huniq -- Filter out duplicates on the command line

### DIFF
--- a/projects/crates.io/huniq/package.yml
+++ b/projects/crates.io/huniq/package.yml
@@ -1,0 +1,22 @@
+distributable:
+  url: https://github.com/koraa/huniq/archive/1d3c47eafb83147ea83594c64ba62b4fbbe3d617.zip
+  strip-components: 1
+
+provides:
+  - bin/huniq
+
+versions:
+  - 0.0.0
+  # FIXME once there has been an official release
+
+build:
+  working-directory: huniq-1d3c47eafb83147ea83594c64ba62b4fbbe3d617
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(huniq --version)" = "huniq 2.7.0"

--- a/projects/crates.io/huniq/package.yml
+++ b/projects/crates.io/huniq/package.yml
@@ -1,16 +1,15 @@
 distributable:
-  url: https://github.com/koraa/huniq/archive/1d3c47eafb83147ea83594c64ba62b4fbbe3d617.zip
+  url: https://github.com/koraa/huniq/archive/1d3c47eafb83147ea83594c64ba62b4fbbe3d617.tar.gz
   strip-components: 1
 
 provides:
   - bin/huniq
 
 versions:
-  - 0.0.0
+  - 2022.12.10
   # FIXME once there has been an official release
 
 build:
-  working-directory: huniq-1d3c47eafb83147ea83594c64ba62b4fbbe3d617
   dependencies:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'


### PR DESCRIPTION
https://github.com/koraa/huniq
https://crates.io/crates/huniq

Filter out duplicates on the command line. Replacement for `sort | uniq` optimized for speed (10x faster) when sorting is not needed. 