### PR TITLE
+vale -- A markup-aware linter for prose

### DIFF
--- a/projects/vale.sh/package.yml
+++ b/projects/vale.sh/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/errata-ai/vale/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: errata-ai/vale
+
+provides:
+  - bin/vale
+
+build:
+  dependencies:
+    go.dev: ^1.20
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/vale
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/vale'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version=v{{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - test "$(vale --version)" = "vale version v{{version}}"


### PR DESCRIPTION
https://github.com/errata-ai/vale
https://vale.sh/