### PR TITLE
+svu -- Semantic Version Util

### DIFF
--- a/projects/github.com/caarlos0/svu/package.yml
+++ b/projects/github.com/caarlos0/svu/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/caarlos0/svu/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: caarlos0/svu
+
+provides:
+  - bin/svu
+
+build:
+  dependencies:
+    go.dev: ^1.20
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/svu'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - test "$(svu --version 2>&1)" = "svu version {{version}}"


### PR DESCRIPTION
Automatically creates the next Git tag for you, using Semantic Version and Conventional Commits.

https://github.com/caarlos0/svu

Recommended by GoReleaser:
https://goreleaser.com/cookbooks/semantic-release/

```shell
git tag "$(svu next)"
git push --tags
```