### PR TITLE
fix(folly)

### DIFF
--- a/projects/facebook.com/folly/package.yml
+++ b/projects/facebook.com/folly/package.yml
@@ -8,7 +8,7 @@ versions:
 dependencies:
   boost.org: '*'
   gflags.github.io: '*'
-  google.com/glog: '*'
+  google.com/glog: '<0.7'
   libevent.org: '*'
   lz4.org: 1
   openssl.org: ^1.1


### PR DESCRIPTION
glog 0.7 can't be consumed via include.

closes #5387
