### PR TITLE
fix(opencanaryd)

### DIFF
--- a/projects/github.com/thinkst/opencanary/package.yml
+++ b/projects/github.com/thinkst/opencanary/package.yml
@@ -6,7 +6,7 @@ versions:
   github: thinkst/opencanary
 
 dependencies:
-  python.org: ^3.10
+  python.org: '>=3.10<3.12'
   tcpdump.org: '*'
   openssl.org: '*'
 


### PR DESCRIPTION
While it was building and running fine on my one system, on a clean system pkgx installed py3.12 which broke the package.

Cap python to less than 3.12