### PR TITLE
fix(helmfile): remove helm as hard dependency

### DIFF
--- a/projects/github.com/helmfile/helmfile/package.yml
+++ b/projects/github.com/helmfile/helmfile/package.yml
@@ -9,7 +9,6 @@ provides:
   - bin/helmfile
 
 dependencies:
-  helm.sh: '*'
   curl.se/ca-certs: '*'
 
 build:
@@ -25,6 +24,8 @@ build:
     mv ./helmfile "{{ prefix }}"/bin
 
 test:
+  dependencies:
+    helm.sh: '*'
   fixture: |
     releases:
       - name: myrelease


### PR DESCRIPTION
I believe this situation is very similar to https://github.com/pkgxdev/pkgx/issues/971, i.e. people are expected to provide their own helm binary of their choice for helmfile to work with.

For the time being, since pkgx does not have a solution for this, I think this PR is a good compromise.

Not to mention helmBinary can be specified in helmfile.yaml, meaning for some users, including me, having a bundled version of helm come with helmfile is unnecessary.

https://helmfile.readthedocs.io/en/latest/#configuration:~:text=binary%20(%2D%2Dhelm%2Dbinary)-,helmBinary,-%3A%20path/to

What do you think?