### PR TITLE
fix(gcc15)

### DIFF
--- a/projects/gnu.org/gcc/package.yml
+++ b/projects/gnu.org/gcc/package.yml
@@ -11,6 +11,7 @@ dependencies:
   gnu.org/gmp: '>=4.2'
   gnu.org/mpfr: '>=2.4.0'
   gnu.org/mpc: '>=0.8.0'
+  zlib.net: ^1.3
 
 build:
   dependencies:
@@ -21,6 +22,8 @@ build:
     gnu.org/patch: '*'
     curl.se: '*'
     github.com/westes/flex: '*'
+    darwin/x86-64: # since 15.1.0
+      libisl.sourceforge.io: ^0
   working-directory: build
   script:
     # Applying ians patches on x86-64 too, since he sometimes gets fixes in faster, like:
@@ -92,6 +95,7 @@ build:
     BRANCH133: https://github.com/iains/gcc-13-branch/archive/refs/heads/gcc-13-3-darwin.tar.gz
     BRANCH141: https://github.com/iains/gcc-14-branch/archive/refs/heads/gcc-14-1-darwin.tar.gz
     BRANCH142: https://github.com/iains/gcc-14-branch/archive/refs/heads/gcc-14-2-darwin.tar.gz
+    BRANCH151: https://github.com/iains/gcc-15-branch/archive/refs/heads/gcc-15-1-darwin-rc1.tar.gz
     ARGS:
       - --prefix={{ prefix }}
       - --libdir={{ prefix }}/lib
@@ -99,6 +103,7 @@ build:
       - --with-bugurl="https://github.com/pkgxdev/pantry/issues"
       - --disable-bootstrap
       - --disable-nls
+      - --with-system-zlib
     linux:
       ARGS:
         - --disable-multilib
@@ -106,9 +111,14 @@ build:
         - --enable-pie-tools
         - --enable-host-pie
     linux/x86-64:
-      LDFLAGS: $LDFLAGS -pie
-      CFLAGS: $CFLAGS -fPIC -fPIE
-      CXXFLAGS: $CXXFLAGS -fPIC -fPIE
+      LDFLAGS:
+        - -pie
+      CFLAGS:
+        - -fPIC
+        - -fPIE
+      CXXFLAGS:
+        - -fPIC
+        - -fPIE
     darwin:
       ARGS:
         # Reliance on CLT hard path is yuck.
@@ -123,9 +133,12 @@ build:
       # llvm-as generates __compact_unwind sections, even when told not to. this causes build errors
       # for ^10 on darwin+x86-64
       # https://stackoverflow.com/questions/52211390/trouble-building-gcc-on-mac-cant-find-system-headers
-      BOOT_CFLAGS: -Wa,-mmacos-version-min=10.5
-      CFLAGS_FOR_TARGET: -Wa,-mmacos-version-min=10.5
-      and CXXFLAGS_FOR_TARGET: -Wa,-mmacos-version-min=10.5
+      BOOT_CFLAGS:
+        - -Wa,-mmacos-version-min=10.5
+      CFLAGS_FOR_TARGET:
+        - -Wa,-mmacos-version-min=10.5
+      CXXFLAGS_FOR_TARGET:
+        - -Wa,-mmacos-version-min=10.5
 
 test:
   - gcc --version | grep -q "pkgx GCC {{version}}"


### PR DESCRIPTION
closes #9247

fixes darwin/aarch64; can't suss out the clang errors for x86-64, yet.