### PR TITLE
new/radmind.org/libsnet

### DIFF
--- a/projects/radmind.org/libsnet/package.yml
+++ b/projects/radmind.org/libsnet/package.yml
@@ -1,0 +1,33 @@
+distributable:
+  url: https://sourceforge.net/projects/libsnet/files/libsnet-{{version}}/libsnet-{{version}}.tar.gz
+  strip-components: 1
+
+display-name: libsnet
+
+versions:
+  - 1.0.0
+#   # This is messy: several versions provided .bz2 rather than
+#   # .gz, and the latest version is v15.9, but the earlier
+#   # versions are 15.8, 15.7a, etc. This will only match v15.9,
+#   # but will hopefully match future versions as well
+#   url: https://sourceforge.net/projects/libsnet/files/
+#   match: projects/libsnet/files/libsnet-\d+.\d+.\d+
+#   strip:
+#     - projects/libsnet/files/libsnet-
+
+platforms:
+  - darwin
+  - linux/x86-64
+
+build:
+  dependencies:
+    gnu.org/autoconf: '*'
+    openssl.org: ^1.1.1
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }} install
+  env:
+    ARGS:
+      - --with-ssl={{ deps.openssl.org.prefix }}
+      - --prefix="{{prefix}}"
+      - --libdir="{{prefix}}/lib"


### PR DESCRIPTION
This library is required for radmind. I'm not sure if I should build this as a separate project or if I should just build it when I build radmind. I am going the separate route for now. If you guys think I should just include it in the radmind build I can close this and modify my radmind build.

I am actually the maintainer of radmind, even though I haven't written a line of code for it. It's a long story. Anyway, I'm trying to get radmind in pkgx. This library is on sourceforge and it is never going to be updated because the people who have access wont reply (ok, I didn't try too hard, my understanding is they don't want to do anything with the project anymore). So I've got the 1.0.0 version hardcoded because it's never going to change. I tried to figure out how to extract the version from the webpage but I couldn't figure it out and now I don't see the point. I need to move it to github actually and that's a lot of work and I don't know how to do it right yet. So anyway, I just want to get this packaged for now. let me know what you think.