### PR TITLE
+radicle -- Sovereign p2p network for code collaboration, built on top of Git

### DIFF
--- a/projects/radicle.xyz/package.yml
+++ b/projects/radicle.xyz/package.yml
@@ -1,23 +1,23 @@
 distributable:
-  url: https://github.com/radicle-dev/radicle-cli/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/radicle-dev/heartwood/archive/1af9480b088c3eec800040a1bdcd09941a31bcf3.tar.gz
   strip-components: 1
 
 versions:
-  github: radicle-dev/radicle-cli
+  - 2023.11.30
 
 dependencies:
   openssl.org: ^1.1.1
 
 build:
+  working-directory: radicle-cli
   dependencies:
     rust-lang.org/cargo: ^0
     cmake.org: ^3
     freedesktop.org/pkg-config: ^0.29
   script: |
-    cargo install --locked --path . --root {{prefix}}
+    cargo install --path . --root {{prefix}}
 
-test:
-  rad --help
+test: rad --help
 
 provides:
   - bin/rad

--- a/projects/radicle.xyz/package.yml
+++ b/projects/radicle.xyz/package.yml
@@ -7,6 +7,7 @@ versions:
 
 dependencies:
   openssl.org: ^1.1.1
+  zlib.net: "*"
 
 build:
   dependencies:

--- a/projects/radicle.xyz/package.yml
+++ b/projects/radicle.xyz/package.yml
@@ -9,40 +9,24 @@ dependencies:
   openssl.org: ^1.1.1
 
 build:
-  working-directory: radicle-cli
   dependencies:
-    rust-lang.org/cargo: ^0
+    rust-lang.org: ">=1.65"
+    rust-lang.org/cargo: "*"
     cmake.org: ^3
     freedesktop.org/pkg-config: ^0.29
-  script: |
-    cargo install --path . --root {{prefix}}
+  script:
+    - cargo install --path radicle-cli --force --locked --root {{prefix}}
+    - cargo install --path radicle-node --force --locked --root {{prefix}}
+    - cargo install --path radicle-remote-helper --force --locked --root {{prefix}}
 
-test: rad --help
+test:
+  script:
+    - rad --help
+    - rad --version
+    - radicle-node --help
+    - radicle-node --version
 
 provides:
   - bin/rad
-  - bin/git-remote-rad
-  - bin/rad-account
-  - bin/rad-auth
-  - bin/rad-checkout
-  - bin/rad-clone
-  - bin/rad-edit
-  - bin/rad-ens
-  - bin/rad-gov
-  - bin/rad-help
-  - bin/rad-init
-  - bin/rad-inspect
-  - bin/rad-issue
-  - bin/rad-ls
-  - bin/rad-merge
-  - bin/rad-patch
-  - bin/rad-path
-  - bin/rad-pull
-  - bin/rad-push
-  - bin/rad-remote
-  - bin/rad-reward
-  - bin/rad-rm
-  - bin/rad-self
-  - bin/rad-sync
-  - bin/rad-track
-  - bin/rad-untrack
+  - bin/radicle-node
+  - bin/radicle-remote-helper


### PR DESCRIPTION
> Radicle is a sovereign peer-to-peer network for code collaboration, built on top of Git.

### Changes

- New website [**radicle.xyz**](https://radicle.xyz/#try)
- Renamed pantry namespace
- New repo ([`radicle-dev/heartwood`](https://github.com/radicle-dev/heartwood)) has no Git tags :(
- Much fewer provided binaries

### Questions

- Is modifying everything like this okay, or would it be better to preserve the initial `radicle.org` project and create a new one?
- What happens if both pantries provide `rad` but one of the underlying projects has been deprecated?