### PR TITLE
fix(pypa/build)

### DIFF
--- a/projects/github.com/pypa/build/package.yml
+++ b/projects/github.com/pypa/build/package.yml
@@ -1,18 +1,22 @@
 distributable:
-  url: https://github.com/pypa/build/archive/refs/tags/{{version}}.tar.gz
+  url: https://github.com/pypa/build/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: pypa/build/tags
 
 dependencies:
-  python.org: '>=3<3.12'
+  pkgx.sh: ^1
 
-build: python-venv.sh {{prefix}}/bin/pyproject-build
+build:
+  dependencies:
+    python.org: '>=3<3.12'
+  script:
+    - bkpyvenv stage {{prefix}} {{version}}
+    - ${{prefix}}/venv/bin/pip install .
+    - bkpyvenv seal {{prefix}} pyproject-build
 
 provides:
   - bin/pyproject-build
 
-test:
-  script: |
-    pyproject-build --version | grep {{version}}
+test: pyproject-build --version | grep {{version}}


### PR DESCRIPTION
v1.1.0 used a `v` in the tag name. 1.1.1 built fine. switched to `bkpyvenv`.

closes #5417
