### PR TITLE
fix(ncurses)

### DIFF
--- a/projects/invisible-island.net/ncurses/package.yml
+++ b/projects/invisible-island.net/ncurses/package.yml
@@ -48,6 +48,16 @@ build:
     sed -i.bak 's|{{prefix}}|\$(dirname "\$0")/..|g' {{prefix}}/bin/ncursesw{{version.major}}-config
     rm {{prefix}}/bin/ncursesw{{version.major}}-config.bak
 
+  # libtermcap and libtinfo are provided by ncurses and have the
+  # same api. Help some older packages to find these dependencies.
+  # https://bugs.centos.org/view.php?id=11423
+  # https://bugs.launchpad.net/ubuntu/+source/ncurses/+bug/259139
+  - run: |
+      ln -s libncurses.so libtermcap.so
+      ln -s libncursesw.so libtinfow.so
+    working-directory: ${{prefix}}/lib
+    if: linux
+
   env:
     PCDIR: ${{prefix}}/lib/pkgconfig
     ARGS:


### PR DESCRIPTION
I found this solution [here](https://github.com/Homebrew/homebrew-core/blob/e2b240c98eb652ddde59492a8b622da3db17213a/Formula/n/ncurses.rb#L74C5-L81C8) 

```
    on_linux do
      # libtermcap and libtinfo are provided by ncurses and have the
      # same api. Help some older packages to find these dependencies.
      # https://bugs.centos.org/view.php?id=11423
      # https://bugs.launchpad.net/ubuntu/+source/ncurses/+bug/259139
      lib.install_symlink "libncurses.so" => "libtermcap.so"
      lib.install_symlink "libncurses.so" => "libtinfo.so"
    end
```