### PR TITLE
-openjdk@20

### DIFF
--- a/projects/openjdk.org/package.yml
+++ b/projects/openjdk.org/package.yml
@@ -2,8 +2,6 @@ distributable:
   # TODO: add jdk8
   - url: https://github.com/openjdk/jdk21u/archive/{{version.tag}}.tar.gz
     strip-components: 1
-  - url: https://github.com/openjdk/jdk20u/archive/{{version.tag}}.tar.gz
-    strip-components: 1
   - url: https://github.com/openjdk/jdk17u/archive/{{version.tag}}.tar.gz
     strip-components: 1
   - url: https://github.com/openjdk/jdk11u/archive/{{version.tag}}.tar.gz
@@ -15,8 +13,6 @@ versions:
   # 21.10.0.
   - github: openjdk/jdk21u/tags
     transform: 'v => v.match(/jdk-21\.0\./) ? v.replace(/\+/, ".").replace(/^jdk-/, "") : undefined'
-  - github: openjdk/jdk20u/tags
-    transform: 'v => v.match(/jdk-20\.0\./) ? v.replace(/\+/, ".").replace(/^jdk-/, "") : undefined'
   - github: openjdk/jdk17u/tags
     transform: 'v => v.match(/jdk-17\.0\./) ? v.replace(/\+/, ".").replace(/^jdk-/, "") : undefined'
   - github: openjdk/jdk11u/tags
@@ -114,8 +110,6 @@ build:
     # or the last previous version of the current major version
     # https://github.com/adoptium/temurin21-binaries/releases
     BOOT_JDK21_VERSION: 21.0.2+13
-    # https://github.com/adoptium/temurin20-binaries/releases
-    BOOT_JDK20_VERSION: 20.0.2+9
     # https://github.com/adoptium/temurin17-binaries/releases
     BOOT_JDK17_VERSION: 17.0.9+9
     # https://github.com/adoptium/temurin11-binaries/releases


### PR DESCRIPTION
- No one uses it. It's like Node.js 19, people only "use" it when they want to test something, but it's immediately forgotten once a new LTS version comes out -- which happened already with java@21.
- Waste of machine time and resources
- Not even sdkman.io (a jdk package manager) bothers to support it anymore
- It may raise a red flag for people looking into https://pkgx.dev/pkgs/openjdk.org/ (like "why would they package 11, 17, 21 and 20? do they know what they are doing?" lol)
- May make version specifiers more complicated. I.e., if I want to specify an older version of java 21, I can't just use <21 because that would include 20 although the user probably meant 17.

I know these are all weak arguments, but I am just opening the PR in case you agree. If you do I'd suggest to even unpublish the existing java@20 package previously built. If you don't agree, fell 100% free to just close this PR.
