### PR TITLE
+pantsbuild.org-scie-pants

### DIFF
--- a/projects/pantsbuild.org/scie-pants/package.yml
+++ b/projects/pantsbuild.org/scie-pants/package.yml
@@ -1,0 +1,40 @@
+distributable: ~
+
+# TODO: build from source (complicated)
+warnings: [vendored]
+
+display-name: scie-pants
+
+versions:
+  - 0.12.0
+
+# patch RPATH has occurred segment fault error
+build:
+  dependencies:
+    curl.se: "*"
+  script: |
+    curl -Lfo pants https://github.com/pantsbuild/scie-pants/releases/download/v{{version}}/scie-pants-$PLATFORM
+    chmod u+x pants
+    mkdir -p "{{prefix}}/bin"
+    cp -a pants "{{prefix}}/bin"
+  skip: fix-patchelf
+  env:
+    darwin/aarch64:
+      PLATFORM: macos-aarch64
+    darwin/x86-64:
+      PLATFORM: macos-x86_64
+    linux/aarch64:
+      PLATFORM: linux-aarch64
+    linux/x86-64:
+      PLATFORM: linux-x86_64
+
+provides:
+  - bin/pants
+
+test:
+  script: |
+    cat << EOF > pants.toml
+    [GLOBAL]
+    pants_version = "2.17.1"
+    EOF
+    test "$(pants --version)" = 2.17.1

--- a/projects/pantsbuild.org/scie-pants/package.yml
+++ b/projects/pantsbuild.org/scie-pants/package.yml
@@ -6,17 +6,19 @@ warnings: [vendored]
 display-name: scie-pants
 
 versions:
-  - 0.12.0
+  github: pantsbuild/scie-pants
 
-# patch RPATH has occurred segment fault error
+dependencies:
+  curl.se/ca-certs: '*'
+
 build:
   dependencies:
-    curl.se: "*"
-  script: |
-    curl -Lfo pants https://github.com/pantsbuild/scie-pants/releases/download/v{{version}}/scie-pants-$PLATFORM
-    chmod u+x pants
-    mkdir -p "{{prefix}}/bin"
-    cp -a pants "{{prefix}}/bin"
+    curl.se: '*'
+  working-directory: '{{prefix}}/bin'
+  script:
+    - curl -Lfo pants https://github.com/pantsbuild/scie-pants/releases/download/v{{version}}/scie-pants-$PLATFORM
+    - chmod u+x pants
+  # patch RPATH has occurred segment fault error
   skip: fix-patchelf
   env:
     darwin/aarch64:
@@ -32,9 +34,8 @@ provides:
   - bin/pants
 
 test:
-  script: |
-    cat << EOF > pants.toml
-    [GLOBAL]
-    pants_version = "2.17.1"
-    EOF
-    test "$(pants --version)" = 2.17.1
+  - run: cp $FIXTURE pants.toml
+    fixture: |
+      [GLOBAL]
+      pants_version = "2.17.1"
+  - test "$(pants --version)" = 2.17.1


### PR DESCRIPTION
Pants v2 entry-point is not pants binary itself, but a thin layer called "scie-pants".
It has been developed by rust and python.

According to their docs, it might take a lot of time to analyze how to build scie-pants and pants from the scratch.

As result, it could be  a good starting point for providing the vendored with no elf patch.