### PR TITLE
fix(sqauwk)

### DIFF
--- a/projects/squawkhq.com/package.yml
+++ b/projects/squawkhq.com/package.yml
@@ -9,15 +9,28 @@ versions:
   github: sbdchd/squawk
 
 build:
-  working-directory: cli
   dependencies:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
     openssl.org: '*'
     perl.org: '*'
   script:
+    - run: cd cli
+      if: <2
+    - run: cd crates/cli
+      if: '>=2'
     # missing version bump
     - sed -i '1,/dependencies/s/version = ".*"/version = "{{ version }}"/' Cargo.toml
     - cargo install --path . --root {{prefix}}
+  env:
+    darwin/x86-64:
+      # error: static declaration of 'strchrnul' follows non-static declaration
+      # warning: 'strchrnul' is only available on macOS 15.4 or newer [-Wunguarded-availability-new]
+      MACOSX_DEPLOYMENT_TARGET: 15.4
 
-test: test "$(squawk --version)" = "squawk {{version}}"
+test:
+  - test "$(squawk --version)" = "squawk {{version}}"
+  - run: squawk $FIXTURE
+    fixture: SELECT 1 from users;
+  - run: if squawk "$FIXTURE"; then exit 1; fi
+    fixture: SELECT 1 from users-what;


### PR DESCRIPTION
 closes #9297

libpq_query-sys has issues with MacOSX15.4.sdk.

but v2 doesn't have a problem, so we're up to date.