### PR TITLE
+gci -- Import sorter for Golang

### DIFF
--- a/projects/github.com/daixiang0/gci/package.yml
+++ b/projects/github.com/daixiang0/gci/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/daixiang0/gci/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: daixiang0/gci
+
+provides:
+  - bin/gci
+
+build:
+  dependencies:
+    go.dev: ^1.18
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/gci'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - test "$(gci --version)" = "gci version {{version}}"


### PR DESCRIPTION
https://github.com/daixiang0/gci

> **GCI**, a tool that control golang package import order and make it always deterministic. 