### PR TITLE
+doctave -- A batteries-included developer documentation site generator

### DIFF
--- a/projects/doctave.com/package.yml
+++ b/projects/doctave.com/package.yml
@@ -1,0 +1,22 @@
+distributable:
+  url: https://github.com/Doctave/doctave/archive/refs/tags/{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/doctave
+
+versions:
+  github: Doctave/doctave
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    # Building with the --locked flag was complaining about proc-macro2 (proc_macro_span_shrink)
+    - cargo install --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(doctave --version)" = "Doctave {{version}}"

--- a/projects/doctave.com/package.yml
+++ b/projects/doctave.com/package.yml
@@ -14,8 +14,7 @@ build:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
   script:
-    # Building with the --locked flag was complaining about proc-macro2 (proc_macro_span_shrink)
-    - cargo install --path . --root {{prefix}}
+    - cargo install --locked --path . --root {{prefix}}
 
 test:
   script:


### PR DESCRIPTION
https://github.com/Doctave/doctave
https://cli.doctave.com/
https://doctave.com/