### PR TITLE
fix(opensearch): don't include the jna library on mac for x86-64

### DIFF
--- a/projects/opensearch.org/package.yml
+++ b/projects/opensearch.org/package.yml
@@ -24,6 +24,11 @@ build:
       openblas.net: "*"
 
   script:
+      # there seems to be a loader bug with trying to dlopen libc on macos 12 and earlier.
+      # remove this step when macos 12 and under are no longer supported.
+    - run: |
+        sed -i 's|JNAKernel32Library.getInstance();|//JNAKernel32Library.getInstance();|' server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+      if: darwin/x86-64
     - gradle -Dbuild.snapshot=false ":distribution:archives:no-jdk-{{hw.platform}}-tar:assemble"
     - run: tar --strip-components=1 -xf $SRCROOT/distribution/archives/no-jdk-{{hw.platform}}-tar/build/distributions/opensearch-*.tar.gz
       working-directory: ${{prefix}}
@@ -31,7 +36,6 @@ build:
     # remove this step when macos 12 and under are no longer supported.
     - run: |
         rm -f lib/jna-*.jar
-        sed -i.bak 's|JNAKernel32Library.getInstance();|//JNAKernel32Library.getInstance();|' server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
       if: darwin/x86-64
       working-directory: ${{prefix}}
     - run: 'sed -i "s|#\s*cluster.name: .*|cluster.name: opensearch_pkgx|" opensearch.yml'

--- a/projects/opensearch.org/package.yml
+++ b/projects/opensearch.org/package.yml
@@ -27,6 +27,11 @@ build:
     - gradle -Dbuild.snapshot=false ":distribution:archives:no-jdk-{{hw.platform}}-tar:assemble"
     - run: tar --strip-components=1 -xf $SRCROOT/distribution/archives/no-jdk-{{hw.platform}}-tar/build/distributions/opensearch-*.tar.gz
       working-directory: ${{prefix}}
+    # there seems to be a loader bug with trying to dlopen libc on macos 12 and earlier.
+    # remove this step when macos 12 and under are no longer supported.
+    - run: rm -f lib/jna-*.jar
+      if: darwin/x86-64
+      working-directory: ${{prefix}}
     - run: 'sed -i "s|#\s*cluster.name: .*|cluster.name: opensearch_pkgx|" opensearch.yml'
       working-directory: ${{prefix}}/config
 

--- a/projects/opensearch.org/package.yml
+++ b/projects/opensearch.org/package.yml
@@ -29,7 +29,9 @@ build:
       working-directory: ${{prefix}}
     # there seems to be a loader bug with trying to dlopen libc on macos 12 and earlier.
     # remove this step when macos 12 and under are no longer supported.
-    - run: rm -f lib/jna-*.jar
+    - run: |
+        rm -f lib/jna-*.jar
+        sed -i.bak 's|JNAKernel32Library.getInstance();|//JNAKernel32Library.getInstance();|' server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
       if: darwin/x86-64
       working-directory: ${{prefix}}
     - run: 'sed -i "s|#\s*cluster.name: .*|cluster.name: opensearch_pkgx|" opensearch.yml'


### PR DESCRIPTION
there seems to be some linker issue with loading libc. calling these native functions doesn't seem strictly necessary. maybe better that the package works at all.

in macos 13 and later, it works fine, so maybe this workaround could be removed when macos 12 is no longer supported