### PR TITLE
+rover -- The CLI for Apollo GraphOS

### DIFF
--- a/projects/apollographql.com/rover/package.yml
+++ b/projects/apollographql.com/rover/package.yml
@@ -18,6 +18,7 @@ build:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
     freedesktop.org/pkg-config: ^0
+    tea.xyz/gx/make: '*'
   script:
     cargo install --locked --path . --root {{prefix}}
 

--- a/projects/apollographql.com/rover/package.yml
+++ b/projects/apollographql.com/rover/package.yml
@@ -5,6 +5,10 @@ distributable:
 provides:
   - bin/rover
 
+dependencies:
+  openssl.org: ^1.1
+  zlib.net: ^1
+
 versions:
   github: apollographql/rover
   strip: /v/
@@ -13,6 +17,7 @@ build:
   dependencies:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
+    freedesktop.org/pkg-config: ^0
   script:
     cargo install --locked --path . --root {{prefix}}
 

--- a/projects/apollographql.com/rover/package.yml
+++ b/projects/apollographql.com/rover/package.yml
@@ -1,0 +1,21 @@
+distributable:
+  url: https://github.com/apollographql/rover/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/rover
+
+versions:
+  github: apollographql/rover
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(rover --version)" = "Rover {{version}}"


### PR DESCRIPTION
[**Rover**](https://www.apollographql.com/docs/rover/) is the command-line interface for managing and maintaining graphs with [Apollo GraphOS](https://www.apollographql.com/docs/graphos/).

https://github.com/apollographql/rover

- Publish a subgraph schema to GraphOS
- Run your supergraph router locally and add multiple subgraphs
- Fetch a GraphQL server's schema via introspection
- Compose a federated supergraph schema from multiple subgraphs