### PR TITLE
fix devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,4 @@
 {
-  "postAttachCommand": "sh <(curl https://pkgx.sh) && pkgx --integrate && echo pkgx integrated && exec bash -i <(echo 'dev && echo dev environment loaded || echo error loading dev environment; exec $SHELL')"
+  "postAttachCommand": "curl https://pkgx.sh | sh && pkgx dev integrate && echo pkgx integrated && ((echo 'dev && echo dev environment loaded || echo error loading dev environment; exec $SHELL') | exec bash -i)",
+  "image": "mcr.microsoft.com/devcontainers/base:debian"
 }


### PR DESCRIPTION
Fix devcontainer config:

- Specify an image; current versions of devcontainer (eg. the VSCode extension) requires an explicit base image. Picked a base debian image, which is a lightweight one with no language-specific additions, since everything else can come from pkgx.
- Fix postAttachCommand to work with newer versions of `dev` (as `pkgx --integrated` doesn't work anymore) and to work on non-bash shells (as debian image uses dash as its `sh` shell).