### PR TITLE
fix(deno)

### DIFF
--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -16,7 +16,13 @@ interprets:
 runtime:
   env:
     DENO_NO_UPDATE_CHECK: 'true'
-    DENORT_BIN: '{{prefix}}/bin/denort'
+    # we cannot do this, as it breaks cross-compilation.
+    # linux/aarch64:
+    # theirs doesn't support glibc old enough
+    #   DENORT_BIN: '{{prefix}}/bin/denort'
+
+companions:
+  info-zip.org/unzip: '*' # needed to download the compilation runtime
 
 build:
   script:
@@ -72,7 +78,8 @@ build:
 
 test:
   dependencies:
-    gnu.org/coreutils: '*' # for stat and numfmt
+    linux/aarch64:
+      gnu.org/coreutils: '*' # for stat and numfmt
   script:
     - deno --version | grep {{version}}
     - mv $FIXTURE test.ts
@@ -80,17 +87,26 @@ test:
     - test "$($HOME/.local/bin/test)" = "Hello, world!"
     - deno compile test.ts
     - test "$(./test)" = "Hello, world!"
+
     # human readable size of ./test should be equal to the size of denort to ensure our denort is being used
-    - run: test "$(stat -c %s ./test | numfmt --to=iec-i)" = "$(stat -c %s "{{prefix}}/bin/denort" | numfmt --to=iec-i)"
+    # only on linux/aarch64 (whose's public denort doesn't support glibc old enough)
+    - run: |
+        if test "{{hw.platform}}/{{hw.arch}}" = "linux/aarch64"; then
+          test "$(stat -c %s ./test | numfmt --to=iec-i)" = "$(stat -c %s "{{prefix}}/bin/denort" | numfmt --to=iec-i)"
+        fi
       if: '>=1.40.5'
+
     # tests download of dependencies
     - deno eval 'import { VERSION } from "https://deno.land/std@0.221.0/version.ts"; console.log(VERSION);' | tee /dev/stderr | grep -q ^0.221.0$
+
     # ensure we haven't linked libunwind
     - if $LIST_LIBS {{prefix}}/bin/deno | grep libunwind; then false; fi
-  fixture: |
-    console.log("Hello, world!");
+  fixture: console.log("Hello, world!");
   env:
     darwin:
       LIST_LIBS: otool -l
     linux:
       LIST_LIBS: ldd
+    linux/aarch64:
+      # their downloadable runtime doesn't support glibc old enough
+      DENORT_BIN: '{{prefix}}/bin/denort'

--- a/projects/fluentci.io/package.yml
+++ b/projects/fluentci.io/package.yml
@@ -24,6 +24,10 @@ build:
     - mkdir -p "{{ prefix }}"/bin
     - cp fluentci "{{ prefix }}"/bin
   skip: fix-patchelf
+  env:
+    linux/aarch64:
+      # deno's pre-built runtime doesn't support glibc old enough
+      DENORT_BIN: '{{deps.deno.land.prefix}}/bin/denort'
 
 provides:
   - bin/fluentci

--- a/projects/pkgx.sh/package.yml
+++ b/projects/pkgx.sh/package.yml
@@ -12,12 +12,15 @@ provides:
 
 build:
   dependencies:
-    deno.land: ~1.39  # 1.40 shouts unskippable deprecation warnings
+    deno.land: ~1.39 # 1.40 shouts unskippable deprecation warnings
   working-directory: ${{prefix}}/bin
   # patchelf messes with Deno's ability to find the DATA block, making it
   # operate as only a bloated Deno binary
   skip: fix-patchelf
-  script: |
-    deno task --config "$SRCROOT"/deno.jsonc compile
+  script: deno task --config "$SRCROOT"/deno.jsonc compile
+  env:
+    linux/aarch64:
+      # deno's pre-built runtime doesn't support glibc old enough
+      DENORT_BIN: '{{deps.deno.land.prefix}}/bin/denort'
 
 test: test "$(pkgx --version)" = "pkgx {{ version }}"

--- a/projects/render.com/package.yml
+++ b/projects/render.com/package.yml
@@ -12,26 +12,31 @@ build:
   # patchelf messes with Deno's ability to find the DATA block, making it
   # operate as only a bloated Deno binary
   skip: fix-patchelf
-  script: |
+  script:
     # Something is wrong with their deps-lock.json.
     # Two of the ajv packages fail to install correctly,
     # and others have hash mismatches.
-    rm deps-lock.json
-    sed -i.bak \
-        -e "s/ajv-formats@2.1.1/ajv-formats@2.1.0/" \
-        -e "s/ajv@8.11.0/ajv@8.11.1/" \
-        deps.ts
-    rm deps.ts.bak
-    deno compile \
-      --unstable \
-      --allow-net \
-      --allow-read \
-      --allow-run \
-      --allow-write \
-      --allow-env \
-      --output='{{prefix}}/bin/render' \
+    - rm deps-lock.json
+
+    - sed
+      -e "s/ajv-formats@2.1.1/ajv-formats@2.1.0/"
+      -e "s/ajv@8.11.0/ajv@8.11.1/"
+      deps.ts
+
+    - deno compile
+      --unstable
+      --allow-net
+      --allow-read
+      --allow-run
+      --allow-write
+      --allow-env
+      --output='{{prefix}}/bin/render'
       ./entry-point.ts
   test: deno test --allow-write --allow-read --allow-net --allow-env --allow-run
+  env:
+    linux/aarch64:
+      # deno's pre-built runtime doesn't support glibc old enough
+      DENORT_BIN: '{{deps.deno.land.prefix}}/bin/denort'
 
 provides:
   - bin/render

--- a/projects/tea.xyz/package.yml
+++ b/projects/tea.xyz/package.yml
@@ -7,15 +7,20 @@ display-name: tea/cli
 
 versions:
   github: teaxyz/cli
+  ignore: /^v[1-9]/
 
 build:
   dependencies:
     deno.land: '>=1.23 <1.25 || ^1.25.3'
     # ^^ 1.25.0 - 1.25.2 panics on Linux for us
   working-directory: ${{prefix}}/bin
-  script:
-    deno task --config "$SRCROOT"/deno.jsonc compile
+  script: deno task --config "$SRCROOT"/deno.jsonc compile
+  skip: fix-patchelf # else segfaults
+  env:
+    linux/aarch64:
+      # deno's pre-built runtime doesn't support glibc old enough
+      DENORT_BIN: '{{deps.deno.land.prefix}}/bin/denort'
 
-test: |
-  tea --version
-  test "$(tea --version)" = "tea {{ version }}"
+test:
+  - tea --version
+  - test "$(tea --version)" = "tea {{ version }}"


### PR DESCRIPTION
setting the runtime explicitly breaks cross-compilation. instead, we'll set the runtime for our builds of linux/aarch64 _only_ since that's where it's needed.

closes #6790
