### PR TITLE
Ncurses fix paths & test

### DIFF
--- a/projects/invisible-island.net/ncurses/package.yml
+++ b/projects/invisible-island.net/ncurses/package.yml
@@ -58,7 +58,13 @@ runtime:
     # ^^ we delegate to the system first since they may apply platform specific info
 
 test:
-  script: true  #FIXME
+  dependencies:
+    freedesktop.org/pkg-config: ^0.29
+  script: |
+    ncursesw6-config --version | grep {{version.marketing}}
+    ncursesw6-config --terminfo-dirs | grep '{{prefix}}'
+    pkg-config --modversion ncursesw | grep {{version.marketing}}
+    pkg-config --libs ncursesw | grep '{{prefix}}'
 
 provides:
   - bin/captoinfo

--- a/projects/invisible-island.net/ncurses/package.yml
+++ b/projects/invisible-island.net/ncurses/package.yml
@@ -31,6 +31,13 @@ build:
     rmdir ncursesw
     ln -sf . ncursesw
 
+    # fix hardcoded paths
+    sed -i.bak 's|{{prefix}}|\${pcfiledir}/../..|g' {{prefix}}/lib/pkgconfig/*.pc
+    rm {{prefix}}/lib/pkgconfig/*.bak
+
+    sed -i.bak 's|{{prefix}}|\${NCURSES_ROOT}|g' {{prefix}}/bin/ncursesw{{version.major}}-config
+    rm {{prefix}}/bin/ncursesw{{version.major}}-config.bak
+
   env:
     PCDIR: ${{prefix}}/lib/pkgconfig
     ARGS:
@@ -46,6 +53,7 @@ build:
 
 runtime:
   env:
+    NCURSES_ROOT: "{{prefix}}"
     TERMINFO: /usr/share/terminfo:{{prefix}}/share/terminfo
     # ^^ we delegate to the system first since they may apply platform specific info
 

--- a/projects/invisible-island.net/ncurses/package.yml
+++ b/projects/invisible-island.net/ncurses/package.yml
@@ -35,7 +35,7 @@ build:
     sed -i.bak 's|{{prefix}}|\${pcfiledir}/../..|g' {{prefix}}/lib/pkgconfig/*.pc
     rm {{prefix}}/lib/pkgconfig/*.bak
 
-    sed -i.bak 's|{{prefix}}|\${NCURSES_ROOT}|g' {{prefix}}/bin/ncursesw{{version.major}}-config
+    sed -i.bak 's|{{prefix}}|\$(dirname "\$0")/..|g' {{prefix}}/bin/ncursesw{{version.major}}-config
     rm {{prefix}}/bin/ncursesw{{version.major}}-config.bak
 
   env:
@@ -53,7 +53,6 @@ build:
 
 runtime:
   env:
-    NCURSES_ROOT: "{{prefix}}"
     TERMINFO: /usr/share/terminfo:{{prefix}}/share/terminfo
     # ^^ we delegate to the system first since they may apply platform specific info
 


### PR DESCRIPTION
This should fix the issue with libraries:
https://github.com/teaxyz/pantry/actions/runs/5986208701/job/16239342575?pr=2756

```
dyld[21426]: Library not loaded: @rpath/invisible-island.net/ncurses/v6.4.0/lib/libncursesw.6.dylib
  Referenced from: <0142D913-002E-3296-9E4B-D1D730514608> /Users/builder/.tea/macvim.org/v177.0.0/MacVim.app/Contents/MacOS/Vim
  Reason: tried: '/opt/invisible-island.net/ncurses/v6.4.0/lib/libncursesw.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/invisible-island.net/ncurses/v6.4.0/lib/libncursesw.6.dylib' (no such file), '/opt/invisible-island.net/ncurses/v6.4.0/lib/libncursesw.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/invisible-island.net/ncurses/v6.4.0/lib/libncursesw.6.dylib' (no such file), '/usr/local/lib/libncursesw.6.dylib' (no such file), '/usr/lib/libncursesw.6.dylib' (no such file, not in dyld cache)
Error: Process completed with exit code 1.
```