### PR TITLE
+cedar-policy-cli -- A CLI for working with the Cedar authz engine

### DIFF
--- a/projects/cedarpolicy.com/cli/package.yml
+++ b/projects/cedarpolicy.com/cli/package.yml
@@ -1,0 +1,22 @@
+distributable:
+  url: https://github.com/cedar-policy/cedar/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/cedar
+
+versions:
+  github: cedar-policy/cedar
+  strip: /v/
+
+build:
+  working-directory: cedar-policy-cli
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(cedar --version)" = "cedar-policy-cli {{version}}"


### PR DESCRIPTION
https://github.com/cedar-policy/cedar/tree/main/cedar-policy-cli
https://www.cedarpolicy.com/en

> CLI is a command line tool. It supports the following subcommands:
>  * authorize:      Evaluate an authorization request
>  * evaluate:       Evaluate a Cedar expression
>  * validate:       Validate a policy set against a schema
>  * check-parse:    Check that policies successfully parse
>  * link:           Link a template
>  * format:         Format a policy set
>  * help:           Print this message or the help of the given subcommand(s)