### PR TITLE
fix(dhall)

### DIFF
--- a/projects/dhall-lang.org/package.yml
+++ b/projects/dhall-lang.org/package.yml
@@ -18,6 +18,12 @@ build:
     haskell.org: '*'
     haskell.org/cabal: '*'
   script:
+    - run: |
+        sed -i '/unordered-containers/i\
+                -- zlib 0.7.0 fails to find zlib.dylib on macOS\
+                zlib                        >= 0.6.0    \&\& < 0.7 ,' \
+        dhall.cabal
+      if: darwin
     - cabal v2-update
     - mkdir -p {{prefix}}/bin
     - cabal v2-install $ARGS


### PR DESCRIPTION
between CI and CD, zlib-0.7.0 released, which fails to find the library on macOS. haskell is *SO* *FRUSTRATING*.
