### PR TITLE
image magick enable shared

### DIFF
--- a/projects/imagemagick.org/package.yml
+++ b/projects/imagemagick.org/package.yml
@@ -123,11 +123,11 @@ build:
 test:
   dependencies:
     linux:
-      llvm.org: '*'
+      gnu.org/gcc: '*'
   script:
     - magick -version | grep {{version.tag}}
     - pkgx curl "https://upload.wikimedia.org/wikipedia/commons/6/6a/PNG_Test.png" -o a.png
     - magick identify a.png | grep "a.png PNG"
 
     # verify that we can build the rmagick gem
-    - CC=clang pkgx +ruby@3.2.2 +imagemagick.org gem install rmagick
+    - pkgx +ruby@3.2.2 +imagemagick.org gem install rmagick

--- a/projects/imagemagick.org/package.yml
+++ b/projects/imagemagick.org/package.yml
@@ -121,17 +121,11 @@ build:
         - --without-x
 
 test:
-  dependencies:
-    linux:
-      llvm.org: '*'
-  env:
-    CC: clang
-  script:
-    - magick -version | grep {{version.tag}}
-    - pkgx curl "https://upload.wikimedia.org/wikipedia/commons/6/6a/PNG_Test.png" -o a.png
-    - magick identify a.png | grep "a.png PNG"
+  - magick -version | grep {{version.tag}}
+  - pkgx curl "https://upload.wikimedia.org/wikipedia/commons/6/6a/PNG_Test.png" -o a.png
+  - magick identify a.png | grep "a.png PNG"
 
-    # verify that we can build the rmagick gem
-    #NOTE only darwin because honestly it looks like the rmagick gem build process is broken on Linux
-    - run: pkgx +ruby@3.2.2 gem install rmagick
-      if: darwin
+  # verify that we can build the rmagick gem
+  #NOTE only darwin because honestly it looks like the rmagick gem build process is broken on Linux
+  - run: pkgx +ruby@3.2.2 gem install rmagick
+    if: darwin

--- a/projects/imagemagick.org/package.yml
+++ b/projects/imagemagick.org/package.yml
@@ -88,7 +88,7 @@ build:
       - --disable-silent-rules
       - --disable-opencl
       - --enable-static
-      - --disable-shared
+      - --enable-shared  # https://github.com/pkgxdev/pantry/issues/4030
       - --with-png=yes
       - --with-tiff=yes
       - --with-jxl=yes
@@ -126,3 +126,6 @@ test:
     - magick -version | grep {{version.tag}}
     - curl "https://upload.wikimedia.org/wikipedia/commons/6/6a/PNG_Test.png" -o a.png
     - magick identify a.png | grep "a.png PNG"
+
+    # verify that we can build the rmagick gem
+    - pkgx +ruby@3.2.2 +imagemagick.org gem install rmagick

--- a/projects/imagemagick.org/package.yml
+++ b/projects/imagemagick.org/package.yml
@@ -55,7 +55,7 @@ dependencies:
 
 runtime:
   env:
-    MAGICK_HOME: "{{prefix}}"
+    MAGICK_HOME: ${{prefix}}
 
 build:
   script:
@@ -88,7 +88,8 @@ build:
       - --disable-silent-rules
       - --disable-opencl
       - --enable-static
-      - --enable-shared  # https://github.com/pkgxdev/pantry/issues/4030
+      - --disable-installed  # makes us relocatable
+      - --enable-shared      # https://github.com/pkgxdev/pantry/issues/4030
       - --with-png=yes
       - --with-tiff=yes
       - --with-jxl=yes

--- a/projects/imagemagick.org/package.yml
+++ b/projects/imagemagick.org/package.yml
@@ -130,4 +130,4 @@ test:
     - magick identify a.png | grep "a.png PNG"
 
     # verify that we can build the rmagick gem
-    - pkgx +ruby@3.2.2 +imagemagick.org gem install rmagick
+    - CC=clang pkgx +ruby@3.2.2 +imagemagick.org gem install rmagick

--- a/projects/imagemagick.org/package.yml
+++ b/projects/imagemagick.org/package.yml
@@ -123,11 +123,15 @@ build:
 test:
   dependencies:
     linux:
-      gnu.org/gcc: '*'
+      llvm.org: '*'
+  env:
+    CC: clang
   script:
     - magick -version | grep {{version.tag}}
     - pkgx curl "https://upload.wikimedia.org/wikipedia/commons/6/6a/PNG_Test.png" -o a.png
     - magick identify a.png | grep "a.png PNG"
 
     # verify that we can build the rmagick gem
-    - pkgx +ruby@3.2.2 +imagemagick.org gem install rmagick
+    #NOTE only darwin because honestly it looks like the rmagick gem build process is broken on Linux
+    - run: pkgx +ruby@3.2.2 gem install rmagick
+      if: darwin

--- a/projects/imagemagick.org/package.yml
+++ b/projects/imagemagick.org/package.yml
@@ -122,10 +122,11 @@ build:
 
 test:
   dependencies:
-    curl.se: '*'
+    linux:
+      llvm.org: '*'
   script:
     - magick -version | grep {{version.tag}}
-    - curl "https://upload.wikimedia.org/wikipedia/commons/6/6a/PNG_Test.png" -o a.png
+    - pkgx curl "https://upload.wikimedia.org/wikipedia/commons/6/6a/PNG_Test.png" -o a.png
     - magick identify a.png | grep "a.png PNG"
 
     # verify that we can build the rmagick gem


### PR DESCRIPTION
Refs #4030.

Tests fail because then image magick cannot find its dylibs. Relocatability bug.