### PR TITLE
+github.com/regclient/regclient

### DIFF
--- a/projects/github.com/regclient/regclient/package.yml
+++ b/projects/github.com/regclient/regclient/package.yml
@@ -1,0 +1,31 @@
+distributable:
+  url: git+https://github.com/regclient/regclient
+  ref: v{{ version }}
+
+versions:
+  github: regclient/regclient/releases/tags
+
+provides:
+  - bin/regctl
+  - bin/regsync
+  - bin/regbot
+
+dependencies:
+  curl.se/ca-certs: '*'
+
+build:
+  dependencies:
+    go.dev: ^1.21
+    git-scm.org: '*'
+  script: |
+    make binaries
+    mkdir -p '{{ prefix }}/bin'
+    mv -f ./bin/{regctl,regsync,regbot} '{{ prefix }}/bin'
+
+test:
+  script: |
+    regctl version | tee /dev/stderr | grep -q -w "v{{ version }}"
+    regsync version | tee /dev/stderr | grep -q -w "v{{ version }}"
+    regbot version | tee /dev/stderr | grep -q -w "v{{ version }}"
+
+    regctl image inspect hello-world --platform linux/amd64 | tee /dev/stderr | grep -q -w '"Image":'

--- a/projects/github.com/regclient/regclient/regbot/package.yml
+++ b/projects/github.com/regclient/regclient/regbot/package.yml
@@ -1,0 +1,25 @@
+distributable:
+  url: git+https://github.com/regclient/regclient
+  ref: v{{ version }}
+
+versions:
+  github: regclient/regclient/releases/tags
+
+provides:
+  - bin/regbot
+
+dependencies:
+  curl.se/ca-certs: '*'
+
+build:
+  dependencies:
+    go.dev: ^1.21
+    git-scm.org: '*'
+  script: |
+    make bin/regbot
+    mkdir -p '{{ prefix }}/bin'
+    mv -f ./bin/regbot '{{ prefix }}/bin'
+
+test:
+  script: |
+    regbot version | tee /dev/stderr | grep -q -w "v{{ version }}"

--- a/projects/github.com/regclient/regclient/regctl/package.yml
+++ b/projects/github.com/regclient/regclient/regctl/package.yml
@@ -1,0 +1,27 @@
+distributable:
+  url: git+https://github.com/regclient/regclient
+  ref: v{{ version }}
+
+versions:
+  github: regclient/regclient/releases/tags
+
+provides:
+  - bin/regctl
+
+dependencies:
+  curl.se/ca-certs: '*'
+
+build:
+  dependencies:
+    go.dev: ^1.21
+    git-scm.org: '*'
+  script: |
+    make bin/regctl
+    mkdir -p '{{ prefix }}/bin'
+    mv -f ./bin/regctl '{{ prefix }}/bin'
+
+test:
+  script: |
+    regctl version | tee /dev/stderr | grep -q -w "v{{ version }}"
+
+    regctl image inspect hello-world --platform linux/amd64 | tee /dev/stderr | grep -q -w '"Image":'

--- a/projects/github.com/regclient/regclient/regsync/package.yml
+++ b/projects/github.com/regclient/regclient/regsync/package.yml
@@ -6,9 +6,7 @@ versions:
   github: regclient/regclient/releases/tags
 
 provides:
-  - bin/regctl
   - bin/regsync
-  - bin/regbot
 
 dependencies:
   curl.se/ca-certs: '*'
@@ -18,14 +16,10 @@ build:
     go.dev: ^1.21
     git-scm.org: '*'
   script: |
-    make binaries
+    make bin/regsync
     mkdir -p '{{ prefix }}/bin'
-    mv -f ./bin/{regctl,regsync,regbot} '{{ prefix }}/bin'
+    mv -f ./bin/regsync '{{ prefix }}/bin'
 
 test:
   script: |
-    regctl version | tee /dev/stderr | grep -q -w "v{{ version }}"
     regsync version | tee /dev/stderr | grep -q -w "v{{ version }}"
-    regbot version | tee /dev/stderr | grep -q -w "v{{ version }}"
-
-    regctl image inspect hello-world --platform linux/amd64 | tee /dev/stderr | grep -q -w '"Image":'


### PR DESCRIPTION
The regclient project provides these three binaries, but they are not dependent on each other. The author even distributes one docker image for each for each of them, so I think we should do the same.

Something I noted however is that VSC_REF is tagged with dirty, apparently because:

```console
$ git status --porcelain
?? props/
?? tea.yaml
?? xyz.tea.build.sh
```

Any ideas on that?