### PR TITLE
fix(php)

### DIFF
--- a/projects/php.net/package.yml
+++ b/projects/php.net/package.yml
@@ -59,7 +59,7 @@ build:
         fi
       if: linux
     - ./configure $ARGS
-    - make --jobs {{ hw.concurrency }} install
+    - make install
 
     # clean up our fake /usr/bin/cpp
     - run: |


### PR DESCRIPTION
multiple arches and versions are getting failures on zend_execute.o, claiming 0 bytes. looks like concurrency, maybe.
