### PR TITLE
fix(mvfst)

### DIFF
--- a/projects/facebook.com/mvfst/package.yml
+++ b/projects/facebook.com/mvfst/package.yml
@@ -26,8 +26,9 @@ build:
     # FIXME: seems unable to find XDP_USE_NEED_WAKEUP in the linux kernel headers...
     # https://github.com/torvalds/linux/blob/54be6c6c5ae8e0d93a6c4641cb7528eb0b6ba478/include/uapi/linux/if_xdp.h#L27
     # revert that commit, and the one that depends on it
+    - run: curl https://github.com/facebook/mvfst/commit/3eb7c16af64af5356fd0eec77449fe0e2cf2fd8a.patch | patch -Rp1
+      if: '>=2024.2.5'
     - run: |
-        curl https://github.com/facebook/mvfst/commit/3eb7c16af64af5356fd0eec77449fe0e2cf2fd8a.patch | patch -Rp1
         curl https://github.com/facebook/mvfst/commit/ea57a18ce6758afe7cc556cbb74f669fbc913915.patch | patch -Rp1
         curl https://github.com/facebook/mvfst/commit/c6032bb3bdd8b892fb80c05f2854b090cfa91de5.patch | patch -Rp1
       if: '>=2024.1.29'


### PR DESCRIPTION
finer-grained so we can build 2024.1.29 too.

unfortunately we can't actually build 2024.1.29 now, since it requires an older version of folly, since they're all version-locked together. so, this depends on a solution to https://github.com/pkgxdev/brewkit/discussions/294