### PR TITLE
add `pcsc-lite`

### DIFF
--- a/projects/pcsclite.apdu.fr/package.yml
+++ b/projects/pcsclite.apdu.fr/package.yml
@@ -12,16 +12,11 @@ versions:
     - /pcsc-lite-/
     - /\.tar/
 
-platforms:
-  - darwin
-  - linux
-
 dependencies:
-  libusb.info: '*'
+  libusb.info: ^1
 
 build:
   dependencies:
-    freedesktop.org/pkg-config: '*'
     cmake.org: ^3
   script: |
     ./configure \
@@ -36,8 +31,4 @@ build:
 provides:
   - bin/pcscd
 
-test:
-  dependencies:
-    libusb.info: '*'
-  script:
-    pcscd --version
+test: pcscd --version

--- a/projects/pcsclite.apdu.fr/package.yml
+++ b/projects/pcsclite.apdu.fr/package.yml
@@ -21,14 +21,13 @@ build:
   dependencies:
     cmake.org: ^3
     github.com/westes/flex: '*'
+    perl.org: ^5 # pod2man
   script: |
     ./configure \
-      --disable-udev \
       --disable-dependency-tracking \
       --disable-silent-rules \
       --prefix={{ prefix }} \
-      --sysconfdir=/etc \
-      --disable-libsystemd
+      --sysconfdir=/etc
     make install
 
 provides:

--- a/projects/pcsclite.apdu.fr/package.yml
+++ b/projects/pcsclite.apdu.fr/package.yml
@@ -14,6 +14,8 @@ versions:
 
 dependencies:
   libusb.info: ^1
+  linux:
+    systemd.io: ^254 # libudev
 
 build:
   dependencies:

--- a/projects/pcsclite.apdu.fr/package.yml
+++ b/projects/pcsclite.apdu.fr/package.yml
@@ -24,7 +24,7 @@ build:
       --disable-dependency-tracking \
       --disable-silent-rules \
       --prefix={{ prefix }} \
-      --sysconfdir=/etc \ # probably wrong
+      --sysconfdir=/etc \
       --disable-libsystemd
     make install
 

--- a/projects/pcsclite.apdu.fr/package.yml
+++ b/projects/pcsclite.apdu.fr/package.yml
@@ -23,12 +23,17 @@ build:
     github.com/westes/flex: '*'
     perl.org: ^5 # pod2man
   script: |
-    ./configure \
-      --disable-dependency-tracking \
-      --disable-silent-rules \
-      --prefix={{ prefix }} \
-      --sysconfdir=/etc
+    ./configure $ARGS
     make install
+  env:
+    ARGS:
+      - --disable-dependency-tracking
+      - --disable-silent-rules
+      - --prefix={{ prefix }}
+      - --sysconfdir=/etc
+    darwin:
+      ARGS:
+        - --disable-libsystemd
 
 provides:
   - bin/pcscd

--- a/projects/pcsclite.apdu.fr/package.yml
+++ b/projects/pcsclite.apdu.fr/package.yml
@@ -18,6 +18,7 @@ dependencies:
 build:
   dependencies:
     cmake.org: ^3
+    github.com/westes/flex: '*'
   script: |
     ./configure \
       --disable-udev \

--- a/projects/pcsclite.apdu.fr/package.yml
+++ b/projects/pcsclite.apdu.fr/package.yml
@@ -7,7 +7,10 @@ display-name: pcsc-lite
 
 versions:
   url: https://pcsclite.apdu.fr/files/
-  match: /href=.*?pcsc-lite[._-]v?(\d+(?:\.\d+)+)\.t/i # probably wrong
+  match: /pcsc-lite-\d+(\.\d+)+\.tar/
+  strip:
+    - /pcsc-lite-/
+    - /\.tar/
 
 platforms:
   - darwin

--- a/projects/pcsclite.apdu.fr/pcsc-lite/package.yml
+++ b/projects/pcsclite.apdu.fr/pcsc-lite/package.yml
@@ -1,0 +1,40 @@
+distributable:
+  url: https://pcsclite.apdu.fr/files/pcsc-lite-{{ version }}.tar.bz2
+  strip-components: 1
+  ref: v{{version}}}
+
+display-name: pcsc-lite
+
+versions:
+  url: https://pcsclite.apdu.fr/files/
+  match: /href=.*?pcsc-lite[._-]v?(\d+(?:\.\d+)+)\.t/i # probably wrong
+
+platforms:
+  - darwin
+  - linux
+
+dependencies:
+  libusb.info: '*'
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+    cmake.org: ^3
+  script: |
+    ./configure \
+      --disable-udev \
+      --disable-dependency-tracking \
+      --disable-silent-rules \
+      --prefix={{ prefix }} \
+      --sysconfdir=/etc \ # probably wrong
+      --disable-libsystemd
+    make install
+
+provides:
+  - bin/pcscd
+
+test:
+  dependencies:
+    libusb.info: '*'
+  script:
+    pcscd --version


### PR DESCRIPTION
adds [`pcsc-lite`](https://pcsclite.apdu.fr/)

port from https://github.com/Homebrew/homebrew-core/blob/1c42d6641601256648ad8dc7d56493dd01a114ed/Formula/p/pcsc-lite.rb
