### PR TITLE
fix(rtx)

### DIFF
--- a/projects/rust-lang.org/package.yml
+++ b/projects/rust-lang.org/package.yml
@@ -20,6 +20,7 @@ provides:
   - bin/rust-gdbgui
   - bin/rust-lldb
   - bin/rustc
+  - bin/rustdoc
   - bin/rustfmt
 
 #TODO: unimplemented idea for the “options” feature
@@ -70,9 +71,10 @@ build:
       - --prefix={{ prefix }}
       - --enable-ninja
       - --disable-docs  # docs are online
-      - --tools=clippy,rustfmt,analysis
+      - --tools=clippy,rustdoc,rustfmt,analysis
     tools:
       - clippy
+      - rustdoc
       - rustfmt
       - rust-analyzer
 

--- a/projects/rust-lang.org/package.yml
+++ b/projects/rust-lang.org/package.yml
@@ -74,7 +74,6 @@ build:
       - --tools=clippy,rustdoc,rustfmt,analysis
     tools:
       - clippy
-      - rustdoc
       - rustfmt
       - rust-analyzer
 


### PR DESCRIPTION
rtx uses built which needs rustdoc to find the version of rustdoc. somehow, we stopped shipping rustdoc with 1.69.0. hopefully this fixes that.

https://github.com/rust-lang/rust/pull/106886