### PR TITLE
[WIP: error during build script] +clojure

### DIFF
--- a/projects/clojure.org/package.yml
+++ b/projects/clojure.org/package.yml
@@ -1,0 +1,25 @@
+distributable:
+  url: https://download.clojure.org/install/clojure-tools-{{ version }}.tar.gz
+  strip-components: 1
+
+versions:
+  - 1.11.1.1413
+
+display-name: clojure.org
+
+provides:
+- bin/clojure
+- bin/clj # depends on rlwrap
+
+dependencies:
+  openjdk.org: 20.0.2.9
+
+build:
+  script: |
+    mkdir -p {{ prefix }}
+
+test:
+  script: |
+    clojure --version
+    test "$(clojure --version)" = "{{ version }}"
+    clojure -e '(prn :abc)'


### PR DESCRIPTION
Invariably when `pkg build` reaches the stage of executing the `build` `script` in this `package.yml` the following error is printed and building fails.

What might I be missing that is causing such an issue?

I presume users are able to build/test/use a local pantry entry without relying on a remote registry, especially for contributions, but perhaps this is not the case and there is some "behind the scenes" work that is needed before this can advance.

```
...
+ mkdir -p /Users/theuser/.pkgx/clojure.org/v1.11.1.1413
  clojure.org
error: Uncaught DownloadError: http: 404: https://dist.pkgx.dev/clojure.org/darwin/x86-64/versions.txt
    throw new DownloadError(rsp.status, {src: url})
          ^
    at Object.get (https://deno.land/x/libpkgx@v0.14.1/src/hooks/useInventory.ts:36:11)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Object.select (https://deno.land/x/libpkgx@v0.14.1/src/hooks/useInventory.ts:18:20)
    at async file:///Users/xento/.pkgx/pkgx.sh/brewkit/v0.55.8/libexec/install.ts:15:21
```