### PR TITLE
Remove `bin/jpackage` for now to fix openjdk@11

### DIFF
--- a/projects/openjdk.org/package.yml
+++ b/projects/openjdk.org/package.yml
@@ -140,6 +140,8 @@ build:
       - --with-zlib=system
 
 provides:
+  # TODO: https://github.com/pkgxdev/libpkgx/issues/68
+  # - bin/jaotc # <=11
   - bin/jar
   - bin/jarsigner
   - bin/java
@@ -155,23 +157,25 @@ provides:
   - bin/jhsdb
   - bin/jimage
   - bin/jinfo
+  # - bin/jjs # <=11
   - bin/jlink
   - bin/jmap
   - bin/jmod
-  # TODO: https://github.com/pkgxdev/libpkgx/issues/68
-  # only available in jdk17+
-  # - bin/jpackage
+  # - bin/jpackage # >=17
   - bin/jps
   - bin/jrunscript
   - bin/jshell
   - bin/jstack
   - bin/jstat
   - bin/jstatd
-  # only available in jdk21+
-  # - bin/jwebserver
+  # - bin/jwebserver # >=21
   - bin/keytool
+  # - bin/pack200 # <=11
+  # - bin/rmic # <=11
+  # - bin/rmid # <=11
   - bin/rmiregistry
   - bin/serialver
+  # - bin/unpack200 # <=11
 
 test:
   script:

--- a/projects/openjdk.org/package.yml
+++ b/projects/openjdk.org/package.yml
@@ -158,15 +158,16 @@ provides:
   - bin/jlink
   - bin/jmap
   - bin/jmod
-  - bin/jpackage
+  # TODO: https://github.com/pkgxdev/libpkgx/issues/68
+  # only available in jdk17+
+  # - bin/jpackage
   - bin/jps
   - bin/jrunscript
   - bin/jshell
   - bin/jstack
   - bin/jstat
   - bin/jstatd
-  # TODO: this bin should only be available in jdk21+
-  # https://github.com/pkgxdev/libpkgx/issues/68
+  # only available in jdk21+
   # - bin/jwebserver
   - bin/keytool
   - bin/rmiregistry


### PR DESCRIPTION
I think this is the best compromise for the time being. `bin/jpackage` is only available for jdk17+.

              Looks like it failed the audit due to a missing binary:

https://github.com/pkgxdev/pantry/actions/runs/8210262716/job/22457399093

_Originally posted by @jhheider in https://github.com/pkgxdev/pantry/issues/5472#issuecomment-1986928440_

Refs https://github.com/pkgxdev/libpkgx/issues/68
