### PR TITLE
update(vaultproject.io) - add linux/aarch64 build

### DIFF
--- a/projects/vaultproject.io/package.yml
+++ b/projects/vaultproject.io/package.yml
@@ -5,10 +5,6 @@ distributable:
 versions:
   github: hashicorp/vault
 
-platforms:
-  - darwin
-  - linux/x86-64
-
 build:
   dependencies:
     go.dev: =1.24.3


### PR DESCRIPTION
Add linux/aarch64 build for vaultproject.io.