### PR TITLE
fix(ruby)

### DIFF
--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -102,6 +102,8 @@ build:
       - --with-vendorarchdir=no # ^^
       - --with-sitearchdir=no   # ^^
       - --enable-yjit  # https://github.com/pkgxdev/pantry/issues/3538
+    linux:
+      CC: clang
 
 test:
   dependencies:

--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -37,7 +37,11 @@ build:
       if: linux
       working-directory: include/ruby/internal/attr
 
-    - make --jobs {{hw.concurrency}} install
+    # 3.1.5 doesn't succeed with concurrent jobs
+    - run: make --jobs {{hw.concurrency}} install
+      if: <3.1.5 || >=3.2
+    - run: make install
+      if: ^3.1.5
 
     # we provide these as `rubygems.org`
     - run: rm -f bundle bundler gem


### PR DESCRIPTION
3.1.5 doesn't build with concurrent jobs

closes #5959
