### PR TITLE
Remove `darwin`-only restriction on `ollama`

### DIFF
--- a/projects/ollama.ai/package.yml
+++ b/projects/ollama.ai/package.yml
@@ -31,13 +31,22 @@ provides:
 
 test:
   qa-required: true
+  dependencies:
+    linux:
+      gitlab.com/procps-ng/procps: '*'
   script:
     # 0.0.19 complains about a missing blobs directory
     - run: mkdir -p ~/.ollama/models/blobs
       if: =0.0.19
-    - killall ollama || true
+    - $KILL ollama || true
+    - sleep 5
     - ollama serve &
     - sleep 5
     - ollama create mario -f ./Modelfile
     - ollama list | grep 'mario'
-    - killall ollama || true
+    - $KILL ollama || true
+  env:
+    darwin:
+      KILL: killall
+    linux:
+      KILL: pkill

--- a/projects/ollama.ai/package.yml
+++ b/projects/ollama.ai/package.yml
@@ -5,12 +5,14 @@ distributable:
 versions:
   github: jmorganca/ollama
 
+dependencies:
+  curl.se/ca-certs: '*'
+
 build:
   dependencies:
     go.dev: ^1.21
     cmake.org: ^3
     git-scm.org: ^2
-    curl.se/ca-certs: '*'
   script:
     - run: |
         git submodule init

--- a/projects/ollama.ai/package.yml
+++ b/projects/ollama.ai/package.yml
@@ -1,8 +1,10 @@
 distributable:
   url: git+https://github.com/jmorganca/ollama
   ref: v{{version}}
+
 versions:
   github: jmorganca/ollama
+
 build:
   dependencies:
     go.dev: ^1.21
@@ -14,11 +16,16 @@ build:
         git submodule update
       if: '>=0.0.18'
     - go generate ./...
-    - go build .
-    - mkdir -p {{prefix}}/bin
-    - install ollama {{prefix}}/bin/
+    - go build -ldflags="$GO_LDFLAGS" -o '{{prefix}}/bin/ollama' .
+  env:
+    linux:
+      GO_LDFLAGS:
+        # else segfaults
+        - -buildmode=pie
+
 provides:
   - bin/ollama
+
 test:
   qa-required: true
   script:

--- a/projects/ollama.ai/package.yml
+++ b/projects/ollama.ai/package.yml
@@ -52,4 +52,4 @@ test:
     darwin:
       KILL: killall
     linux:
-      KILL: pkill
+      KILL: pkill -x

--- a/projects/ollama.ai/package.yml
+++ b/projects/ollama.ai/package.yml
@@ -10,6 +10,7 @@ build:
     go.dev: ^1.21
     cmake.org: ^3
     git-scm.org: ^2
+    curl.se/ca-certs: '*'
   script:
     - run: |
         git submodule init

--- a/projects/ollama.ai/package.yml
+++ b/projects/ollama.ai/package.yml
@@ -38,6 +38,9 @@ test:
     # 0.0.19 complains about a missing blobs directory
     - run: mkdir -p ~/.ollama/models/blobs
       if: =0.0.19
+    # why is this killing the test, it seems like?
+    - run: pgrep -l ollama
+      if: linux
     - $KILL ollama || true
     - sleep 5
     - ollama serve &

--- a/projects/ollama.ai/package.yml
+++ b/projects/ollama.ai/package.yml
@@ -3,8 +3,6 @@ distributable:
   ref: v{{version}}
 versions:
   github: jmorganca/ollama
-platforms:
-  - darwin # Available for macOS Windows & Linux support coming soon. <= from https://ollama.ai/
 build:
   dependencies:
     go.dev: ^1.21


### PR DESCRIPTION
ollama works on Linux (and allegedly Windows) nowadays.

Hopefully resolves https://github.com/pkgxdev/pkgx/issues/975