### PR TITLE
Remove openjdk dependency from ktlint

### DIFF
--- a/projects/ktlint.github.io/package.yml
+++ b/projects/ktlint.github.io/package.yml
@@ -6,13 +6,12 @@ versions:
 
 warnings:
   - vendored
-
-dependencies:
-  openjdk.org: ^20
-
+  
 build:
-  - mkdir -p {{prefix}}/bin
-  - cp ktlint-{{version}}/bin/ktlint {{prefix}}/bin/
+  dependencies:
+    openjdk.org: ^20
+  script:
+    - install -D ktlint-{{version}}/bin/ktlint {{prefix}}/bin/ktlint
 
 provides:
   - bin/ktlint

--- a/projects/ktlint.github.io/package.yml
+++ b/projects/ktlint.github.io/package.yml
@@ -9,7 +9,7 @@ warnings:
 
 dependencies:
   openjdk.org: '*'
-  
+
 build:
   - install -D ktlint-{{version}}/bin/ktlint {{prefix}}/bin/ktlint
 

--- a/projects/ktlint.github.io/package.yml
+++ b/projects/ktlint.github.io/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/pinterest/ktlint/releases/download/{{version}}/ktlint-{{version}}.zip
+  url: https://github.com/pinterest/ktlint/releases/download/{{version}}/ktlint
 
 versions:
   github: pinterest/ktlint
@@ -8,10 +8,7 @@ warnings:
   - vendored
   
 build:
-  dependencies:
-    openjdk.org: ^20
-  script:
-    - install -D ktlint-{{version}}/bin/ktlint {{prefix}}/bin/ktlint
+  - install -D ktlint-{{version}}/bin/ktlint {{prefix}}/bin/ktlint
 
 provides:
   - bin/ktlint

--- a/projects/ktlint.github.io/package.yml
+++ b/projects/ktlint.github.io/package.yml
@@ -1,11 +1,14 @@
 distributable:
-  url: https://github.com/pinterest/ktlint/releases/download/{{version}}/ktlint
+  url: https://github.com/pinterest/ktlint/releases/download/{{version}}/ktlint-{{version}}.zip
 
 versions:
   github: pinterest/ktlint
 
 warnings:
   - vendored
+
+dependencies:
+  openjdk.org: '*'
   
 build:
   - install -D ktlint-{{version}}/bin/ktlint {{prefix}}/bin/ktlint


### PR DESCRIPTION
I'm not certain it's the right solution, but for earlier versions of ktlint at least, I'm pretty sure it depends on earlier versions of java.

Additionally, you could also use another jdk like temurin or zulu, so I'm leaning towards not specifying the dependency at all?