### PR TITLE
+tilt -- A toolkit for fixing the pains of microservice development

### DIFF
--- a/projects/tilt.dev/package.yml
+++ b/projects/tilt.dev/package.yml
@@ -1,0 +1,40 @@
+distributable:
+  url: https://github.com/tilt-dev/tilt/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: tilt-dev/tilt
+
+provides:
+  - bin/tilt
+
+build:
+  dependencies:
+    go.dev: ^1.19
+    # python.org: "3.11"
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/tilt
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 1
+    BUILDLOC: "{{prefix}}/bin/tilt"
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+      # - -X main.commit={{.Commit}}
+      # - -X main.date={{.Date}}
+      - -X main.builtBy=pkgx
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+        - -buildmode=pie
+
+test:
+  script:
+    - test "$(tilt version)" = "v{{version}}"

--- a/projects/tilt.dev/package.yml
+++ b/projects/tilt.dev/package.yml
@@ -37,4 +37,4 @@ build:
 
 test:
   script:
-    - test "$(tilt version)" = "v{{version}}"
+    - tilt version | grep "v{{version}}"


### PR DESCRIPTION
https://tilt.dev/
https://github.com/tilt-dev/tilt

> A toolkit for fixing the pains of microservice development.
>
> Are your servers running locally? In Kubernetes? Both? Tilt gives you smart rebuilds and live updates everywhere so that you can make progress.
>
> Define your dev environment as code. For microservice apps on Kubernetes.