### PR TITLE
fix(nasm)

### DIFF
--- a/projects/nasm.us/package.yml
+++ b/projects/nasm.us/package.yml
@@ -10,22 +10,21 @@ versions:
     - /\/"$/
 
 build:
-  script: |
-    ./configure --prefix="{{prefix}}"
-    make --jobs {{hw.concurrency}} rdf
-    make install install_rdf
+  script:
+    - ./configure --prefix="{{prefix}}"
+    - run: |
+        make --jobs {{hw.concurrency}} rdf
+        make install install_rdf
+      if: <2.16
+    # rdoff tools removed as unfixable
+    # https://github.com/netwide-assembler/nasm/commit/93548c2de2a3c218b3d0ab4061b26d9781cb6b37
+    - run: |
+        make --jobs {{hw.concurrency}}
+        make install
+      if: '>=2.16'
 
 test: nasm --version
 
 provides:
-  - bin/ldrdf
   - bin/nasm
   - bin/ndisasm
-  - bin/rdf2bin
-  - bin/rdf2com
-  - bin/rdf2ihx
-  - bin/rdf2ith
-  - bin/rdf2srec
-  - bin/rdfdump
-  - bin/rdflib
-  - bin/rdx


### PR DESCRIPTION
rdoff tools removed as unfixable in 2.16

closes #5803
