### PR TITLE
fix(postgresql.org): install contrib extensions

### DIFF
--- a/projects/postgresql.org/package.yml
+++ b/projects/postgresql.org/package.yml
@@ -23,12 +23,17 @@ build:
     freedesktop.org/pkg-config: '*'
     #gnu.org/gcc: '*'
     gnu.org/bison: '*'
+    gnu.org/sed: '*'
     github.com/westes/flex: ^2.5.31
     perl.org: '*'
   script: |
     # remove `-w`` from CFLAGS, because it causes build to fail, ironically.
     # `./configure` *specifically* checks that certain warnings are emitted.
     export CFLAGS="$(echo $CFLAGS | tr ' ' '\n' | sed -e '/^-w$/d' | tr '\n' ' ')"
+
+    # disable sgml doc generation, since that seems to fail.
+    # sorry all you sgml-heads out there
+    sed -i 's|\([^\t]*sgml.*\)$|#\1|' GNUmakefile.in doc/src/Makefile
 
     ./configure $ARGS
     make --jobs {{ hw.concurrency }}

--- a/projects/postgresql.org/package.yml
+++ b/projects/postgresql.org/package.yml
@@ -51,6 +51,9 @@ build:
     darwin:
       LDFLAGS:
         - -headerpad_max_install_names $LDFLAGS
+    linux:
+      CFLAGS:
+        - -Wno-incompatible-function-pointer-types $CFLAGS
 
 provides:
   - bin/clusterdb

--- a/projects/postgresql.org/package.yml
+++ b/projects/postgresql.org/package.yml
@@ -32,7 +32,7 @@ build:
 
     ./configure $ARGS
     make --jobs {{ hw.concurrency }}
-    make install
+    make install-world
   env:
     CC: clang
     CXX: clang++


### PR DESCRIPTION
in the homebrew formula, postgres does `make install-world`, not just `make install`, which installs extensions under the `contrib/` source dir.

in my case, i need the pg_trgm (trigram index) extension