### PR TITLE
fix(ruby): include sitedir in rbconfig

### DIFF
--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -96,7 +96,6 @@ build:
       - --disable-multiarch                        # ^^
       - --with-vendordir=no     # is empty so don’t pollute
       - --with-vendorarchdir=no # ^^
-      - --with-sitedir=no       # ^^
       - --with-sitearchdir=no   # ^^
       - --enable-yjit  # https://github.com/pkgxdev/pantry/issues/3538
 


### PR DESCRIPTION
ruby on rails depends on bootsnap which requires it to be defined. otherwise, it crashes when the app starts.

i admittedly don't know the history of why it was originally removed, but the build seems to work and it looks like a relative path when it gets generated