### PR TITLE
+elixir-lang.org/otp-27

### DIFF
--- a/projects/elixir-lang.org/otp-27/package.yml
+++ b/projects/elixir-lang.org/otp-27/package.yml
@@ -1,0 +1,35 @@
+distributable:
+  url: https://github.com/elixir-lang/elixir/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: elixir-lang/elixir
+  strip: /v/
+
+dependencies:
+  erlang.org: ^27
+
+build: make install PREFIX="{{prefix}}"
+
+test:
+  script: |
+    elixir --version | grep "compiled with Erlang/OTP 27"
+    
+    mkdir test
+    cp $FIXTURE test/test.exs
+    cd test
+    elixir test.exs
+
+  fixture: |
+    whichfizz = fn
+      (0, 0, _) -> "FizzBuzz"
+      (0, _, _) -> "Fizz"
+      (_, 0, _) -> "Buzz"
+      (_, _, n) -> n
+    end
+
+    fizzbuzz = fn (n) ->
+      whichfizz.(rem(n, 3), rem(n, 5), n)
+    end
+
+    [1, 2, "Fizz", 4, "Buzz", "Fizz", 7, 8, "Fizz", "Buzz"] = Enum.map(1..10, fizzbuzz)


### PR DESCRIPTION
This adds Elixir specifically compiled and linked against Erlang OTP 27.

Why?

Elixir has tight build-time coupling with Erlang OTP versions. `pkgx`'s main `elixir-lang.org` package remains as `erlang.org: '*'` for latest everything, but production systems often need specific OTP versions for compatibility and reproducibility. For example, [Elixir 1.18.4](https://github.com/elixir-lang/elixir/releases/tag/v1.18.4) supports OTP 25-27.

- This new `package.yml` is identical to main package except the `erlang.org: ^27` dependency
- No `provides` key to avoid conflicting with main package
- Test verifies binary is built against expected OTP version
- Usage: `pkgx +elixir-lang.org/otp-27 elixir --version`
