### PR TITLE
upgrade(buster,bullseye)

### DIFF
--- a/.github/scripts/get-ci-matrix.ts
+++ b/.github/scripts/get-ci-matrix.ts
@@ -70,7 +70,7 @@ function get_matrix(platform: string) {
       const os = {group: "linux-x86-64"}
       return {
         os, name,
-        container: "debian:buster-slim",
+        container: "debian:bullseye-slim",
         tinyname: "*nix64"
       }}
     case 'linux/aarch64': {

--- a/.github/scripts/get-matrix.ts
+++ b/.github/scripts/get-matrix.ts
@@ -71,9 +71,9 @@ function get_matrix(platform: string) {
       const os = {group: "linux-x86-64"}
       return {
         os, name,
-        container: "debian:buster-slim",
+        container: "debian:bullseye-slim",
         "test-os": [os],
-        "test-container": ["debian:buster-slim", "ubuntu", "archlinux"],
+        "test-container": ["debian:bullseye-slim", "ubuntu", "archlinux"],
         tinyname: "*nix64"
       }}
     case 'linux/aarch64': {


### PR DESCRIPTION
buster-* images no longer published on docker hub by debian

tagging @mxcl for visibility