### PR TITLE
+(opencanaryd)

### DIFF
--- a/projects/github.com/thinkst/opencanary/README.md
+++ b/projects/github.com/thinkst/opencanary/README.md
@@ -1,0 +1,27 @@
+# Running OpenCanary via pkgx
+
+## Configuring OpenCanary
+
+When OpenCanary starts it looks for config files in the following locations and will stop when the first configuration is found:
+
+1. `./opencanary.conf` (i.e. the directory where OpenCanary is installed)
+2. `~/.opencanary.conf` (i.e. the home directory of the user, usually this will be `root` so `/root/.opencanary.conf`)
+3. `/etc/opencanaryd/opencanary.conf`
+
+To create an initial configuration, run as `root` (you may be prompted for a `sudo` password):
+```
+$ pkgx opencanaryd --copyconfig
+[*] A sample config file is ready /etc/opencanaryd/opencanary.conf
+
+[*] Edit your configuration, then launch with "pkgx opencanaryd --start"
+```
+
+This creates the path and file `/etc/opencanaryd/opencanary.conf`. You must now edit the config file to determine which services and logging options you want to enable.
+
+# Launching OpenCanary
+
+Start OpenCanary by running the following as root (or with `sudo -E`):
+
+```
+$ pkgx opencanaryd --start
+```

--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -1,0 +1,35 @@
+distributable:
+  url: https://github.com/thinkst/opencanary/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: thinkst/opencanary
+
+dependencies:
+  python.org: ~3.10
+  tcpdump.org: '*'
+  openssl.org: '*'
+
+runtime:
+  env:
+    PYTHONPATH: "$PYTHONPATH:{{prefix}}/lib/python3.10/site-packages"
+
+build:
+  dependencies:
+    pip.pypa.io: '*'
+
+  script: |
+    pip install setuptools
+    cat setup.py | sed -e 's/requirements = \[/requirements = \["scapy","pcapy-ng",/' > setup.py.mod
+    mv setup.py.mod setup.py
+    python setup.py sdist
+    python -m pip install --prefix={{prefix}} dist/opencanary-{{version}}.tar.gz
+
+provides:
+  - bin/opencanaryd
+  - bin/opencanary.tac
+  - bin/twistd
+
+test:
+  script: test "$(opencanaryd --version)" = "{{version}}"
+    

--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -6,24 +6,28 @@ versions:
   github: thinkst/opencanary
 
 dependencies:
-  python.org: ~3.10
+  python.org: ~3.7
   tcpdump.org: '*'
   openssl.org: '*'
 
 runtime:
   env:
-    PYTHONPATH: "$PYTHONPATH:{{prefix}}/lib/python{{deps.python.org.version.marketing}}/site-packages"
+    PYTHONPATH: "$PYTHONPATH:{{prefix}}/lib/python{{deps.python.org.version.major}}/site-packages"
 
 build:
   dependencies:
     pip.pypa.io: '*'
 
-  script: |
-    pip install setuptools
-    cat setup.py | sed -e 's/requirements = \[/requirements = \["scapy","pcapy-ng",/' > setup.py.mod
-    mv setup.py.mod setup.py
-    python setup.py sdist
-    python -m pip install --prefix={{prefix}} dist/opencanary-{{version}}.tar.gz
+  script: 
+    - run: |
+        pip install setuptools
+        cat setup.py | sed -e 's/requirements = \[/requirements = \["scapy","pcapy-ng",/' > setup.py.mod
+        mv setup.py.mod setup.py
+        python setup.py sdist
+        python -m pip install --prefix={{prefix}} dist/opencanary-{{version}}.tar.gz
+
+    - run: ln -s python{{deps.python.org.version.marketing}} python{{deps.python.org.version.major}}
+      working-directory: ${{prefix}}/lib/
 
 provides:
   - bin/opencanaryd

--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -6,7 +6,7 @@ versions:
   github: thinkst/opencanary
 
 dependencies:
-  python.org: ~3.9
+  python.org: ^3.10
   tcpdump.org: '*'
   openssl.org: '*'
 
@@ -17,8 +17,6 @@ runtime:
 build:
   dependencies:
     pip.pypa.io: '*'
-    gnu.org/gcc: '*'
-    sourceware.org/libffi: '*'
 
   script: 
     - run: |

--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -6,7 +6,7 @@ versions:
   github: thinkst/opencanary
 
 dependencies:
-  python.org: ~3.8
+  python.org: ~3.9
   tcpdump.org: '*'
   openssl.org: '*'
 
@@ -22,7 +22,7 @@ build:
 
   script: 
     - run: |
-        pip install --upgrade pip wheel setuptools
+        pip install setuptools
         cat setup.py | sed -e 's/requirements = \[/requirements = \["scapy","pcapy-ng",/' > setup.py.mod
         mv setup.py.mod setup.py
         python setup.py sdist

--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -12,7 +12,7 @@ dependencies:
 
 runtime:
   env:
-    PYTHONPATH: "$PYTHONPATH:{{prefix}}/lib/python3.10/site-packages"
+    PYTHONPATH: "$PYTHONPATH:{{prefix}}/lib/python{{deps.python.org.version.marketing}}/site-packages"
 
 build:
   dependencies:
@@ -27,8 +27,6 @@ build:
 
 provides:
   - bin/opencanaryd
-  - bin/opencanary.tac
-  - bin/twistd
 
 test:
   script: test "$(opencanaryd --version)" = "{{version}}"

--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -18,6 +18,7 @@ build:
   dependencies:
     pip.pypa.io: '*'
     gnu.org/gcc: '*'
+    sourceware.org/libffi: '*'
 
   script: 
     - run: |

--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -6,7 +6,7 @@ versions:
   github: thinkst/opencanary
 
 dependencies:
-  python.org: ~3.7
+  python.org: ~3.8
   tcpdump.org: '*'
   openssl.org: '*'
 

--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -17,10 +17,11 @@ runtime:
 build:
   dependencies:
     pip.pypa.io: '*'
+    gnu.org/gcc: '*'
 
   script: 
     - run: |
-        pip install setuptools
+        pip install --upgrade pip wheel setuptools
         cat setup.py | sed -e 's/requirements = \[/requirements = \["scapy","pcapy-ng",/' > setup.py.mod
         mv setup.py.mod setup.py
         python setup.py sdist


### PR DESCRIPTION
I tried using the deps.python.version.major in the PYTHONPATH, but it did not work correctly, so I left it hard-coded to 3.10.

Also, I'm not sure if there's a comment option, but you need to run this as root in order for it to work (it opens low ports), and the script itself will use sudo if not root which will wipe the env and break the PYTHONPATH.