### PR TITLE
+usql — Universal SQL client

### DIFF
--- a/projects/github.com/xo/usql/package.yml
+++ b/projects/github.com/xo/usql/package.yml
@@ -1,0 +1,39 @@
+distributable:
+  url: https://github.com/xo/usql/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: xo/usql
+
+provides:
+  - bin/usql
+
+build:
+  dependencies:
+    go.dev: ^1.21
+    crates.io/sd: "*"
+  script:
+    - sd 0.0.0-dev v{{version}} text/text.go
+    - go mod download
+    - mkdir -p "{{ prefix }}"/bin
+    - go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 1
+    BUILDLOC: "{{prefix}}/bin/usql"
+    LDFLAGS:
+      - -s
+      - -w
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+        - -buildmode=pie
+
+test:
+  script:
+    # No LDFLAGS
+    # https://github.com/xo/usql/blob/master/text/text.go#L13
+    - test "$(usql --version)" = "usql {{version}}"

--- a/projects/github.com/xo/usql/package.yml
+++ b/projects/github.com/xo/usql/package.yml
@@ -36,4 +36,4 @@ test:
   script:
     # No LDFLAGS
     # https://github.com/xo/usql/blob/master/text/text.go#L13
-    - test "$(usql --version)" = "usql {{version}}"
+    - test "$(usql --version)" = "usql v{{version}}"


### PR DESCRIPTION
https://github.com/xo/usql/tree/master

> Universal command-line interface for SQL databases
>
> usql is a universal command-line interface for PostgreSQL, MySQL, Oracle Database, SQLite3, Microsoft SQL Server, [and many other databases](https://github.com/xo/usql/tree/master#database-support) including NoSQL and non-relational databases!
>
> usql provides a simple way to work with [SQL and NoSQL databases](https://github.com/xo/usql/tree/master#database-support) via a command-line inspired by PostgreSQL's psql.
>
> Database administrators and developers that would prefer to work with a tool like psql with non-PostgreSQL databases, will find usql intuitive, easy-to-use, and a great replacement for the command-line clients/tools for other databases.