### PR TITLE
fix(glog)

### DIFF
--- a/projects/google.com/glog/package.yml
+++ b/projects/google.com/glog/package.yml
@@ -20,18 +20,32 @@ build:
     ARGS:
       - -DCMAKE_INSTALL_PREFIX={{prefix}}
       - -DBUILD_SHARED_LIBS=ON
+      - -DCMAKE_CXX_FLAGS=-std=c++14
 
 test:
-  fixture: |
-    #include <glog/logging.h>
-    #include <iostream>
-    #include <memory>
-    int main(int argc, char* argv[])
-    {
-      google::InitGoogleLogging(argv[0]);
-      LOG(INFO) << "test";
-    }
-  script: |
-    mv $FIXTURE test.cpp
-    g++ test.cpp -lglog -lgflags -o test
-    ./test
+  dependencies:
+    cmake.org: '*'
+    linux:
+      gnu.org/make: '*'
+      llvm.org: '*'
+  script:
+    - run: cat $FIXTURE >main.cpp
+      fixture: |
+        #include <glog/logging.h>
+        #include <iostream>
+        #include <memory>
+        int main(int argc, char* argv[])
+        {
+          google::InitGoogleLogging(argv[0]);
+          LOG(INFO) << "test";
+        }
+    - run: cat $FIXTURE >CMakeLists.txt
+      fixture: |
+        cmake_minimum_required (VERSION 3.16)
+        project (myproj VERSION 1.0)
+        find_package (glog 0.6.0 REQUIRED)
+        add_executable (myapp main.cpp)
+        target_link_libraries (myapp glog::glog)
+    - cmake -S . -B build
+    - cmake --build build
+    - ./build/myapp


### PR DESCRIPTION
glog 0.7.0 can no long be used without a build system.

frankly, i find that stupid, but it's C++, and i don't accept C++'s foibles anymore anyway.

closes #5243
