### PR TITLE
+commit -- CLI to assist with Conventional Commits

### DIFF
--- a/projects/github.com/alt-art/commit/package.yml
+++ b/projects/github.com/alt-art/commit/package.yml
@@ -1,0 +1,21 @@
+distributable:
+  url: https://github.com/alt-art/commit/archive/refs/tags/{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/commit
+
+versions:
+  github: alt-art/commit
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(commit --version)" = "commit {{version}}"


### PR DESCRIPTION
https://github.com/alt-art/commit

> This command-line interface makes it possible to make patterned (conventional) commit messages to organize your repository.
> 
> This project is a clone of [cz-cli](https://github.com/commitizen/cz-cli) with some minor changes.
> 
> I made this project for my own use, because I don't want to mess with the original cz-cli.
> Principal changes in this project
> 
> - Don't need to make your project commitizen friendly
> - Can be used with any project and any language
> - Custom conventional commit message style can be used without any other packages
> - Plug and play just needs git installed