### PR TITLE
Props no longer need escaping which means fix them

### DIFF
--- a/projects/facebook.com/folly/package.yml
+++ b/projects/facebook.com/folly/package.yml
@@ -35,10 +35,10 @@ build:
       prop: |
         /^REMOVE_MATCHES_FROM_LISTS\(files hfiles/ {
           i\\
-        string(REPLACE "+" "\\\\\\\\+" ESCAPED_FOLLY_DIR "\\\${FOLLY_DIR}")
+        string(REPLACE "+" "\\\\\\\\+" ESCAPED_FOLLY_DIR "\${FOLLY_DIR}")
         }
 
-        s/\^\\\$\{FOLLY_DIR\}/^\\\$\{ESCAPED_FOLLY_DIR\}/g
+        s/\^\$\{FOLLY_DIR\}/^\$\{ESCAPED_FOLLY_DIR\}/g
 
     - cmake $ARGS -DBUILD_SHARED_LIBS=ON -S . -B shared
     - cmake --build shared

--- a/projects/github.com/julienXX/terminal-notifier/package.yml
+++ b/projects/github.com/julienXX/terminal-notifier/package.yml
@@ -21,8 +21,7 @@ build:
       working-directory: ${{prefix}}/bin
       prop: |
         #!/bin/bash
-    
-        \$(dirname \$0)/../terminal-notifier.app/Contents/MacOS/terminal-notifier \$*
+        $(dirname $0)/../terminal-notifier.app/Contents/MacOS/terminal-notifier $*
 
 provides:
   - bin/terminal-notifier

--- a/projects/mandoc.bsd.lv/package.yml
+++ b/projects/mandoc.bsd.lv/package.yml
@@ -33,7 +33,7 @@ build:
         MANM_ROFF=mandoc_roff
         MANM_EQN=eqn
         MANM_TBL=tbl
-        OSNAME='$(uname -a)'
+        OSNAME=$(uname -a)
         MANPATH_DEFAULT={{prefix}}/share/man
         HAVE_MANPATH=0
         STATIC=

--- a/projects/netpbm.sourceforge.net/package.yml
+++ b/projects/netpbm.sourceforge.net/package.yml
@@ -42,27 +42,27 @@ build:
     - run: sed -i.bak 's|CFLAGS_SHLIB = |CFLAGS_SHLIB = -fPIC|g' config.mk
       if: linux
     - rm config.mk.bak
-    
+
     - make --jobs {{hw.concurrency}}
     - make --jobs {{hw.concurrency}} package pkgdir=$SRCROOT/stage
     - run: |
         mkdir -p {{prefix}}
         mv bin include lib misc {{prefix}}/
-        
+
         mkdir -p {{prefix}}/lib/pkgconfig
         cp $PROP {{prefix}}/lib/pkgconfig/netpbm.pc
       working-directory: stage
       prop: |
-        prefix=\${pcfiledir}/../..
-        exec_prefix=\${prefix}
-        libdir=\${exec_prefix}/lib
-        includedir=\${prefix}/include/netpbm
+        prefix=${pcfiledir}/../..
+        exec_prefix=${prefix}
+        libdir=${exec_prefix}/lib
+        includedir=${prefix}/include/netpbm
 
         Name: Netpbm
         Description: Graphics utilities
         Version: {{version}}
-        Libs: -L\${libdir} -lmylibrary
-        Cflags: -I\${includedir}
+        Libs: -L${libdir} -lmylibrary
+        Cflags: -I${includedir}
   env:
     CFLAGS: "-Wno-implicit-function-declaration $CFLAGS"
 provides:

--- a/projects/podman.io/package.yml
+++ b/projects/podman.io/package.yml
@@ -28,10 +28,11 @@ build:
     - run: |
         sed -i.bak -f $PROP config_{darwin,linux}.go
         rm config_{darwin,linux}.go.bak
-      working-directory: vendor/github.com/containers/common/pkg/config
+      working-directory:
+        vendor/github.com/containers/common/pkg/config
       prop: |-
         s_\(^var defaultHelperBinariesDir.*\)_\
-        \1\n        "\$BINDIR/../../../$GVISOR_MAJOR/bin",_
+        \1\n        "$BINDIR/../../../github.com/containers/gvisor-tap-vsock/v{{deps.github.com/containers/gvisor-tap-vsock.version.major}}/bin",_
 
     - mkdir -p "{{ prefix }}"/bin
     - make --jobs {{ hw.concurrency }} podman-remote
@@ -47,11 +48,6 @@ build:
         ln -s podman "{{ prefix }}"/bin/podman-remote
       if: darwin
   env:
-    # path for gvproxy to add to platform config
-    GVISOR_MAJOR: |-
-      $(cd "{{deps.github.com/containers/gvisor-tap-vsock.prefix}}/../\
-      /v{{deps.github.com/containers/gvisor-tap-vsock.version.major}}" \
-      && pwd | sed -e "s_$PKGX_DIR/__")
     CGO_ENABLED: 1
     linux:
       EXTRA_LDFLAGS: -buildmode=pie


### PR DESCRIPTION
Strictly this was a breaking change that should require brewkit v2.

I didn’t consider this, and it’s too late. My bad.