### PR TITLE
+uplift -- CI Tool for Semantic Versioning + Conventional Commits

### DIFF
--- a/projects/upliftci.dev/package.yml
+++ b/projects/upliftci.dev/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/gembaadvantage/uplift/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: gembaadvantage/uplift
+
+provides:
+  - bin/uplift
+
+build:
+  dependencies:
+    go.dev: ^1.19
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/uplift
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/uplift'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/gembaadvantage/uplift/internal/version.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - uplift version | grep {{version}}


### PR DESCRIPTION
> Semantic versioning the easy way. Powered by Conventional Commits. Built for use with CI.

https://github.com/gembaadvantage/uplift
https://upliftci.dev/