### PR TITLE
Remove llvm.org as runtime dependency of deno on Linux

### DIFF
--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -18,10 +18,10 @@ runtime:
     DENO_NO_UPDATE_CHECK: 'true'
     DENORT_BIN: '{{prefix}}/bin/denort'
 
-# dependencies:
-#   darwin/x86-64:
-#     # FIXME try removing this after new builds are available
-#     llvm.org: 17 # libunwind
+dependencies:
+  darwin/x86-64:
+    # FIXME try removing this after new builds are available
+    llvm.org: 17 # libunwind
 
 build:
   script:

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -18,10 +18,10 @@ runtime:
     DENO_NO_UPDATE_CHECK: 'true'
     DENORT_BIN: '{{prefix}}/bin/denort'
 
-dependencies:
-  darwin/x86-64:
-    # FIXME try removing this after new builds are available
-    llvm.org: 17 # libunwind
+# dependencies:
+#   darwin/x86-64:
+#     # FIXME try removing this after new builds are available
+#     llvm.org: 17 # libunwind
 
 build:
   script:

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -37,6 +37,12 @@ build:
 
     - |
       rust_version=$(yq -er .toolchain.channel rust-toolchain.toml)
+      if semverator lt "$rust_version" 1.67.0; then
+        # older versions of pkgx's rustc --print=split-debuginfo fails with:
+        # error: unknown print request `split-debuginfo`
+        # maybe due to newer cargo?
+        rust_version=1.67.0
+      fi
       set -o allexport
       source <(pkgx "+rust-lang.org~${rust_version}" +rust-lang.org/cargo^0)
       set +o allexport
@@ -65,6 +71,7 @@ build:
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake
     protobuf.dev: '*' # deno.land>=1.36.4 requires protoc
     github.com/mikefarah/yq: ^4
+    crates.io/semverator: ^0
 
 test:
   dependencies:

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -25,16 +25,6 @@ dependencies:
 
 build:
   script:
-    # deno does not need llvm to build on darwin+x86-64, and if it is present,
-    # deno will be linked to its libunwind, which then causes deno to need llvm
-    # in runtime.
-    - |
-      if test "{{hw.platform}}+{{ hw.arch }}" != "darwin+x86-64"; then
-        set -o allexport
-        source <(pkgx +llvm.org@17)
-        set +o allexport
-      fi
-
     - |
       rust_version=$(yq -er .toolchain.channel rust-toolchain.toml)
       if semverator lt "$rust_version" 1.67.0; then
@@ -67,6 +57,7 @@ build:
     - cargo install --locked --path cli --root "{{ prefix }}"
   dependencies:
     git-scm.org: 2 # to build tinycc
+    llvm.org: 17
     curl.se: '*' # required to download v8 (python is another option)
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake
     protobuf.dev: '*' # deno.land>=1.36.4 requires protoc
@@ -86,5 +77,10 @@ test:
       if: '>=1.40.5'  
     # tests download of dependencies
     - deno eval 'import { VERSION } from "https://deno.land/std@0.221.0/version.ts"; console.log(VERSION);' | tee /dev/stderr | grep -q ^0.221.0$
+    # ensures deno is not linked to libunwind
+    - run: otool -l {{prefix}}/bin/deno | grep -v libunwind
+      if: darwin
+    - run: ldd {{prefix}}/bin/deno | grep -v libunwind
+      if: linux
   fixture: |
     console.log("Hello, world!");

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -38,7 +38,7 @@ build:
     - |
       rust_version=$(yq -er .toolchain.channel rust-toolchain.toml)
       if semverator lt "$rust_version" 1.67.0; then
-        # older versions of pkgx's rustc --print=split-debuginfo fails with:
+        # older versions of rustc --print=split-debuginfo fails with:
         # error: unknown print request `split-debuginfo`
         # maybe due to newer cargo?
         rust_version=1.67.0
@@ -74,8 +74,6 @@ build:
     crates.io/semverator: ^0
 
 test:
-  dependencies:
-    crates.io/semverator: ^0
   script:
     - deno --version | grep {{version}}
     - mv $FIXTURE test.ts
@@ -84,10 +82,8 @@ test:
     - deno compile test.ts
     - test "$(./test)" = "Hello, world!"
     # human readable size of ./test should be equal to the size of denort to ensure our denort is being used
-    - |
-      if semverator gt {{version}} 1.40.4; then
-        test "$(stat -c %s ./test | numfmt --to=iec-i)" = "$(stat -c %s "{{prefix}}/bin/denort" | numfmt --to=iec-i)"
-      fi
+    - run: test "$(stat -c %s ./test | numfmt --to=iec-i)" = "$(stat -c %s "{{prefix}}/bin/denort" | numfmt --to=iec-i)"  
+      if: '>=1.40.5'  
     # tests download of dependencies
     - deno eval 'import { VERSION } from "https://deno.land/std@0.221.0/version.ts"; console.log(VERSION);' | tee /dev/stderr | grep -q ^0.221.0$
   fixture: |

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -18,12 +18,19 @@ runtime:
     DENO_NO_UPDATE_CHECK: 'true'
     DENORT_BIN: '{{prefix}}/bin/denort'
 
-dependencies:
-  x86-64:
-    llvm.org: 17 # libunwind
+# dependencies:
+#   darwin/x86-64:
+#     llvm.org: 17 # libunwind
 
 build:
   script:
+    - |
+      if test "{{hw.platform}}+{{ hw.arch }}" = "darwin+aarch64"; then
+        set -a
+        source <(pkgx +llvm.org@17)
+        set +a
+      fi
+
     # https://github.com/denoland/deno/issues/15596 -- reported fixed in 1.25.3
     - run: |
         find ext/ffi/tinycc -maxdepth 0 -empty -exec \
@@ -45,7 +52,6 @@ build:
     git-scm.org: 2 # to build tinycc
     rust-lang.org: ^1.70
     rust-lang.org/cargo: ^0
-    llvm.org: 17 # macOS/aarch64 requires (FIXME only dep where needed)
     curl.se: '*' # required to download v8 (python is another option)
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake
     protobuf.dev: '*' # deno.land>=1.36.4 requires protoc

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -18,9 +18,9 @@ runtime:
     DENO_NO_UPDATE_CHECK: 'true'
     DENORT_BIN: '{{prefix}}/bin/denort'
 
-# dependencies:
-#   darwin/x86-64:
-#     llvm.org: 17 # libunwind
+dependencies:
+  darwin/x86-64:
+    llvm.org: 17 # libunwind
 
 build:
   script:
@@ -54,9 +54,6 @@ build:
     curl.se: '*' # required to download v8 (python is another option)
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake
     protobuf.dev: '*' # deno.land>=1.36.4 requires protoc
-  # env:
-  #   linux:
-  #     LD: clang
 
 test:
   script:
@@ -68,6 +65,7 @@ test:
     - test "$(./test)" = "Hello, world!"
     # human readable size of ./test should be equal to the size of denort to ensure our denort is being used
     - test "$(stat -c %s ./test | numfmt --to=iec-i)" = "$(stat -c %s "{{prefix}}/bin/denort" | numfmt --to=iec-i)"
+    # tests download of dependencies
+    - deno eval 'import { VERSION } from "https://deno.land/std@0.221.0/version.ts"; console.log(VERSION);' | tee /dev/stderr | grep -q ^0.221.0$
   fixture: |
-    import { test } from "https://deno.land/std/testing/mod.ts";
     console.log("Hello, world!");

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -34,7 +34,7 @@ build:
         rust_version=1.67.0
       fi
       set -o allexport
-      source <(pkgx "+rust-lang.org~${rust_version}" +rust-lang.org/cargo^0)
+      source <(pkgx "+rust-lang.org~${rust_version}" +rust-lang.org/cargo^0 +llvm.org^17)
       set +o allexport
       unset rust_version
 
@@ -57,7 +57,6 @@ build:
     - cargo install --locked --path cli --root "{{ prefix }}"
   dependencies:
     git-scm.org: 2 # to build tinycc
-    llvm.org: 17
     curl.se: '*' # required to download v8 (python is another option)
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake
     protobuf.dev: '*' # deno.land>=1.36.4 requires protoc

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -65,6 +65,8 @@ build:
     crates.io/semverator: ^0
 
 test:
+  dependencies:
+    gnu.org/coreutils: '*' # for stat and numfmt
   script:
     - deno --version | grep {{version}}
     - mv $FIXTURE test.ts

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -54,9 +54,9 @@ build:
     curl.se: '*' # required to download v8 (python is another option)
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake
     protobuf.dev: '*' # deno.land>=1.36.4 requires protoc
-  env:
-    linux:
-      LD: clang
+  # env:
+  #   linux:
+  #     LD: clang
 
 test:
   script:
@@ -69,4 +69,5 @@ test:
     # human readable size of ./test should be equal to the size of denort to ensure our denort is being used
     - test "$(stat -c %s ./test | numfmt --to=iec-i)" = "$(stat -c %s "{{prefix}}/bin/denort" | numfmt --to=iec-i)"
   fixture: |
+    import { test } from "https://deno.land/std/testing/mod.ts";
     console.log("Hello, world!");

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -24,12 +24,11 @@ runtime:
 
 build:
   script:
-    - |
-      if test "{{hw.platform}}+{{ hw.arch }}" = "darwin+aarch64"; then
-        set -a
+    - run: |
+        set -o allexport
         source <(pkgx +llvm.org@17)
-        set +a
-      fi
+        set +o allexport
+      if: darwin/aarch64
 
     # https://github.com/denoland/deno/issues/15596 -- reported fixed in 1.25.3
     - run: |

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -35,6 +35,13 @@ build:
         set +o allexport
       fi
 
+    - |
+      rust_version=$(yq -er .toolchain.channel rust-toolchain.toml)
+      set -o allexport
+      source <(pkgx "+rust-lang.org~${rust_version}" +rust-lang.org/cargo^0)
+      set +o allexport
+      unset rust_version
+
     # https://github.com/denoland/deno/issues/15596 -- reported fixed in 1.25.3
     - run: |
         find ext/ffi/tinycc -maxdepth 0 -empty -exec \
@@ -54,13 +61,14 @@ build:
     - cargo install --locked --path cli --root "{{ prefix }}"
   dependencies:
     git-scm.org: 2 # to build tinycc
-    rust-lang.org: ^1.70
-    rust-lang.org/cargo: ^0
     curl.se: '*' # required to download v8 (python is another option)
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake
     protobuf.dev: '*' # deno.land>=1.36.4 requires protoc
+    github.com/mikefarah/yq: ^4
 
 test:
+  dependencies:
+    crates.io/semverator: ^0
   script:
     - deno --version | grep {{version}}
     - mv $FIXTURE test.ts
@@ -69,7 +77,10 @@ test:
     - deno compile test.ts
     - test "$(./test)" = "Hello, world!"
     # human readable size of ./test should be equal to the size of denort to ensure our denort is being used
-    - test "$(stat -c %s ./test | numfmt --to=iec-i)" = "$(stat -c %s "{{prefix}}/bin/denort" | numfmt --to=iec-i)"
+    - |
+      if semverator gt {{version}} 1.40.4; then
+        test "$(stat -c %s ./test | numfmt --to=iec-i)" = "$(stat -c %s "{{prefix}}/bin/denort" | numfmt --to=iec-i)"
+      fi
     # tests download of dependencies
     - deno eval 'import { VERSION } from "https://deno.land/std@0.221.0/version.ts"; console.log(VERSION);' | tee /dev/stderr | grep -q ^0.221.0$
   fixture: |

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -20,22 +20,27 @@ runtime:
 
 dependencies:
   darwin/x86-64:
+    # FIXME try removing this after new builds are available
     llvm.org: 17 # libunwind
 
 build:
   script:
-    - run: |
+    # deno does not need llvm to build on darwin+x86-64, and if it is present,
+    # deno will be linked to its libunwind, which then causes deno to need llvm
+    # in runtime.
+    - |
+      if test "{{hw.platform}}+{{ hw.arch }}" != "darwin+x86-64"; then
         set -o allexport
         source <(pkgx +llvm.org@17)
         set +o allexport
-      if: darwin/aarch64
+      fi
 
     # https://github.com/denoland/deno/issues/15596 -- reported fixed in 1.25.3
     - run: |
         find ext/ffi/tinycc -maxdepth 0 -empty -exec \
           git clone https://github.com/TinyCC/tinycc.git {} \;
 
-        if test {{ hw.target }} = x86_64-apple-darwin; then
+        if test "{{hw.platform}}+{{ hw.arch }}" = "darwin+x86-64"; then
           # our LLVM cannot build with deployment target set to 10.6
           sed -i.bak s/MACOSX_DEPLOYMENT_TARGET/\#/ ext/ffi/tinycc/Makefile
         fi


### PR DESCRIPTION
This works on my machine (linux x86-64). I'm using this PR to trigger CI to test on other platforms.

Refs https://github.com/pkgxdev/pantry/commit/5f7af42e953e97e4b0e1a8df01254f39a7c41eaf#commitcomment-140400383