### PR TITLE
Don’t `--sync` for git aliases

### DIFF
--- a/projects/git-scm.org/git-shim
+++ b/projects/git-scm.org/git-shim
@@ -46,13 +46,17 @@ _provides() {
   fi
 }
 
+_is_alias() {
+  git config --get-regexp '^alias\.' | awk '{ print $1 }' | sed 's/alias\.//' | grep -qx "$cmd"
+}
+
 if [ -z "$cmd" ]; then
   exec "$libexec/git" "$@"
 elif [ -x "$libexec/git-$cmd" ] && [ -f "$libexec/git-$cmd" ]; then
   exec "$libexec/git" "$@"
 elif type "git-$cmd" >/dev/null 2>&1; then
   exec "$libexec/git" "$@"
-elif command -v pkgx >/dev/null 2>&1 && pkg=$(_provides); then
+elif ! _is_alias && command -v pkgx >/dev/null 2>&1 && pkg=$(_provides); then
   exec pkgx +"$pkg" "$libexec/git" "$@"
 else
   exec "$libexec/git" "$@"


### PR DESCRIPTION
Fixes #4833