### PR TITLE
+git-town -- Git workflow automation for branches

### DIFF
--- a/projects/git-town.com/package.yml
+++ b/projects/git-town.com/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/git-town/git-town/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: git-town/git-town
+
+provides:
+  - bin/git-town
+
+build:
+  dependencies:
+    go.dev: ^1.19
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/git-town'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/git-town/git-town/v9/src/cmd.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - test "$(git-town version)" = "Git Town {{version}} ()"


### PR DESCRIPTION
https://github.com/git-town/git-town
https://www.git-town.com/

> Git Town adds Git commands that make software development more efficient by keeping Git branches better in sync with each other. This reduces merge conflicts and the number of Git commands you need to run.