### PR TITLE
Install pre-reqs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -53,3 +53,15 @@ runs:
       if: runner.os == 'macOS' && inputs.p12-password && inputs.p12-file-base64
       with:
         run: security delete-keychain signing_temp.keychain
+
+    # the intention is to make none of these required eventually
+    - name: apt-get install
+      run: |
+        SUDO=$(if command -v sudo >/dev/null 2>&1; then echo "sudo"; else echo ""; fi)
+        $SUDO apt-get update && $SUDO apt-get install --yes \
+          netbase \
+          ca-certificates \
+          libc-dev libstdc++-8-dev libgcc-8-dev \
+          libudev-dev
+      shell: bash
+      if: runner.os == 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - projects/**/*
       - .github/workflows/ci.yml
+      - .github/actions/setup/action.yml
 
 concurrency:
   group: ci/${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
My intention is to remove the pre-reqs installation from the installer (and thus also the `pkgxdev/setup` github action). Because:

* It slows down pkgxdev/setup a lot (minutes vs seconds)
* These deps aren't needed (99%)
  * Mostly they are only needed compiling C++ bar the `netbase` dep which is trickier.
* Once we merge manifests they won't be needed at all

So we install them here instead.