### PR TITLE
gpgme

### DIFF
--- a/projects/gnupg.org/gpgme/package.yml
+++ b/projects/gnupg.org/gpgme/package.yml
@@ -1,0 +1,30 @@
+distributable:
+  url: https://gnupg.org/ftp/gcrypt/gpgme/gpgme-{{version.raw}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://gnupg.org/ftp/gcrypt/gpgme/
+  match: /gpgme-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /gpgme-/
+    - /.tar.gz/
+
+provides:
+  - bin/gpgme
+
+build:
+  script: |
+    echo {{deps.gnupg.org/libgpg-error.prefix}}
+    ./configure --prefix={{prefix}} --with-libassuan-prefix={{deps.gnupg.org/libgpg-error.prefix}}/bin
+    make
+    make check
+    make install
+  dependencies:
+    tea.xyz/gx/cc: c99
+    tea.xyz/gx/make: '*'
+    gnupg.org/libassuan: ^2.0.2
+    gnupg.org/libgpg-error: ^1.11
+test:
+  script: test "$(gpgme 56)" = "$OUTPUT"
+  env:
+    OUTPUT: "56 = (0, 56) = (GPG_ERR_SOURCE_UNKNOWN, GPG_ERR_BAD_CERT_CHAIN) = (Unspecified source, Bad certificate chain)"

--- a/projects/gnupg.org/gpgme/package.yml
+++ b/projects/gnupg.org/gpgme/package.yml
@@ -15,7 +15,9 @@ provides:
 build:
   script: |
     echo {{deps.gnupg.org/libgpg-error.prefix}}
-    ./configure --prefix={{prefix}} --with-libassuan-prefix={{deps.gnupg.org/libgpg-error.prefix}}/bin
+    ./configure --prefix={{prefix}} \
+      --with-libassuan-prefix={{deps.gnupg.org/libassuan.prefix}} \
+      --with-libgpg-error-prefix={{deps.gnupg.org/libgpg-error.prefix}}
     make
     make check
     make install

--- a/projects/gnupg.org/gpgme/package.yml
+++ b/projects/gnupg.org/gpgme/package.yml
@@ -10,23 +10,25 @@ versions:
     - /.tar.gz/
 
 provides:
-  - bin/gpgme
+  - bin/gpgme-config
 
 build:
-  script: |
-    echo {{deps.gnupg.org/libgpg-error.prefix}}
-    ./configure --prefix={{prefix}} \
-      --with-libassuan-prefix={{deps.gnupg.org/libassuan.prefix}} \
-      --with-libgpg-error-prefix={{deps.gnupg.org/libgpg-error.prefix}}
-    make
-    make check
-    make install
+  script:
+    - ./configure $ARGS
+    - make
+    - make install
+  env:
+    ARGS:
+      - --prefix={{prefix}}
+      - --with-libassuan-prefix={{deps.gnupg.org/libassuan.prefix}}
+      - --with-libgpg-error-prefix={{deps.gnupg.org/libgpg-error.prefix}}
+    CFLAGS: $CFLAGS -Wno-implicit-function-declaration
+    CXXFLAGS: $CXXFLAGS -std=c++14
   dependencies:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
+    gnupg.org: '*'
     gnupg.org/libassuan: ^2.0.2
     gnupg.org/libgpg-error: ^1.11
 test:
-  script: test "$(gpgme 56)" = "$OUTPUT"
-  env:
-    OUTPUT: "56 = (0, 56) = (GPG_ERR_SOURCE_UNKNOWN, GPG_ERR_BAD_CERT_CHAIN) = (Unspecified source, Bad certificate chain)"
+  script: test "$(gpgme-config --version)" = "{{version}}"

--- a/projects/gnupg.org/libgpg-error/package.yml
+++ b/projects/gnupg.org/libgpg-error/package.yml
@@ -11,12 +11,14 @@ versions:
 
 provides:
   - bin/gpg-error
+  # Deprecated, but required for gpgme
+  - bin/gpg-error-config
   - bin/gpgrt-config
   - bin/yat2m
 
 build:
   script: |
-    ./configure --prefix={{prefix}}
+    ./configure --prefix={{prefix}} --enable-install-gpg-error-config
     make
     make check
     make install


### PR DESCRIPTION
https://gnupg.org/software/gpgme/index.html
https://gnupg.org/ftp/gcrypt/

https://github.com/gpg/gpgme
https://github.com/gpg/libassuan
https://github.com/gpg/libgpg-error

>  GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG easier for applications. It provides a High-Level Crypto API for encryption, decryption, signing, signature verification, and key management. Currently, it uses GnuPG's OpenPGP backend as the default, but the API isn't restricted to this engine. We have, in fact, already developed a backend for CMS (S/MIME).
>
> Because the direct use of GnuPG from an application can be a complicated programming task, it is suggested that all software should try to use GPGME instead. This way bug fixes or improvements can be done at a central place and every application benefits from this. Furthermore, there is no guarantee that any particular command line option will remain exactly the same at any given point.