### PR TITLE
fix(crates.io/git-gone)

### DIFF
--- a/projects/crates.io/git-gone/package.yml
+++ b/projects/crates.io/git-gone/package.yml
@@ -9,6 +9,9 @@ versions:
   github: swsnr/git-gone
   strip: /v/
 
+dependencies:
+  libgit2.org: ^1.7
+
 build:
   dependencies:
     rust-lang.org: '>=1.65'


### PR DESCRIPTION
closes #5400