### PR TITLE
+tfupdate -- Update version constraints in your Terraform configurations

### DIFF
--- a/projects/github.com/minamijoyo/tfupdate/package.yml
+++ b/projects/github.com/minamijoyo/tfupdate/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/minamijoyo/tfupdate/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: minamijoyo/tfupdate
+
+provides:
+  - bin/tfupdate
+
+build:
+  dependencies:
+    go.dev: ^1.21
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/tfupdate'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - test "$(tfupdate --version)" = "{{version}}"


### PR DESCRIPTION
https://github.com/minamijoyo/tfupdate

> It is a best practice to break your Terraform configuration and state into small pieces to minimize the impact of an accident. It is also recommended to lock versions of Terraform core, providers and modules to avoid unexpected breaking changes. If you decided to lock version constraints, you probably **want to keep them up-to-date frequently to reduce the risk of version upgrade failures**. It's easy to update a single directory, but what if they are **scattered across multiple directories**?
>
> That is why I wrote a tool which **parses Terraform configurations and updates all version constraints at once**.