### PR TITLE
Remove llvm.org as deno dependency on darwin+x86-64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,12 @@ jobs:
         with:
           PKGX_DIR: /opt
 
-      - uses: pkgxdev/brewkit/build@v1
+      - uses: pkgxdev/brewkit/build@8af9fe5a1c1ccd2c7aa9210bf42f4b02f04b64e4 # TODO: revert to v1
         id: build
         with:
           pkg: ${{ matrix.pkg }}
 
-      - uses: pkgxdev/brewkit/audit@v1
+      - uses: pkgxdev/brewkit/audit@8af9fe5a1c1ccd2c7aa9210bf42f4b02f04b64e4 # TODO: revert to v1
         with:
           pkg: ${{ steps.build.outputs.pkgspec }}
 
@@ -82,7 +82,7 @@ jobs:
             SUDO=sudo
           fi
           $SUDO rm -rf builds
-
-      - uses: pkgxdev/brewkit/test@v1
+        
+      - uses: pkgxdev/brewkit/test@8af9fe5a1c1ccd2c7aa9210bf42f4b02f04b64e4 # TODO: revert to v1
         with:
           pkg: ${{ steps.build.outputs.pkgspec }}

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -20,16 +20,6 @@ runtime:
 
 build:
   script:
-    # deno does not need llvm to build on darwin+x86-64, and if it is present,
-    # deno will be linked to its libunwind, which then causes deno to need llvm
-    # in runtime.
-    - |
-      if test "{{hw.platform}}+{{ hw.arch }}" != "darwin+x86-64"; then
-        set -o allexport
-        source <(pkgx +llvm.org^17)
-        set +o allexport
-      fi
-
     - |
       rust_version=$(yq -er .toolchain.channel rust-toolchain.toml)
       if semverator lt "$rust_version" 1.67.0; then
@@ -61,6 +51,13 @@ build:
 
     - cargo install --locked --path cli --root "{{ prefix }}"
   dependencies:
+    # deno does not need llvm to build on darwin+x86-64, and if it is present,
+    # deno will be linked to its libunwind, which then causes deno to need llvm
+    # in runtime.
+    linux:
+      llvm.org: ^17
+    darwin/aarch64:
+      llvm.org: ^17
     git-scm.org: 2 # to build tinycc
     curl.se: '*' # required to download v8 (python is another option)
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -20,6 +20,16 @@ runtime:
 
 build:
   script:
+    # deno does not need llvm to build on darwin+x86-64, and if it is present,
+    # deno will be linked to its libunwind, which then causes deno to need llvm
+    # in runtime.
+    - |
+      if test "{{hw.platform}}+{{ hw.arch }}" != "darwin+x86-64"; then
+        set -o allexport
+        source <(pkgx +llvm.org^17)
+        set +o allexport
+      fi
+
     - |
       rust_version=$(yq -er .toolchain.channel rust-toolchain.toml)
       if semverator lt "$rust_version" 1.67.0; then
@@ -29,7 +39,7 @@ build:
         rust_version=1.67.0
       fi
       set -o allexport
-      source <(pkgx "+rust-lang.org~${rust_version}" +rust-lang.org/cargo^0 +llvm.org^17)
+      source <(pkgx "+rust-lang.org~${rust_version}" +rust-lang.org/cargo^0)
       set +o allexport
       unset rust_version
 

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -20,6 +20,16 @@ runtime:
 
 build:
   script:
+    # deno does not need llvm to build on darwin+x86-64, and if it is present,
+    # deno will be linked to its libunwind, which then causes deno to need llvm
+    # in runtime.
+    - |
+      if test "{{hw.platform}}+{{ hw.arch }}" != "darwin+x86-64"; then
+        set -o allexport
+        source <(pkgx +llvm.org^17)
+        set +o allexport
+      fi
+
     - |
       rust_version=$(yq -er .toolchain.channel rust-toolchain.toml)
       if semverator lt "$rust_version" 1.67.0; then
@@ -51,13 +61,6 @@ build:
 
     - cargo install --locked --path cli --root "{{ prefix }}"
   dependencies:
-    # deno does not need llvm to build on darwin+x86-64, and if it is present,
-    # deno will be linked to its libunwind, which then causes deno to need llvm
-    # in runtime.
-    linux:
-      llvm.org: ^17
-    darwin/aarch64:
-      llvm.org: ^17
     git-scm.org: 2 # to build tinycc
     curl.se: '*' # required to download v8 (python is another option)
     cmake.org: ^3 # deno.land>=1.36.1 requires cmake

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -83,10 +83,5 @@ test:
       if: '>=1.40.5'  
     # tests download of dependencies
     - deno eval 'import { VERSION } from "https://deno.land/std@0.221.0/version.ts"; console.log(VERSION);' | tee /dev/stderr | grep -q ^0.221.0$
-    # ensures deno is not linked to libunwind
-    - run: otool -l {{prefix}}/bin/deno | grep -v libunwind
-      if: darwin
-    - run: ldd {{prefix}}/bin/deno | grep -v libunwind
-      if: linux
   fixture: |
     console.log("Hello, world!");

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -18,11 +18,6 @@ runtime:
     DENO_NO_UPDATE_CHECK: 'true'
     DENORT_BIN: '{{prefix}}/bin/denort'
 
-dependencies:
-  darwin/x86-64:
-    # FIXME try removing this after new builds are available
-    llvm.org: 17 # libunwind
-
 build:
   script:
     - |


### PR DESCRIPTION
Continues #5751 