### PR TITLE
Remove volta-shim and volta-migrate from provides

### DIFF
--- a/projects/volta.sh/package.yml
+++ b/projects/volta.sh/package.yml
@@ -23,8 +23,6 @@ build:
     
 provides:
   - bin/volta
-  - bin/volta-shim
-  - bin/volta-migrate
 
 test:
   - volta --version | grep {{version}}


### PR DESCRIPTION
Both programs are not meant to be invoked directly by the user.

It's pointless to have them stubbed when pkgx install volta.sh.

volta-shim will automatically be used by volta when installing node, npm and other tools.

volta-migrate will automatically be called by volta when ~/.volta is not populated.

This is somewhat similar to how deno pkg.yaml handles denort.