### PR TITLE
+driftctl -- Detect, track and alert on infrastructure drift

### DIFF
--- a/projects/snyk.io/driftctl/package.yml
+++ b/projects/snyk.io/driftctl/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/snyk/driftctl/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: snyk/driftctl
+
+provides:
+  - bin/driftctl
+
+build:
+  dependencies:
+    go.dev: ^1.21
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/driftctl'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/snyk/driftctl/pkg/version.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - driftctl version | grep {{version}}


### PR DESCRIPTION
https://github.com/snyk/driftctl
https://docs.driftctl.com/0.39.0

> Infrastructure drift is a blind spot and a source of potential security issues. Drift can have multiple causes: from team members creating or updating infrastructure through the web console without backporting changes to Terraform, to unexpected actions from authenticated apps and services.
> 
> You can't efficiently improve what you don't track. We track coverage for unit tests, why not infrastructure as code coverage?
> 
> Spot discrepancies as they happen: driftctl is a free and open-source CLI that warns of infrastructure drifts and fills in the missing piece in your DevSecOps toolbox.