### PR TITLE
+gqlgen -- Type-safe GraphQL for Go

### DIFF
--- a/projects/gqlgen.com/package.yml
+++ b/projects/gqlgen.com/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/99designs/gqlgen/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: 99designs/gqlgen
+
+provides:
+  - bin/gqlgen
+
+build:
+  dependencies:
+    go.dev: ^1.18
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/gqlgen'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X graphql.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - test "$(gqlgen version)" = "v{{version}}"


### PR DESCRIPTION
https://gqlgen.com/
https://github.com/99designs/gqlgen

> Type-safe GraphQL for Go
>
> What is gqlgen?
>
> [gqlgen](https://github.com/99designs/gqlgen) is a Go library for building GraphQL servers without any fuss.
>
> 
> - gqlgen is based on a Schema first approach — You get to Define your API using the GraphQL [Schema Definition Language](http://graphql.org/learn/schema/).
> - gqlgen prioritizes Type safety — You should never see map[string]interface{} here.
> - gqlgen enables Codegen — We generate the boring bits, so you can focus on building your app quickly.