### PR TITLE
add `air`

### DIFF
--- a/projects/github.com/cosmtrek/air/package.yml
+++ b/projects/github.com/cosmtrek/air/package.yml
@@ -1,0 +1,29 @@
+distributable:
+  url: https://github.com/cosmtrek/air/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+display-name: air
+
+versions:
+  github: cosmtrek/air
+
+provides:
+  - bin/air
+
+build:
+  script: |
+    make build
+    mkdir -p "{{ prefix }}"/bin
+    mv air "{{ prefix }}"/bin
+  env:
+    linux:
+      LDFLAGS:
+        - -buildmode=pie
+  dependencies:
+    git-scm.org: '*'
+    go.dev: ^1.20
+    gnu.org/make: '*'
+
+test:
+  air -v
+


### PR DESCRIPTION
adds [cosmtrek/air](https://github.com/cosmtrek/air).

Fixes for #3668.