### PR TITLE
+genqlient -- CLI to generate type-safe Go GraphQL client

### DIFF
--- a/projects/khanacademy.org/genqlient/package.yml
+++ b/projects/khanacademy.org/genqlient/package.yml
@@ -1,0 +1,35 @@
+distributable:
+  url: https://github.com/Khan/genqlient/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: Khan/genqlient
+
+provides:
+  - bin/genqlient
+
+build:
+  dependencies:
+    go.dev: ^1.18
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/genqlient'
+    LDFLAGS:
+      - -s
+      - -w
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - genqlient --help


### PR DESCRIPTION
https://github.com/Khan/genqlient

> a truly type-safe Go GraphQL client
>
> genqlient is a Go library to easily generate type-safe code to query a GraphQL API. It takes advantage of the fact that both GraphQL and Go are typed languages to ensure at compile-time that your code is making a valid GraphQL query and using the result correctly, all with a minimum of boilerplate.
> 
> genqlient provides:
> 
> - Compile-time validation of GraphQL queries: never ship an invalid GraphQL query again!
> - Type-safe response objects: genqlient generates the right type for each query, so you know the response will unmarshal correctly and never need to use `interface{}`.
> - Production-readiness: genqlient is used in production at Khan Academy, where it supports millions of learners and teachers around the world.