### PR TITLE
rclone: cmount flags

### DIFF
--- a/projects/rclone.org/package.yml
+++ b/projects/rclone.org/package.yml
@@ -18,6 +18,7 @@ build:
     ARGS:
       - -trimpath
       - -o={{prefix}}/bin/rclone
+      - -tags cmount
 provides:
   - bin/rclone
 test:


### PR DESCRIPTION
https://github.com/rclone/rclone

https://github.com/Homebrew/homebrew-core/commit/4f0402fb80551779c603add4c8b67a51bd324f09#commitcomment-44226882
^ may need FUSE libraries to build this

this should fix this error when running rclone mount:
"Error: unknown command "mount" for "rclone" "



