### PR TITLE
fix(kubectx.dev)

### DIFF
--- a/projects/kubectx.dev/package.yml
+++ b/projects/kubectx.dev/package.yml
@@ -1,6 +1,6 @@
 distributable:
-  url: https://github.com/ahmetb/kubectx/archive/refs/tags/v{{version}}.tar.gz
-  strip-components: 1
+  url: git+https://github.com/ahmetb/kubectx.git
+  ref: ${{version.tag}}
 
 versions:
   github: ahmetb/kubectx
@@ -10,14 +10,16 @@ provides:
   - bin/kubens
 
 dependencies:
-  kubernetes.io/kubectl: ^1.26.2
-  gnu.org/bash: ^5.1
+  github.com/junegunn/fzf: '*'
 
 build:
+  dependencies:
+    go.dev: ^1.20
+  env:
+    CGO_ENABLED: '0'
   script: |
-    mkdir -p "{{ prefix }}"/bin
-    mv kubectx "{{ prefix }}"/bin
-    mv kubens "{{ prefix }}"/bin
+    go build -o '{{ prefix }}/bin/kubectx' ./cmd/kubectx
+    go build -o '{{ prefix }}/bin/kubens' ./cmd/kubens
 
 test:
   script: |

--- a/projects/kubectx.dev/package.yml
+++ b/projects/kubectx.dev/package.yml
@@ -4,7 +4,7 @@ distributable:
 
 versions:
   github: ahmetb/kubectx
-  ignore: ['<0.9'] # prior to 0.9 kubectx was a bash script
+  ignore: /^v?0\.[0-8](\.|$)/ # prior to 0.9 kubectx was a bash script
 
 provides:
   - bin/kubectx
@@ -18,11 +18,10 @@ build:
     go.dev: ^1.20
   env:
     CGO_ENABLED: '0'
-  script: |
-    go build -o '{{ prefix }}/bin/kubectx' ./cmd/kubectx
-    go build -o '{{ prefix }}/bin/kubens' ./cmd/kubens
+  script:
+    - go build -o '{{ prefix }}/bin/kubectx' ./cmd/kubectx
+    - go build -o '{{ prefix }}/bin/kubens' ./cmd/kubens
 
 test:
-  script: |
-    kubectx --help
-    kubens --help
+  - kubectx --help
+  - kubens --help

--- a/projects/kubectx.dev/package.yml
+++ b/projects/kubectx.dev/package.yml
@@ -4,6 +4,7 @@ distributable:
 
 versions:
   github: ahmetb/kubectx
+  ignore: ['<0.9'] # prior to 0.9 kubectx was a bash script
 
 provides:
   - bin/kubectx


### PR DESCRIPTION
This fixes multiple problems with this package:

1. Since 0.9.0 the package is now made in Go, and requires no kubectl nor bash to run
2. It always required fzf to be installed for full functionality, but it was not set as a dependency

Looks like [Homebrew is outdated](https://github.com/Homebrew/homebrew-core/blob/af831d4c8a82c0789f9447e16033c6e1675181eb/Formula/k/kubectx.rb), and this pkg was based on it.