### PR TITLE
chore(spacetimedb): Bump from v0.6.1 to v0.8.0

### DIFF
--- a/projects/spacetimedb.com/package.yml
+++ b/projects/spacetimedb.com/package.yml
@@ -1,12 +1,12 @@
 distributable:
-  url: https://github.com/clockworklabs/SpacetimeDB/archive/refs/tags/v0.6.1-beta.tar.gz
+  url: https://github.com/clockworklabs/SpacetimeDB/archive/refs/tags/v0.8.0-beta.tar.gz
   strip-components: 1
 
 provides:
   - bin/spacetime
 
 versions:
-  - 2023.8.12
+  - 2023.12.8
   # FIXME once there has been an official release
   # See https://github.com/orgs/teaxyz/discussions/321
   # github: clockworklabs/SpacetimeDB


### PR DESCRIPTION
https://github.com/clockworklabs/SpacetimeDB
https://github.com/clockworklabs/SpacetimeDB/releases/tag/v0.8.0-beta
https://spacetimedb.com/

Original PR: https://github.com/pkgxdev/pantry/pull/3062