### PR TITLE
+pgen: Passphrase generator CLI

### DIFF
--- a/projects/crates.io/pgen/package.yml
+++ b/projects/crates.io/pgen/package.yml
@@ -1,0 +1,22 @@
+distributable:
+  url: https://github.com/ctsrc/Pgen/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/pgen
+
+versions:
+  github: ctsrc/Pgen/tags
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.65'
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --path . --root {{prefix}}
+
+test:
+  script:
+    - test "$(pgen --version)" = "pgen {{version}}"
+    - pgen -l -n 12 -e


### PR DESCRIPTION
https://github.com/ctsrc/Pgen

> Generate passphrases using the [wordlists for random passphrases](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases) made by the EFF.
> 
> The EFF wordlists consist of words that are easy to type and easy to remember.
> 
> By default, passphrases generated by pgen consist of twelve words randomly selected from the autocomplete-optimized wordlist. Be sure to [read the article](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases) to learn about the difference between the different wordlists provided by the EFF.
> 
> These are some examples of generated passphrases:
> 
>     gimmick saffron nirvana superstore voicemail dedicate guacamole oftentimes dwindling kingdom shuttle upright
>     bobcat pulley yearbook nectar krypton pesticide relic sauna detergent amnesty dishcloth tapestry
>     porcupine identical occupation oxidize avalanche celery vaporizer dastardly vicinity enlarged hatchling urethane