### PR TITLE
+borgbackup.org

### DIFF
--- a/projects/borgbackup.org/package.yml
+++ b/projects/borgbackup.org/package.yml
@@ -1,0 +1,43 @@
+distributable:
+  url: https://github.com/borgbackup/borg/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: borgbackup/borg/tags
+
+dependencies:
+  pkgx.sh: ^1
+
+platforms:
+  - linux
+  - darwin
+
+build:
+  dependencies:
+    python.org: ^3.10
+    openssl.org: ^1.1
+    gnu.org/gcc: "*"
+    facebook.com/zstd: "*"
+    github.com/Cyan4973/xxHash: ^0.8
+    freedesktop.org/pkg-config: "*"
+    lz4.org: "*"
+    linux:
+      savannah.nongnu.org/acl: ^2.3.1
+  env:
+    BORG_OPENSSL_PREFIX: "{{deps.openssl.org.prefix}}"
+    BORG_LIBLZ4_PREFIX: "{{deps.lz4.org.prefix}}"
+    BORG_LIBZSTD_PREFIX: "{{deps.facebook.com/zstd.prefix}}"
+    BORG_LIBXXHASH_PREFIX: "{{deps.github.com/Cyan4973/xxHash.prefix}}"
+    BORG_LIBACL_PREFIX: "{{deps.savannah.nongnu.org/acl.prefix}}"
+    CC: gcc
+  script:
+    - bkpyvenv stage {{prefix}} {{version}}
+    - ${{prefix}}/venv/bin/pip install --prefix {{prefix}} -r requirements.d/development.txt
+    - ${{prefix}}/venv/bin/pip install --prefix {{prefix}} .
+    - bkpyvenv seal {{prefix}} borg
+
+provides:
+  - bin/borg
+
+test:
+  - borg --version | grep "^borg {{version}}"

--- a/projects/borgbackup.org/package.yml
+++ b/projects/borgbackup.org/package.yml
@@ -3,52 +3,45 @@ distributable:
   strip-components: 1
 
 versions:
-  github: borgbackup/borg/tags
+  github: borgbackup/borg
 
 dependencies:
   pkgx.sh: ^1
-
-platforms:
-  - linux
-  - darwin
+  github.com/Cyan4973/xxHash: ^0.8
 
 build:
   dependencies:
     python.org: ^3.10
     openssl.org: ^1.1
-    gnu.org/gcc: "*"
-    facebook.com/zstd: "*"
-    github.com/Cyan4973/xxHash: ^0.8
-    freedesktop.org/pkg-config: "*"
-    lz4.org: "*"
+    facebook.com/zstd: '*'
+    lz4.org: '*'
     linux:
       savannah.nongnu.org/acl: ^2.3.1
   env:
-    BORG_OPENSSL_PREFIX: "{{deps.openssl.org.prefix}}"
-    BORG_LIBLZ4_PREFIX: "{{deps.lz4.org.prefix}}"
-    BORG_LIBZSTD_PREFIX: "{{deps.facebook.com/zstd.prefix}}"
-    BORG_LIBXXHASH_PREFIX: "{{deps.github.com/Cyan4973/xxHash.prefix}}"
-    BORG_LIBACL_PREFIX: "{{deps.savannah.nongnu.org/acl.prefix}}"
-    CC: gcc
+    BORG_OPENSSL_PREFIX: '{{deps.openssl.org.prefix}}'
+    BORG_LIBLZ4_PREFIX: '{{deps.lz4.org.prefix}}'
+    BORG_LIBZSTD_PREFIX: '{{deps.facebook.com/zstd.prefix}}'
+    BORG_LIBXXHASH_PREFIX: '{{deps.github.com/Cyan4973/xxHash.prefix}}'
+    BORG_LIBACL_PREFIX: '{{deps.savannah.nongnu.org/acl.prefix}}'
   script:
     - bkpyvenv stage {{prefix}} {{version}}
-    - ${{prefix}}/venv/bin/pip install --prefix {{prefix}} -r requirements.d/development.txt
-    - ${{prefix}}/venv/bin/pip install --prefix {{prefix}} .
-    - bkpyvenv seal {{prefix}} borg
+    - ${{prefix}}/venv/bin/pip install -r requirements.d/development.txt
+    - ${{prefix}}/venv/bin/pip install .
+    - bkpyvenv seal {{prefix}} borg borgfs
 
 provides:
   - bin/borg
+  - bin/borgfs
 
 test:
-    fixture: |
-      # borg test fixture
-    script:
+  fixture: |
+    # borg test fixture
+  script:
     - borg --version | grep "^borg {{version}}"
     - borg init --encryption=none test-repo
     - borg create --compression zstd test-repo::test-archive $FIXTURE
-    - rm -f $FIXTURE
     - borg list test-repo | grep "test-archive"
     - borg extract test-repo::test-archive
-    - grep $FIXTURE "# borg test fixture"
-    - rm -rf test-repo
-
+    # note that the extract path is a full subdirectory based on the original
+    # absolute path of the fixture file
+    - test "# borg test fixture" = "$(cat .$FIXTURE)"

--- a/projects/borgbackup.org/package.yml
+++ b/projects/borgbackup.org/package.yml
@@ -40,4 +40,15 @@ provides:
   - bin/borg
 
 test:
-  - borg --version | grep "^borg {{version}}"
+    fixture: |
+      # borg test fixture
+    script:
+    - borg --version | grep "^borg {{version}}"
+    - borg init --encryption=none test-repo
+    - borg create --compression zstd test-repo::test-archive $FIXTURE
+    - rm -f $FIXTURE
+    - borg list test-repo | grep "test-archive"
+    - borg extract test-repo::test-archive
+    - grep $FIXTURE "# borg test fixture"
+    - rm -rf test-repo
+

--- a/projects/savannah.nongnu.org/acl/package.yml
+++ b/projects/savannah.nongnu.org/acl/package.yml
@@ -31,6 +31,7 @@ build:
       - --prefix="{{prefix}}"
       - --libdir="{{prefix}}/lib"
       - --disable-rpath
+
 provides:
    - bin/chacl
    - bin/getfacl

--- a/projects/savannah.nongnu.org/acl/package.yml
+++ b/projects/savannah.nongnu.org/acl/package.yml
@@ -31,7 +31,6 @@ build:
       - --prefix="{{prefix}}"
       - --libdir="{{prefix}}/lib"
       - --disable-rpath
-
 provides:
    - bin/chacl
    - bin/getfacl


### PR DESCRIPTION
Borg backup tool

There are linking issues with the python libs, that still need to be fixed:

```
...
      building 'borg.crypto.low_level' extension
      creating build/temp.linux-x86_64-cpython-313/src/borg/crypto
      gcc -fPIC -fPIC -Isrc/borg/crypto -I/home/rschulze/.pkgx/openssl.org/v1.1.1w/include -I/home/rschulze/.pkgx/borgbackup.org/v1.4.1+brewing/venv/include -I/home/rschulze/.pkgx/python.org/v3.13.3/include/python3.13 -c src/borg/crypto/low_level.c -o build/temp.linux-x86_64-cpython-313/src/borg/crypto/low_level.o -Wall -Wextra -Wpointer-arith
      gcc -shared -pie -L/opt/zlib.net/v1.3.1/lib -pie -L/opt/zlib.net/v1.3.1/lib -pie -fPIC build/temp.linux-x86_64-cpython-313/src/borg/crypto/low_level.o -L/home/rschulze/.pkgx/openssl.org/v1.1.1w/lib -L/home/rschulze/.pkgx/python.org/v3.13.3/lib -lcrypto -o build/lib.linux-x86_64-cpython-313/borg/crypto/low_level.cpython-313-x86_64-linux-gnu.so
      /home/rschulze/.pkgx/gnu.org/binutils/v2.44.0/bin/ld: /lib/x86_64-linux-gnu/Scrt1.o: in function `_start':
      (.text+0x1b): undefined reference to `main'
      /home/rschulze/.pkgx/gnu.org/binutils/v2.44.0/bin/ld: build/temp.linux-x86_64-cpython-313/src/borg/crypto/low_level.o: in function `Py_SIZE':
      low_level.c:(.text+0x3a): undefined reference to `PyLong_Type'
      /home/rschulze/.pkgx/gnu.org/binutils/v2.44.0/bin/ld: low_level.c:(.text+0x73): undefined reference to `PyBool_Type'
      /home/rschulze/.pkgx/gnu.org/binutils/v2.44.0/bin/ld: build/temp.linux-x86_64-cpython-313/src/borg/crypto/low_level.o: in function `PyObject_TypeCheck':
      low_level.c:(.text+0x149): undefined reference to `PyType_IsSubtype'
...
```

Could it be an issue with the python package?