### PR TITLE
fix(dagger): correctly inject version number during build

### DIFF
--- a/projects/dagger.io/package.yml
+++ b/projects/dagger.io/package.yml
@@ -21,8 +21,7 @@ build:
     LDFLAGS:
       - -s
       - -w
-      - -X go.dagger.io/dagger/version.Version={{ version }}
-      - -X go.dagger.io/dagger/version.Revision=tea
+      - -X github.com/dagger/dagger/engine.Version={{ version }}
     linux:
       # or segmentation fault
       # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575

--- a/projects/dagger.io/package.yml
+++ b/projects/dagger.io/package.yml
@@ -28,8 +28,7 @@ build:
       LDFLAGS:
         - -buildmode=pie
 
-test: |
-    dagger version
+test: dagger version | grep '{{version}}'
     # This is a better test, but we might mask failures using || true
     # think more about this.
     #out=$(dagger query <<EOF 2>&1 || true


### PR DESCRIPTION
The version number was not properly injected, resulting in a failure when starting the engine.