### PR TITLE
add openjdk to appium deps

### DIFF
--- a/projects/appium.io/package.yml
+++ b/projects/appium.io/package.yml
@@ -28,5 +28,5 @@ provides:
   - bin/appium
 
 test: 
-  appium --version | grep {{version}}
-  appium driver install uiautomator2
+  - appium --version | grep {{version}}
+  - appium driver install uiautomator2

--- a/projects/appium.io/package.yml
+++ b/projects/appium.io/package.yml
@@ -11,6 +11,7 @@ versions:
 dependencies:
   npmjs.com: '*'
   nodejs.org: ^10.13.0 || ^12 || ^14 || ^16 || ^18 || ^20
+  openjdk.org: '*'
 
 build:
   dependencies:

--- a/projects/appium.io/package.yml
+++ b/projects/appium.io/package.yml
@@ -27,4 +27,6 @@ build:
 provides:
   - bin/appium
 
-test: appium --version | grep {{version}}
+test: 
+  appium --version | grep {{version}}
+  appium driver install uiautomator2


### PR DESCRIPTION
it isn't needed for building but is needed for most operations of the package.
Sorry for not initially including this.