### PR TITLE
+gotestsum

### DIFF
--- a/projects/gotestsum/package.yml
+++ b/projects/gotestsum/package.yml
@@ -1,0 +1,12 @@
+distributable:
+  url: https://github.com/gotestyourself/gotestsum/archive/refs/tags/v{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: gotestyourself/gotestsum
+
+dependencies:
+  go.dev: ^1.21
+
+provides:
+  - bin/gotestsum


### PR DESCRIPTION
Im trying to include this package on pantry, however when I run `bk build gotestsum` I get the following error:

```js
error: Uncaught (in promise) Error: ambiguous pkg spec
      if (rest.length) throw new Error("ambiguous pkg spec")
 ```

Can someone please give me some pointers on what I'm doing wrong and next steps? Ty :)