### PR TITLE
better fix(libcxx)

### DIFF
--- a/projects/libcxx.llvm.org/package.yml
+++ b/projects/libcxx.llvm.org/package.yml
@@ -6,6 +6,11 @@ versions:
   github: llvm/llvm-project
   strip: /^llvmorg-/
 
+runtime:
+  env:
+    linux:
+      CPATH: $CPATH:{{prefix}}/include/c++/v1
+
 build:
   dependencies:
     cmake.org: '>=3<3.29'
@@ -58,4 +63,3 @@ test:
       - -std=c++11
       - -stdlib=libc++
       - -lc++
-      - -isystem {{prefix}}/include/c++/v1


### PR DESCRIPTION
use CPATH to find C++ headers on linux (mac needs apple's).
