### PR TITLE
fix(werf): remove runtime dependencies

### DIFF
--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -5,11 +5,6 @@ distributable:
 versions:
   github: werf/werf
 
-dependencies:
-  linux:
-    github.com/kdave/btrfs-progs: ^6.7
-    sourceware.org/dm: ^2.3
-
 build:
   dependencies:
     go.dev: ^1.21

--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -31,9 +31,7 @@ build:
         - -buildmode=pie
       TAGS:
         - osusergo
-        - exclude_graphdriver_devicemapper
         - netgo
-        - no_devmapper
         - static_build
     ARGS:
       - -v


### PR DESCRIPTION
They were surely taken from Homebrew's formulae, but I'm not sure if they are really required for anything. Downloading the werf binaries from the GitHub Releases also works just fine, so I'm trying to remove them. Let's see what CI tests says.

They make installing werf take way longer than otherwise.
