### PR TITLE
Consolidate on unicode.org^73

### DIFF
--- a/projects/dotnet.microsoft.com/package.yml
+++ b/projects/dotnet.microsoft.com/package.yml
@@ -14,7 +14,7 @@ runtime:
     DOTNET_ROOT: "{{prefix}}"
 dependencies:
   linux:
-    unicode.org: ^71
+    unicode.org: ^73
 build:
   dependencies:
     curl.se: '*'

--- a/projects/harfbuzz.org/package.yml
+++ b/projects/harfbuzz.org/package.yml
@@ -10,7 +10,7 @@ dependencies:
   freetype.org: 2
   gnome.org/glib: 2
   graphite.sil.org: '*'
-  unicode.org: ^71
+  unicode.org: ^73
 
 build:
   dependencies:

--- a/projects/mysql.com/package.yml
+++ b/projects/mysql.com/package.yml
@@ -7,7 +7,7 @@ versions:
   strip: /^mysql-/
 
 dependencies:
-  unicode.org: ^71
+  unicode.org: ^73
   libevent.org: ^2
   lz4.org: ^1
   openssl.org: ^1.1

--- a/projects/nodejs.org/package.yml
+++ b/projects/nodejs.org/package.yml
@@ -10,7 +10,7 @@ companions:
 
 dependencies:
   # prior builds of nodejs used our icu4c
-  unicode.org: ^71
+  unicode.org: ^73
   openssl.org: 1.1
   zlib.net: 1
 

--- a/projects/php.net/package.yml
+++ b/projects/php.net/package.yml
@@ -22,7 +22,7 @@ dependencies:
   openssl.org: '*'
   pcre.org/v2: '>=10.30'
   sqlite.org: ^3
-  unicode.org: ^71
+  unicode.org: ^73
   gnu.org/libiconv: ^1
   kerberos.org: ^1
   gnome.org/libxml2: '>=2.9.0<2.12'

--- a/projects/postgresql.org/libpq/package.yml
+++ b/projects/postgresql.org/libpq/package.yml
@@ -13,7 +13,7 @@ dependencies:
   kerberos.org: '*'
   openssl.org: ^1.1
   zlib.net: ^1
-  unicode.org: ^71
+  unicode.org: ^73
   linux:
     gnu.org/readline: '*'
 

--- a/projects/qt.io/package.yml
+++ b/projects/qt.io/package.yml
@@ -15,12 +15,12 @@ dependencies:
   kerberos.org: '*'
   gnome.org/libxslt: '*'
   sqlite.org: '*'
-  unicode.org: ^71
+  unicode.org: ^73
   linux:
     alsa-project.org/alsa-lib: '*'
     freedesktop.org/fontconfig: '*'
     harfbuzz.org: '*'
-    unicode.org: ~71
+    unicode.org: ^73
     dri.freedesktop.org: '*'
     libevent.org: '*'
     x.org/ice: '*'

--- a/projects/rockdaboot.github.io/libpsl/package.yml
+++ b/projects/rockdaboot.github.io/libpsl/package.yml
@@ -4,7 +4,7 @@ distributable:
 versions:
   github: rockdaboot/libpsl
 dependencies:
-  unicode.org: ^71
+  unicode.org: ^73
 build:
   dependencies:
     mesonbuild.com: '*'

--- a/projects/tectonic-typesetting.github.io/package.yml
+++ b/projects/tectonic-typesetting.github.io/package.yml
@@ -12,7 +12,7 @@ dependencies:
   harfbuzz.org: "*"
   libpng.org: "*"
   openssl.org: ^1.1
-  unicode.org: ^71
+  unicode.org: ^73
 
 build:
   dependencies:

--- a/projects/tesseract-ocr.github.io/package.yml
+++ b/projects/tesseract-ocr.github.io/package.yml
@@ -7,7 +7,7 @@ versions:
 
 dependencies:
   cairographics.org: 1
-  unicode.org: 71
+  unicode.org: ^73
   leptonica.org: '*'
   libarchive.org: '*'
   gnome.org/pango: 1
@@ -26,17 +26,17 @@ build:
   script: |
     ./autogen.sh
     ./configure $ARGS
-    make --jobs {{ hw.concurrency }} 
-    make install 
+    make --jobs {{ hw.concurrency }}
+    make install
 
     # install trained datafiles and move to share/tessdata
     wget https://github.com/tesseract-ocr/tessdata/blob/main/eng.traineddata?raw=true -O eng.traineddata
     wget https://github.com/tesseract-ocr/tessdata/blob/main/osd.traineddata?raw=true -O osd.traineddata
     mv eng.traineddata "{{prefix}}"/share/tessdata/
     mv osd.traineddata "{{prefix}}"/share/tessdata/
-    
-  env: 
-    ARGS: 
+
+  env:
+    ARGS:
       - --prefix="{{prefix}}"
       - --disable-dependency-tracking
       - --datarootdir="{{prefix}}"/share
@@ -48,5 +48,5 @@ test:
   dependencies:
     gnu.org/wget: '*'
   script: |
-    wget https://raw.githubusercontent.com/tesseract-ocr/test/6dd816cdaf3e76153271daf773e562e24c928bf5/testing/eurotext.tif 
+    wget https://raw.githubusercontent.com/tesseract-ocr/test/6dd816cdaf3e76153271daf773e562e24c928bf5/testing/eurotext.tif
     tesseract eurotext.tif stdout -l eng


### PR DESCRIPTION
Consolidating on a single unicode.org version is a temporary measure at best. Longer term we need to be able to vary dependencies based on version somehow.