### PR TITLE
fix(yarn)

### DIFF
--- a/projects/yarnpkg.com/package.yml
+++ b/projects/yarnpkg.com/package.yml
@@ -15,13 +15,8 @@ dependencies:
 build:
   dependencies:
     classic.yarnpkg.com: ^1 # works and prevents bootstrapping issues
-    gnu.org/autoconf: ^2 # required to rebuild mozjpeg module :(
-    gnu.org/automake: ^1 # required to rebuild mozjpeg module :(
-    gnu.org/libtool: ^2 # required to rebuild mozjpeg module :(
-    libpng.org: ^1 # required to rebuild mozjpeg module :(
-    freedesktop.org/pkg-config: ^0 # required to rebuild mozjpeg module :(
   script:
-    - yarn install
+    - yarn install --immutable --mode=skip-build
     - yarn build:cli
 
     - run: |


### PR DESCRIPTION
`--mode=skip-build` was the fix; something deep in the dep tree for one of the workspace packages was trying to build `phantomjs` and `mozjpeg`, and failing on linux building the binary bits.