### PR TITLE
split(neowofetch)

### DIFF
--- a/projects/github.com/hykilpikonna/hyfetch/neowofetch/package.yml
+++ b/projects/github.com/hykilpikonna/hyfetch/neowofetch/package.yml
@@ -1,0 +1,18 @@
+distributable:
+  url: https://github.com/hykilpikonna/hyfetch/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: hykilpikonna/hyfetch
+
+dependencies:
+  pkgx.sh: ^1
+
+build:
+  - mkdir -p '{{prefix}}/bin'
+  - install neofetch '{{prefix}}/bin/neowofetch'
+
+provides:
+  - bin/neowofetch
+
+test: neowofetch --config none --color-blocks off --disable wm de term gpu

--- a/projects/github.com/hykilpikonna/hyfetch/package.yml
+++ b/projects/github.com/hykilpikonna/hyfetch/package.yml
@@ -14,14 +14,12 @@ build:
   script:
     - bkpyvenv stage {{prefix}} {{version}}
     - ${{prefix}}/venv/bin/pip install .
-    - bkpyvenv seal {{prefix}} hyfetch neowofetch
+    - bkpyvenv seal {{prefix}} hyfetch
 
 provides:
   - bin/hyfetch
-  - bin/neowofetch
 
 test:
-  - neowofetch --config none --color-blocks off --disable wm de term gpu
   - run: hyfetch -C $FIXTURE --args="--config none --color-blocks off --disable wm de term gpu"
     fixture: |
       {


### PR DESCRIPTION
moves the simple bash `neowofetch` tool into its own sub repo for users who don't want a whole python system

ref: https://github.com/pkgxdev/pantry/pull/6042#issuecomment-2091269675
