### PR TITLE
+wails.io

### DIFF
--- a/projects/wails.io/package.yml
+++ b/projects/wails.io/package.yml
@@ -1,0 +1,46 @@
+distributable:
+  url: https://github.com/wailsapp/wails/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: wailsapp/wails
+  strip: /^v/
+
+dependencies:
+  go.dev: ^1.18
+  npmjs.com: "*"
+  linux:
+    gnu.org/gcc: "*"
+    freedesktop.org/pkg-config: "*"
+    # we are missing dependencies for:
+    #   - libgtk-3
+    #   - libwebkit
+  darwin:
+    # we are missing dependencies for:
+    #   - xcode
+
+build:
+  script: |
+    cd ./v2
+    go build -v -ldflags="$LDFLAGS" -o wails ./cmd/wails
+    mkdir -p "{{ prefix }}"/bin
+    mv wails "{{ prefix }}"/bin
+  env:
+    CGO_ENABLED: 0
+    LDFLAGS:
+      - -extldflags=-static
+      - -w
+      - -s
+
+provides:
+  - bin/wails
+
+test:
+  script:
+    - wails version | grep "v{{version}}"
+    # - test "$(wails doctor | grep "Your system has missing dependencies!" | wc -l)" != "1"
+    # ^^ only works as soon as all dependencies are fulfilled
+    - wails init -n example -t vanilla
+    # - cd example
+    # - wails build
+    # ^^ only works as soon as all dependencies are fulfilled

--- a/projects/wails.io/package.yml
+++ b/projects/wails.io/package.yml
@@ -6,6 +6,8 @@ versions:
   github: wailsapp/wails
   strip: /^v/
 
+platforms: [darwin]
+
 dependencies:
   go.dev: ^1.18
   npmjs.com: "*"
@@ -16,16 +18,12 @@ dependencies:
     # we are missing dependencies for:
     #   - libgtk-3
     #   - libwebkit
-  # darwin:
-    # we are missing dependencies for:
-    #   - xcode
 
 build:
-  script: |
-    cd ./v2
-    go build -v -ldflags="$LDFLAGS" -o wails ./cmd/wails
-    mkdir -p "{{ prefix }}"/bin
-    mv wails "{{ prefix }}"/bin
+  working-directory: v2
+  script:
+    - go build -v -ldflags="$LDFLAGS" -o wails ./cmd/wails
+    - install -D wails {{prefix}}/bin/wails
   env:
     CGO_ENABLED: 0
     LDFLAGS:

--- a/projects/wails.io/package.yml
+++ b/projects/wails.io/package.yml
@@ -15,7 +15,7 @@ dependencies:
     # we are missing dependencies for:
     #   - libgtk-3
     #   - libwebkit
-  darwin:
+  # darwin:
     # we are missing dependencies for:
     #   - xcode
 

--- a/projects/wails.io/package.yml
+++ b/projects/wails.io/package.yml
@@ -11,6 +11,7 @@ dependencies:
   npmjs.com: "*"
   linux:
     gnu.org/gcc: "*"
+    gtk.org/gtk3: "*"
     freedesktop.org/pkg-config: "*"
     # we are missing dependencies for:
     #   - libgtk-3
@@ -36,11 +37,15 @@ provides:
   - bin/wails
 
 test:
+  depdendencies:
+    gnu.org/coreutils: "*"
+    gnu.org/grep: "*"
   script:
     - wails version | grep "v{{version}}"
-    # - test "$(wails doctor | grep "Your system has missing dependencies!" | wc -l)" != "1"
+    - wails doctor -nocolour | tee doctor.txt
+    - test "$(cat doctor.txt | grep "Your system has missing dependencies!" | wc -l)" != "1"
     # ^^ only works as soon as all dependencies are fulfilled
     - wails init -n example -t vanilla
-    # - cd example
-    # - wails build
+    - cd example
+    - wails build
     # ^^ only works as soon as all dependencies are fulfilled


### PR DESCRIPTION
Adding [wails](https://wails.io/)

Draft because we are currently missing [some dependencies](https://wails.io/docs/gettingstarted/installation#platform-specific-dependencies) (see comments).