### PR TITLE
fix(ruby-lang.org)

### DIFF
--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -80,7 +80,8 @@ build:
     - run: sed -i.bak
         -e 's|$(DESTDIR){{prefix}}|$(topdir)|g'
         -e 's|CONFIG\["topdir"\] = .*|CONFIG\["topdir"\] = TOPDIR|g'
-        -e 's|\(["'\'']\)/.*/brewkit/|TOPDIR \+ \1/../../pkgx.sh/brewkit/|g'
+        -e 's|CONFIG\["INSTALL"\].*|CONFIG\["INSTALL"\] = "/usr/bin/install"|g'
+        -e 's|CONFIG\["MJIT_CC"\].*|CONFIG\["MJIT_CC"\] = "/usr/bin/cc"|g'
         rbconfig.rb
       working-directory: ${{prefix}}/lib/ruby/{{version.marketing}}.0
   env:

--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -80,8 +80,8 @@ build:
     - run: sed -i.bak
         -e 's|$(DESTDIR){{prefix}}|$(topdir)|g'
         -e 's|CONFIG\["topdir"\] = .*|CONFIG\["topdir"\] = TOPDIR|g'
-        -e 's|CONFIG\["INSTALL"\].*|CONFIG\["INSTALL"\] = "/usr/bin/install"|g'
-        -e 's|CONFIG\["MJIT_CC"\].*|CONFIG\["MJIT_CC"\] = "/usr/bin/cc"|g'
+        -e 's|CONFIG\["INSTALL"\] =.*|CONFIG\["INSTALL"\] = "/usr/bin/install"|g'
+        -e 's|CONFIG\["MJIT_CC"\] =.*|CONFIG\["MJIT_CC"\] = "/usr/bin/cc"|g'
         rbconfig.rb
       working-directory: ${{prefix}}/lib/ruby/{{version.marketing}}.0
   env:

--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -80,6 +80,7 @@ build:
     - run: sed -i.bak
         -e 's|$(DESTDIR){{prefix}}|$(topdir)|g'
         -e 's|CONFIG\["topdir"\] = .*|CONFIG\["topdir"\] = TOPDIR|g'
+        -e 's|\(["'\'']\)/.*/brewkit/|TOPDIR \+ \1/../../pkgx.sh/brewkit/|g'
         rbconfig.rb
       working-directory: ${{prefix}}/lib/ruby/{{version.marketing}}.0
   env:


### PR DESCRIPTION
it appears there are a few hardcoded paths from ci that made it into the packaged rbconfig.rb. this breaks installation of gems that require native compilation. so, lets patch that up