### PR TITLE
Fix argbash

### DIFF
--- a/projects/argbash.dev/package.yml
+++ b/projects/argbash.dev/package.yml
@@ -6,22 +6,23 @@ versions:
   github: matejak/argbash
 
 dependencies:
-  gnu.org/bash: '>=3.0'
+  gnu.org/bash: '>=3'
+  gnu.org/autoconf: '*'
 
 build:
-  dependencies:
-    gnu.org/autoconf: '*'
   script:
-    - make install PREFIX={{prefix}}
-  working-directory: resources
-  
+    - mkdir -p '{{prefix}}'
+    - cp -r bin src '{{prefix}}'
+
 provides:
   - bin/argbash
   - bin/argbash-init
   - bin/argbash-1to2
 
 test:
-  - argbash-init --pos positional-arg --opt option --opt-bool print minimal.m4
-  - cat minimal.m4 | grep 'This is just a script template'
   - argbash --version | grep {{version}}
   - argbash --help | grep 'Argbash is an argument parser generator for Bash'
+  - argbash-init --pos positional-arg --opt option --opt-bool print minimal.m4
+  - cat minimal.m4 | grep 'This is just a script template'
+  - argbash minimal.m4 -o minimal.sh
+  - ./minimal.sh --help | grep 'Usage:'


### PR DESCRIPTION
First it was failing because missing `autom4te`.

Second it was failing with:

```
The directory '//opt/argbash.dev/v2.10.0+brewing/lib/argbash' with files needed by Argbash is not browsable. Check whether it exists and review it's permissions.
```

This is because of:

https://github.com/matejak/argbash/blob/0d046ad6a208a8ba2820fa7bdd13d21eb211e51e/resources/Makefile#L171

So I believe our best option is not use their `Makefile` for now. Fortunately, things are simple enough.

I also added a test to cover this.
