### PR TITLE
Bump minimal Rust version of the _scryer.pl_ package.

### DIFF
--- a/projects/scryer.pl/package.yml
+++ b/projects/scryer.pl/package.yml
@@ -12,8 +12,8 @@ dependencies:
 
 build:
   dependencies:
-    rust-lang.org: ^1.70
-    rust-lang.org/cargo: '*'
+    rust-lang.org: ^1.85
+    rust-lang.org/cargo: "*"
   script: cargo install --path . --root '{{prefix}}'
 
 provides:


### PR DESCRIPTION
- Bump minimal Rust version of _scryer.pl_ to 1.85 according to https://github.com/mthom/scryer-prolog/commit/638a765937288e9319877a386f9169eff3d0f74f commit.
- Format the _scryer.pl_ package.yml file.