### PR TITLE
Bump SurrealDB to latest beta version

### DIFF
--- a/projects/surrealdb.com/package.yml
+++ b/projects/surrealdb.com/package.yml
@@ -1,13 +1,13 @@
 distributable:
-  url: https://github.com/surrealdb/surrealdb/archive/refs/tags/v1.0.0-beta.8.tar.gz
+  url: https://github.com/surrealdb/surrealdb/archive/refs/tags/v1.0.0-beta.10.tar.gz
   strip-components: 1
 
 provides:
   - bin/surreal
 
 versions:
-  - 0.0.0
-  # FIXME once there has been an official release
+  - 2023.09.01
+  # FIXME once v1 launches on 2023.09.13
   # github: surrealdb/surrealdb
 
 dependencies:


### PR DESCRIPTION
From v1.0.0-beta.8 to v1.0.0-beta.10.

### Their Roadmap

https://surrealdb.com/roadmap

Apparently, we're getting a stable v1 release in ten days, on Sept 13.

### A lot has changed in just the last two releases

https://surrealdb.com/releases#v1-0-0-beta-10
https://surrealdb.com/releases#v1-0-0-beta-9