### PR TITLE
+git-absorb -- Tool for rewriting Git history after PR feedback

### DIFF
--- a/projects/crates.io/git-absorb/package.yml
+++ b/projects/crates.io/git-absorb/package.yml
@@ -1,0 +1,21 @@
+distributable:
+  url: https://github.com/tummychow/git-absorb/archive/refs/tags/{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/git-absorb
+
+versions:
+  github: tummychow/git-absorb
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(git-absorb --version)" = "git-absorb {{version}}"


### PR DESCRIPTION
https://github.com/tummychow/git-absorb
https://crates.io/crates/git-absorb

> You have a feature branch with a few commits. Your teammate reviewed the branch and pointed out a few bugs. You have fixes for the bugs, but you don't want to shove them all into an opaque commit that says fixes, because you believe in atomic commits. Instead of manually finding commit SHAs for git commit --fixup, or running a manual interactive rebase, do this:
> ```
> git add $FILES_YOU_FIXED
> git absorb --and-rebase
> ```