### PR TITLE
migrate(pipx, venv)

### DIFF
--- a/projects/pypa.github.io/pipx/package.yml
+++ b/projects/pypa.github.io/pipx/package.yml
@@ -6,13 +6,17 @@ versions:
   github: pypa/pipx
 
 dependencies:
-  python.org: '>=3<3.12'
+  pkgx.sh: ^1
 
 build:
-  python-venv.sh "{{prefix}}"/bin/pipx
+  dependencies:
+    python.org: '>=3<3.12'
+  script:
+    - bkpyvenv stage '{{prefix}}' {{version}}
+    - ${{prefix}}/venv/bin/pip install .
+    - bkpyvenv seal '{{prefix}}' pipx
 
-test:
-  pipx run pycowsay moooo!
+test: pipx run pycowsay moooo!
 
 provides:
   - bin/pipx

--- a/projects/virtualenv.pypa.io/package.yml
+++ b/projects/virtualenv.pypa.io/package.yml
@@ -8,6 +8,8 @@ versions:
 
 dependencies:
   pkgx.sh: ^1
+  libexpat.github.io: ^2
+  openssl.org: ^1.1
 
 build:
   dependencies:
@@ -16,8 +18,9 @@ build:
     - bkpyvenv stage '{{prefix}}' {{version}}
     - ${{prefix}}/venv/bin/pip install .
     - bkpyvenv seal '{{prefix}}' virtualenv
-    - run: ln -s venv/lib lib
-      working-directory: '{{prefix}}'
+    # needs this to find its libpython on linux
+    - run: cp '{{deps.python.org.prefix}}/lib/libpython'* .
+      working-directory: '{{prefix}}/lib'
 
 test:
   script: |

--- a/projects/virtualenv.pypa.io/package.yml
+++ b/projects/virtualenv.pypa.io/package.yml
@@ -16,6 +16,8 @@ build:
     - bkpyvenv stage '{{prefix}}' {{version}}
     - ${{prefix}}/venv/bin/pip install .
     - bkpyvenv seal '{{prefix}}' virtualenv
+    - run: ln -s venv/lib lib
+      working-directory: '{{prefix}}'
 
 test:
   script: |

--- a/projects/virtualenv.pypa.io/package.yml
+++ b/projects/virtualenv.pypa.io/package.yml
@@ -3,14 +3,19 @@ distributable:
   strip-components: 1
 
 versions:
-  github: pypa/virtualenv/releases/tags  # reads github *releases* but uses the tags of those releases
+  github: pypa/virtualenv/releases/tags # reads github *releases* but uses the tags of those releases
   strip: /^v/
 
 dependencies:
-  python.org: '>=3.7<3.12'
+  pkgx.sh: ^1
 
 build:
-  python-venv.sh {{prefix}}/bin/virtualenv
+  dependencies:
+    python.org: '>=3.7<3.12'
+  script:
+    - bkpyvenv stage '{{prefix}}' {{version}}
+    - ${{prefix}}/venv/bin/pip install .
+    - bkpyvenv seal '{{prefix}}' virtualenv
 
 test:
   script: |


### PR DESCRIPTION
suggested by @felipecrs ([here](https://github.com/pkgxdev/pantry/commit/587441621e2d68f35349380e69a8b253f7164f3c#commitcomment-141416453)) so we don't lock users of these packages out of newer pythons (now that 3.12 is reasonably well-supported).
