### PR TITLE
Add package manifest for bybit_to_tradingview Python script

### DIFF
--- a/projects/github.com/vanobond/dtmain/package.yml
+++ b/projects/github.com/vanobond/dtmain/package.yml
@@ -32,6 +32,23 @@ fetch:
 
 build:
   script: |
+    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingviewprovides:
+  - bybit_to_tradingview
+
+description: >
+  Скрипт для передачи данных из Bybit в TradingView.
+
+homepage: https://github.com/vanobond/dtmain
+
+versions:
+  - 1.0.0
+
+fetch:
+  url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
+  sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5
+
+build:
+  script: |
     install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingviewfetch:
   url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
   sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5

--- a/projects/github.com/vanobond/dtmain/package.yml
+++ b/projects/github.com/vanobond/dtmain/package.yml
@@ -15,6 +15,23 @@ fetch:
 
 build:
   script: |
+    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingviewprovides:
+  - bybit_to_tradingview
+
+description: >
+  Скрипт для передачи данных из Bybit в TradingView.
+
+homepage: https://github.com/vanobond/dtmain
+
+versions:
+  - 1.0.0
+
+fetch:
+  url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
+  sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5
+
+build:
+  script: |
     install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingviewfetch:
   url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
   sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5

--- a/projects/github.com/vanobond/dtmain/package.yml
+++ b/projects/github.com/vanobond/dtmain/package.yml
@@ -15,40 +15,4 @@ fetch:
 
 build:
   script: |
-    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingviewprovides:
-  - bybit_to_tradingview
-
-description: >
-  Скрипт для передачи данных из Bybit в TradingView.
-
-homepage: https://github.com/vanobond/dtmain
-
-versions:
-  - 1.0.0
-
-fetch:
-  url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
-  sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5
-
-build:
-  script: |
-    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingviewprovides:
-  - bybit_to_tradingview
-
-description: >
-  Скрипт для передачи данных из Bybit в TradingView.
-
-homepage: https://github.com/vanobond/dtmain
-
-versions:
-  - 1.0.0
-
-fetch:
-  url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
-  sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5
-
-build:
-  script: |
-    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingviewfetch:
-  url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
-  sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5
+    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingview

--- a/projects/github.com/vanobond/dtmain/package.yml
+++ b/projects/github.com/vanobond/dtmain/package.yml
@@ -4,15 +4,17 @@ provides:
 description: >
   Скрипт для передачи данных из Bybit в TradingView.
 
-homepage: https://github.com/твой-логин/название-репозитория
+homepage: https://github.com/vanobond/dtmain
 
 versions:
   - 1.0.0
 
 fetch:
-  url: https://github.com/твой-логин/название-репозитория/archive/refs/tags/v1.0.0.tar.gz
-  sha256: твоя_SHA256_сумма
+  url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
+  sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5
 
 build:
   script: |
-    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingview
+    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingviewfetch:
+  url: https://github.com/vanobond/dtmain/archive/refs/tags/v1.0.0.tar.gz
+  sha256: e00f695ea39d24ee810f5c95bdf4d62f31f22afa370284421e064d80b8766dd5

--- a/projects/github.com/vanobond/dtmain/package.yml
+++ b/projects/github.com/vanobond/dtmain/package.yml
@@ -1,0 +1,18 @@
+provides:
+  - bybit_to_tradingview
+
+description: >
+  Скрипт для передачи данных из Bybit в TradingView.
+
+homepage: https://github.com/твой-логин/название-репозитория
+
+versions:
+  - 1.0.0
+
+fetch:
+  url: https://github.com/твой-логин/название-репозитория/archive/refs/tags/v1.0.0.tar.gz
+  sha256: твоя_SHA256_сумма
+
+build:
+  script: |
+    install -Dm755 bybit_to_tradingview.py $PREFIX/bin/bybit_to_tradingview


### PR DESCRIPTION
This pull request adds a new package `bybit_to_tradingview`, which is a simple Python script that sends market data from Bybit to TradingView.

📦 Source repository: https://github.com/vanobond/dtmain  
🔖 Version: 1.0.0  
🔑 License: MIT  
🧪 Tested on: Python 3.11+

Let me know if anything needs to be adjusted — happy to improve the manifest!