### PR TITLE
+github.com/containers/skopeo

### DIFF
--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -14,12 +14,13 @@ dependencies:
 build:
   dependencies:
     go.dev: "^1.18"
-    github.com/cpuguy83/go-md2man: "*"
     tea.xyz/gx/make: "*"
     curl.se: "*"
     git-scm.org: "*"
+  env:
+    DISABLE_DOCS: 1 # disables the generation of man pages with go-md2man
   script: |
-    # bundle default-policy.json into the binary to provide a working out-of-the-box experience
+    # bundles default-policy.json into the binary to provide a working out-of-the-box experience
     # https://github.com/containers/skopeo/pull/2014
     curl -fsSL https://github.com/containers/skopeo/pull/2014.diff | git apply
 

--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -1,0 +1,39 @@
+distributable:
+  url: https://github.com/containers/skopeo/archive/v{{ version }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: containers/skopeo/tags
+
+provides:
+  - bin/skopeo
+
+dependencies:
+  curl.se/ca-certs: "*"
+
+build:
+  dependencies:
+    go.dev: "^1.18"
+    github.com/cpuguy83/go-md2man: "*"
+    tea.xyz/gx/make: "*"
+    curl.se: "*"
+    git-scm.org: "*"
+  env:
+    CGO_ENABLED: 0
+  script: |
+    # This makes skopeo a fully self-contained binary
+    curl -fsSL https://github.com/containers/skopeo/pull/2014.diff | git apply
+    make BUILDTAGS=containers_image_openpgp GO_DYN_FLAGS=
+    mkdir -p '{{prefix}}/bin'
+    mv -f ./bin/skopeo '{{prefix}}/bin'
+
+test:
+  script: |
+    skopeo --version | tee /dev/stderr | grep -q -w '{{ version }}'
+
+    skopeo --override-os linux inspect docker://busybox | tee /dev/stderr |
+      grep -q -w 'docker.io/library/busybox'
+
+    skopeo copy docker://alpine docker-archive:alpine.tar
+
+    test -f alpine.tar

--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -14,7 +14,6 @@ dependencies:
 build:
   dependencies:
     go.dev: "^1.18"
-    tea.xyz/gx/make: "*"
     curl.se: "*"
     git-scm.org: "*"
   env:

--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -18,12 +18,14 @@ build:
     tea.xyz/gx/make: "*"
     curl.se: "*"
     git-scm.org: "*"
-  env:
-    CGO_ENABLED: 0
   script: |
-    # This makes skopeo a fully self-contained binary
+    # bundle default-policy.json into the binary to provide a working out-of-the-box experience
+    # https://github.com/containers/skopeo/pull/2014
     curl -fsSL https://github.com/containers/skopeo/pull/2014.diff | git apply
-    make BUILDTAGS=containers_image_openpgp GO_DYN_FLAGS=
+
+    # https://github.com/containers/skopeo/blob/2d1ae1fdb3d88347eec8a17d4415a964ce86d54f/install.md#building-a-static-binary
+    CGO_ENABLED=0 make BUILDTAGS=containers_image_openpgp GO_DYN_FLAGS=
+
     mkdir -p '{{prefix}}/bin'
     mv -f ./bin/skopeo '{{prefix}}/bin'
 

--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -31,8 +31,8 @@ test:
   script: |
     skopeo --version | tee /dev/stderr | grep -q -w '{{ version }}'
 
-    skopeo --override-os linux inspect docker://busybox | tee /dev/stderr |
-      grep -q -w 'docker.io/library/busybox'
+    skopeo --override-os linux inspect docker://hello-world | tee /dev/stderr |
+      grep -q -w 'docker.io/library/hello-world'
 
     skopeo --override-os linux copy docker://hello-world docker-archive:hello-world.tar
     test -f hello-world.tar

--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -34,6 +34,5 @@ test:
     skopeo --override-os linux inspect docker://busybox | tee /dev/stderr |
       grep -q -w 'docker.io/library/busybox'
 
-    skopeo copy docker://alpine docker-archive:alpine.tar
-
-    test -f alpine.tar
+    skopeo --override-os linux copy docker://hello-world docker-archive:hello-world.tar
+    test -f hello-world.tar

--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -21,7 +21,8 @@ build:
   script: |
     # bundles default-policy.json into the binary to provide a working out-of-the-box experience
     # https://github.com/containers/skopeo/pull/2014
-    curl -fsSL https://github.com/containers/skopeo/pull/2014.diff | patch -p1
+    curl -fsSL https://github.com/containers/skopeo/commit/fb180f03ca43ea7a9130a48639f483fa46cffe50.diff |
+      patch -p1
 
     # https://github.com/containers/skopeo/blob/2d1ae1fdb3d88347eec8a17d4415a964ce86d54f/install.md#building-a-static-binary
     CGO_ENABLED=0 make BUILDTAGS=containers_image_openpgp GO_DYN_FLAGS=

--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -15,13 +15,13 @@ build:
   dependencies:
     go.dev: "^1.18"
     curl.se: "*"
-    git-scm.org: "*"
+    gnu.org/patch: "*"
   env:
     DISABLE_DOCS: 1 # disables the generation of man pages with go-md2man
   script: |
     # bundles default-policy.json into the binary to provide a working out-of-the-box experience
     # https://github.com/containers/skopeo/pull/2014
-    curl -fsSL https://github.com/containers/skopeo/pull/2014.diff | git apply
+    curl -fsSL https://github.com/containers/skopeo/pull/2014.diff | patch -p1
 
     # https://github.com/containers/skopeo/blob/2d1ae1fdb3d88347eec8a17d4415a964ce86d54f/install.md#building-a-static-binary
     CGO_ENABLED=0 make BUILDTAGS=containers_image_openpgp GO_DYN_FLAGS=

--- a/projects/github.com/containers/skopeo/package.yml
+++ b/projects/github.com/containers/skopeo/package.yml
@@ -3,7 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  github: containers/skopeo/tags
+  github: containers/skopeo/releases/tags
 
 provides:
   - bin/skopeo


### PR DESCRIPTION
Things to note:

1. This skopeo is statically linked, different than [Homebrew's](https://github.com/Homebrew/homebrew-core/blob/f82bfa8133fa7c84a368e5f9cb972fbce9c730f4/Formula/s/skopeo.rb) version.
2. Skopeo's team itself does not encourage static linking, but it is possible and [documented](https://github.com/containers/skopeo/blob/2d1ae1fdb3d88347eec8a17d4415a964ce86d54f/install.md#building-a-static-binary).
3. This applies https://github.com/containers/skopeo/pull/2014 to make the Skopeo binary truly self-contained and portable.
4. This "bottle" is much inspired by my own project [skopeo-bin](https://github.com/felipecrs/skopeo-bin), which aims to provide portable binaries for Skopeo.

Closes #2695
