### PR TITLE
update(pango)

### DIFF
--- a/projects/gnome.org/pango/package.yml
+++ b/projects/gnome.org/pango/package.yml
@@ -9,7 +9,7 @@ versions:
     - /1\.90\.*/ # beta of 2.0
 
 dependencies:
-  cairographics.org: ~1.16
+  cairographics.org: ^1.18
   freetype.org: 2
   gnome.org/glib: 2
   harfbuzz.org: '>=4'


### PR DESCRIPTION
most of gnome needs the new cairo. needs #5564
