### PR TITLE
+digger -- Run IaC in your existing CI pipeline

### DIFF
--- a/projects/digger.dev/package.yml
+++ b/projects/digger.dev/package.yml
@@ -29,7 +29,7 @@ build:
     LDFLAGS:
       - -s
       - -w
-      - -X github.com/diggerhq/digger/pkg/utils.version={{version}}
+      - -X digger/pkg/utils.version={{version}}
     linux:
       # or segmentation fault
       # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575

--- a/projects/digger.dev/package.yml
+++ b/projects/digger.dev/package.yml
@@ -11,10 +11,15 @@ provides:
 build:
   dependencies:
     go.dev: ^1.21
-  script: |
-    go mod download
-    mkdir -p "{{ prefix }}"/bin
-    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/digger
+  script:
+    - go mod download
+    # Fix merged but not released https://github.com/diggerhq/digger/issues/581
+    # by @kevinmichaelchen
+    - run: |
+        sed -i.bak -e 's/^const version =/var version =/' version.go
+        rm version.go.bak
+      working-directory: pkg/utils
+    - go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/digger
   env:
     GOPROXY: https://proxy.golang.org,direct
     GOSUMDB: sum.golang.org
@@ -33,5 +38,4 @@ build:
 
 test:
   script:
-    # FIX after https://github.com/diggerhq/digger/issues/581
-    - test "$(digger version)" = "you are using digger version 0.1.6"
+    - test "$(digger version)" = "you are using digger version {{version}}"

--- a/projects/digger.dev/package.yml
+++ b/projects/digger.dev/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/diggerhq/digger/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: diggerhq/digger
+
+provides:
+  - bin/digger
+
+build:
+  dependencies:
+    go.dev: ^1.21
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/digger
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/digger'
+    LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/diggerhq/digger/pkg/utils.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+      - -buildmode=pie
+
+test:
+  script:
+    - digger --help

--- a/projects/digger.dev/package.yml
+++ b/projects/digger.dev/package.yml
@@ -33,4 +33,5 @@ build:
 
 test:
   script:
-    - digger --help
+    # FIX after https://github.com/diggerhq/digger/issues/581
+    - test "$(digger version)" = "you are using digger version 0.1.6"


### PR DESCRIPTION
https://github.com/diggerhq/digger
https://digger.dev/

> CI/CD for Terraform is [tricky](https://itnext.io/pains-in-terraform-collaboration-249a56b4534e). To make life easier, specialised CI systems aka [TACOS](https://itnext.io/spice-up-your-infrastructure-as-code-with-tacos-1a9c179e0783) exist - Terraform Cloud, Spacelift, Atlantis, etc.
> 
> But why have 2 CI systems? Why not reuse the async jobs infrastructure with compute, orchestration, logs, etc of your existing CI?
> 
> Digger runs terraform natively in your CI. This is:
> 
>     Secure, because cloud access secrets aren't shared with a third-party
>     Cost-effective, because you are not paying for additional compute just to run your terraform