### PR TITLE
fix(binutils).gold

### DIFF
--- a/projects/gnu.org/binutils/package.yml
+++ b/projects/gnu.org/binutils/package.yml
@@ -1,6 +1,9 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/binutils/binutils-{{ version.raw }}.tar.gz
-  strip-components: 1
+  # as of 2.44, this is a different tarball
+  - url: https://ftp.gnu.org/gnu/binutils/binutils-with-gold-{{ version.raw }}.tar.gz
+    strip-components: 1
+  - url: https://ftp.gnu.org/gnu/binutils/binutils-{{ version.raw }}.tar.gz
+    strip-components: 1
 
 versions:
   url: https://ftp.gnu.org/gnu/binutils/
@@ -65,8 +68,7 @@ provides:
     - bin/gprofng
     - bin/ld
     - bin/ld.bfd
-    # 2.44 doesn't produce this, despite being requested...
-    # - bin/ld.gold
+    - bin/ld.gold
     - bin/nm
     - bin/objcopy
     - bin/objdump


### PR DESCRIPTION
they split off the source repos (since it's 80% larger)
