### PR TITLE
fix turso build

### DIFF
--- a/projects/turso.tech/package.yml
+++ b/projects/turso.tech/package.yml
@@ -13,6 +13,7 @@ build:
   script:
     - echo "{{version}}" > internal/cmd/version.txt
     - go mod download
+    - go generate --tags=prod ./...
     - go build $ARGS -ldflags="$LDFLAGS" ./cmd/turso
   dependencies:
     go.dev: ^1.20

--- a/projects/turso.tech/package.yml
+++ b/projects/turso.tech/package.yml
@@ -33,6 +33,8 @@ build:
       # or segmentation fault
       # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
       LDFLAGS:
-      - -buildmode=pie
+        - -buildmode=pie
 
-test: turso --version | grep {{version}}
+test:
+  - turso --version
+  - 'test "$(turso db locations 2>&1 || true)" = "Error: user not logged in, please login with turso auth login"'

--- a/projects/turso.tech/package.yml
+++ b/projects/turso.tech/package.yml
@@ -35,6 +35,4 @@ build:
       LDFLAGS:
         - -buildmode=pie
 
-test:
-  - turso --version
-  - 'test "$(turso db locations 2>&1 || true)" = "Error: user not logged in, please login with turso auth login"'
+test: 'test "$(turso db locations 2>&1 || true)" = "Error: user not logged in, please login with turso auth login"'


### PR DESCRIPTION
I'm new at using pkgx so apologies if I'm doing something wrong.

The turso cli does not work currently, it gives the following error when running any command against [turso.tech](https://turso.tech):

```
Error: failed to get database listing: Get "https://api.turso.tech/v1/databases": net/http: invalid header field value for "Tursocliversion"
```

I'm not a fluent gopher either but I managed to get it working by adding a `go generate...`. I copied it from [This file](https://github.com/tursodatabase/turso-cli/blob/main/.goreleaser.yaml)