### PR TITLE
+dgraph -- GraphQL Database With A Graph Backend

### DIFF
--- a/projects/dgraph.io/package.yml
+++ b/projects/dgraph.io/package.yml
@@ -31,4 +31,4 @@ build:
       LDFLAGS:
         - -buildmode=pie
 
-test: dgraph --version | grep {{version}}
+test: dgraph version | grep {{version}}

--- a/projects/dgraph.io/package.yml
+++ b/projects/dgraph.io/package.yml
@@ -1,0 +1,34 @@
+distributable:
+  url: https://github.com/dgraph-io/dgraph/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: dgraph-io/dgraph
+
+provides:
+  - bin/dgraph
+
+build:
+  dependencies:
+    go.dev: ^1.19
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./dgraph
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: "{{prefix}}/bin/dgraph"
+    LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/dgraph-io/dgraph/x.dgraphVersion={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+        - -buildmode=pie
+
+test: dgraph --version | grep {{version}}


### PR DESCRIPTION
- https://dgraph.io/
- [github repo](https://github.com/dgraph-io/dgraph)
- [ldflags](https://github.com/dgraph-io/dgraph/blob/3754e876e0a5c9889a7410b4d8d3a0751c10432d/dgraph/Makefile#L38-L45)
- Unlimited joins without performance impact
