### PR TITLE
werf: remove linux dependencies

### DIFF
--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -35,7 +35,8 @@ build:
         - netgo
         - no_devmapper
         - static_build
-        - cni
+        # test without
+        # - cni
     ARGS:
       - -v
       - -trimpath

--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -18,7 +18,7 @@ build:
       gnu.org/gcc: '*'
       gnu.org/binutils: '*' # some go packages demand ld.gold
       # testing...
-      github.com/kdave/btrfs-progs: ^6.7
+      # github.com/kdave/btrfs-progs: ^6.7
       sourceware.org/dm: ^2.3
   script: go build $ARGS -ldflags="$LD_FLAGS" -tags="$TAGS" ./cmd/werf
   env:

--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -5,11 +5,11 @@ distributable:
 versions:
   github: werf/werf
 
-# test with
-dependencies:
-  linux:
-    github.com/kdave/btrfs-progs: ^6.7
-    sourceware.org/dm: ^2.3
+# testing...
+# dependencies:
+#   linux:
+#     github.com/kdave/btrfs-progs: ^6.7
+#     sourceware.org/dm: ^2.3
 
 build:
   dependencies:
@@ -17,6 +17,9 @@ build:
     linux:
       gnu.org/gcc: '*'
       gnu.org/binutils: '*' # some go packages demand ld.gold
+      # testing...
+      github.com/kdave/btrfs-progs: ^6.7
+      sourceware.org/dm: ^2.3
   script: go build $ARGS -ldflags="$LD_FLAGS" -tags="$TAGS" ./cmd/werf
   env:
     TAGS:
@@ -41,7 +44,7 @@ build:
         - netgo
         - no_devmapper
         - static_build
-        # test without
+        # testing...
         # - cni
     ARGS:
       - -v

--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -5,14 +5,9 @@ distributable:
 versions:
   github: werf/werf
 
-dependencies:
-  linux:
-    github.com/kdave/btrfs-progs: ^6.7
-    sourceware.org/dm: ^2.3
-
 build:
   dependencies:
-    go.dev: ^1.21
+    go.dev: ^1.23
     linux:
       gnu.org/gcc: '*'
       gnu.org/binutils: '*' # some go packages demand ld.gold
@@ -40,6 +35,7 @@ build:
         - netgo
         - no_devmapper
         - static_build
+        - cni
     ARGS:
       - -v
       - -trimpath

--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -5,6 +5,12 @@ distributable:
 versions:
   github: werf/werf
 
+# test with
+dependencies:
+  linux:
+    github.com/kdave/btrfs-progs: ^6.7
+    sourceware.org/dm: ^2.3
+
 build:
   dependencies:
     go.dev: ^1.23

--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -18,8 +18,8 @@ build:
       gnu.org/gcc: '*'
       gnu.org/binutils: '*' # some go packages demand ld.gold
       # testing...
-      # github.com/kdave/btrfs-progs: ^6.7
-      sourceware.org/dm: ^2.3
+      github.com/kdave/btrfs-progs: ^6.7
+      # sourceware.org/dm: ^2.3
   script: go build $ARGS -ldflags="$LD_FLAGS" -tags="$TAGS" ./cmd/werf
   env:
     TAGS:

--- a/projects/werf.io/package.yml
+++ b/projects/werf.io/package.yml
@@ -5,21 +5,13 @@ distributable:
 versions:
   github: werf/werf
 
-# testing...
-# dependencies:
-#   linux:
-#     github.com/kdave/btrfs-progs: ^6.7
-#     sourceware.org/dm: ^2.3
-
 build:
   dependencies:
     go.dev: ^1.23
     linux:
       gnu.org/gcc: '*'
       gnu.org/binutils: '*' # some go packages demand ld.gold
-      # testing...
       github.com/kdave/btrfs-progs: ^6.7
-      # sourceware.org/dm: ^2.3
   script: go build $ARGS -ldflags="$LD_FLAGS" -tags="$TAGS" ./cmd/werf
   env:
     TAGS:
@@ -44,8 +36,7 @@ build:
         - netgo
         - no_devmapper
         - static_build
-        # testing...
-        # - cni
+        - cni
     ARGS:
       - -v
       - -trimpath


### PR DESCRIPTION
I don't know why these deps are needed, but they make werf installation a lot heavier than otherwise.

I also refreshed the go version and added the cni go build tag as found [here](https://github.com/werf/werf/blob/081b6e5d884f55504f93e41b87eb3160a526ed41/Taskfile.dist.yaml#L25).
