### PR TITLE
fix: make ncurses build terminfo db in linux

### DIFF
--- a/projects/invisible-island.net/ncurses/package.yml
+++ b/projects/invisible-island.net/ncurses/package.yml
@@ -60,11 +60,10 @@ build:
       - --with-gpm=no
       - --without-ada
       - --with-pkg-config-libdir=$PCDIR
-      - --with-default-terminfo-dir=/usr/share/terminfo   # or breaks on macOS
 
 runtime:
   env:
-    TERMINFO_DIRS: ${{prefix}}/share/terminfo
+    TERMINFO_DIRS: /usr/share/terminfo:{{prefix}}/share/terminfo
     # ^^ we delegate to the system first since they may apply platform specific info
 
 test:


### PR DESCRIPTION
After [Don’t set TERMINFO by mxcl · Pull Request #3792 · pkgxdev/pantry](https://github.com/pkgxdev/pantry/pull/3792) , in linux env, we can't run tmux because ncurses terminfo db was not generated.
This PR fix it.

details: https://github.com/pkgxdev/pantry/issues/3809#issuecomment-1780361056
close: https://github.com/pkgxdev/pantry/issues/3809