### PR TITLE
+grpcurl — Like cURL, but for gRPC: CLI for interacting with gRPC servers

### DIFF
--- a/projects/fullstory.com/grpcurl/package.yml
+++ b/projects/fullstory.com/grpcurl/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/fullstorydev/grpcurl/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: fullstorydev/grpcurl
+
+provides:
+  - bin/grpcurl
+
+build:
+  dependencies:
+    go.dev: ^1.19
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/grpcurl
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: "{{prefix}}/bin/grpcurl"
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+        - -buildmode=pie
+
+test:
+  script:
+    - test "$(grpcurl -version 2>&1)" = "grpcurl {{version}}"


### PR DESCRIPTION
https://github.com/fullstorydev/grpcurl

> Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers