### PR TITLE
fix(openjdk)

### DIFF
--- a/projects/openjdk.org/package.yml
+++ b/projects/openjdk.org/package.yml
@@ -90,6 +90,11 @@ build:
     - make images $MAKE_ARGS
     - mkdir -p {{prefix}}
     - mv $JDK_DIR {{prefix}}/
+    - run: |
+        # jni.h:45:10: fatal error: 'jni_md.h' file not found
+        ln -s ./{{ hw.platform }}/jawt_md.h jawt_md.h
+        ln -s ./{{ hw.platform }}/jni_md.h jni_md.h
+      working-directory: ${{prefix}}/include
   env:
     MAKE_ARGS: 'JOBS={{ hw.concurrency }}'
     darwin:

--- a/projects/openjdk.org/package.yml
+++ b/projects/openjdk.org/package.yml
@@ -92,8 +92,11 @@ build:
     - mv $JDK_DIR {{prefix}}/
     - run: |
         # jni.h:45:10: fatal error: 'jni_md.h' file not found
-        ln -s ./{{ hw.platform }}/jawt_md.h jawt_md.h
-        ln -s ./{{ hw.platform }}/jni_md.h jni_md.h
+        if test -d {{ hw.platform }}; then
+          mv {{ hw.platform }}/* .
+          rmdir {{ hw.platform }}
+          ln -s . {{ hw.platform }}
+        fi
       working-directory: ${{prefix}}/include
   env:
     MAKE_ARGS: 'JOBS={{ hw.concurrency }}'


### PR DESCRIPTION
I get this error when building an app with `eas-cli`

```bash
~/.pkgx/openjdk.org/v20.0.2.9/include/jni.h:45:10: fatal error: 'jni_md.h' file not found
```