### PR TITLE
libdrm (gz => xz)

### DIFF
--- a/projects/dri.freedesktop.org/package.yml
+++ b/projects/dri.freedesktop.org/package.yml
@@ -1,13 +1,13 @@
 distributable:
-  url: https://dri.freedesktop.org/libdrm/libdrm-{{version}}.tar.gz
+  url: https://dri.freedesktop.org/libdrm/libdrm-{{version}}.tar.xz
   strip-components: 1
 
 versions:
   url: https://dri.freedesktop.org/libdrm/
-  match: /libdrm-\d+\.\d+\.\d+\.tar\.gz/
+  match: /libdrm-\d+\.\d+\.\d+\.tar\.xz/
   strip:
     - /^libdrm-/
-    - /\.tar\.gz$/
+    - /\.tar\.xz$/
 
 display-name: libdrm
 


### PR DESCRIPTION
https://dri.freedesktop.org/libdrm/
They started using `.tar.xz` archives since version `2.4.101`