### PR TITLE
fix(qemu)

### DIFF
--- a/projects/qemu.org/package.yml
+++ b/projects/qemu.org/package.yml
@@ -59,7 +59,7 @@ build:
   dependencies:
     gnu.org/bison: '*'
     github.com/westes/flex: '*'
-    python.org: '<3.10'
+    python.org: ~3.11
     ninja-build.org: '*'
     mesonbuild.com: '*'
   script:


### PR DESCRIPTION
mesonbuild needs python as a dep for libpython; so we need to match its version, unless we pass python in  https://github.com/pkgxdev/libpkgx/discussions/67
