### PR TITLE
+puzzles

### DIFF
--- a/projects/chiark.greenend.org.uk/puzzles/package.yml
+++ b/projects/chiark.greenend.org.uk/puzzles/package.yml
@@ -1,0 +1,76 @@
+distributable:
+  # Actual version number does not comply with semantic versioning
+  url: https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles.tar.gz
+  strip-components: 1
+
+display-name: puzzles
+
+versions:
+  url: https://www.chiark.greenend.org.uk/~sgtatham/puzzles/doc/
+  match: /\d+\.[\da-f]{7}/
+  strip:
+    - /\.[\da-f]{7}$/
+
+dependencies:
+  linux:
+    gtk.org/gtk3: '*'
+
+build:
+  dependencies:
+    cmake.org: '>=3.5'
+    chiark.greenend.org.uk/halibut: '*'
+    linux:
+      gnu.org/gcc: '*'
+      imagemagick.org: '*'
+  script: |
+    cmake . $ARGS
+    cmake --build . -j {{ hw.concurrency }}
+    cmake --install .
+  env:
+    ARGS:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+
+provides:
+  - bin/blackbox
+  - bin/bridges
+  - bin/cube
+  - bin/dominosa
+  - bin/fifteen
+  - bin/filling
+  - bin/flip
+  - bin/flood
+  - bin/galaxies
+  - bin/guess
+  - bin/inertia
+  - bin/keen
+  - bin/lightup
+  - bin/loopy
+  - bin/magnets
+  - bin/map
+  - bin/mines
+  - bin/mosaic
+  - bin/net
+  - bin/netslide
+  - bin/palisade
+  - bin/pattern
+  - bin/pearl
+  - bin/pegs
+  - bin/range
+  - bin/rect
+  - bin/samegame
+  - bin/signpost
+  - bin/singles
+  - bin/sixteen
+  - bin/slant
+  - bin/solo
+  - bin/tents
+  - bin/towers
+  - bin/tracks
+  - bin/twiddle
+  - bin/undead
+  - bin/unequal
+  - bin/unruly
+  - bin/untangle
+
+test: map --generate

--- a/projects/chiark.greenend.org.uk/puzzles/package.yml
+++ b/projects/chiark.greenend.org.uk/puzzles/package.yml
@@ -20,57 +20,66 @@ build:
     cmake.org: '>=3.5'
     chiark.greenend.org.uk/halibut: '*'
     linux:
-      gnu.org/gcc: '*'
+      llvm.org: 20
       imagemagick.org: '*'
-  script: |
-    cmake . $ARGS
-    cmake --build . -j {{ hw.concurrency }}
-    cmake --install .
+  script:
+    - cmake . $ARGS
+    - cmake --build . -j {{ hw.concurrency }}
+    - cmake --install .
+    - run: ln -s ../Puzzles.app/Contents/MacOS/Puzzles puzzles
+      if: darwin
   env:
     ARGS:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX={{prefix}}
 
 provides:
-  - bin/blackbox
-  - bin/bridges
-  - bin/cube
-  - bin/dominosa
-  - bin/fifteen
-  - bin/filling
-  - bin/flip
-  - bin/flood
-  - bin/galaxies
-  - bin/guess
-  - bin/inertia
-  - bin/keen
-  - bin/lightup
-  - bin/loopy
-  - bin/magnets
-  - bin/map
-  - bin/mines
-  - bin/mosaic
-  - bin/net
-  - bin/netslide
-  - bin/palisade
-  - bin/pattern
-  - bin/pearl
-  - bin/pegs
-  - bin/range
-  - bin/rect
-  - bin/samegame
-  - bin/signpost
-  - bin/singles
-  - bin/sixteen
-  - bin/slant
-  - bin/solo
-  - bin/tents
-  - bin/towers
-  - bin/tracks
-  - bin/twiddle
-  - bin/undead
-  - bin/unequal
-  - bin/unruly
-  - bin/untangle
+  darwin:
+    - bin/puzzles
+  linux:
+    - bin/blackbox
+    - bin/bridges
+    - bin/cube
+    - bin/dominosa
+    - bin/fifteen
+    - bin/filling
+    - bin/flip
+    - bin/flood
+    - bin/galaxies
+    - bin/guess
+    - bin/inertia
+    - bin/keen
+    - bin/lightup
+    - bin/loopy
+    - bin/magnets
+    - bin/map
+    - bin/mines
+    - bin/mosaic
+    - bin/net
+    - bin/netslide
+    - bin/palisade
+    - bin/pattern
+    - bin/pearl
+    - bin/pegs
+    - bin/range
+    - bin/rect
+    - bin/samegame
+    - bin/signpost
+    - bin/singles
+    - bin/sixteen
+    - bin/slant
+    - bin/solo
+    - bin/tents
+    - bin/towers
+    - bin/tracks
+    - bin/twiddle
+    - bin/undead
+    - bin/unequal
+    - bin/unruly
+    - bin/untangle
 
-test: map --generate
+test:
+  - run: map --generate
+    if: linux
+  - run: puzzles --help
+    if: darwin

--- a/projects/chiark.greenend.org.uk/puzzles/package.yml
+++ b/projects/chiark.greenend.org.uk/puzzles/package.yml
@@ -26,7 +26,22 @@ build:
     - cmake . $ARGS
     - cmake --build . -j {{ hw.concurrency }}
     - cmake --install .
-    - run: ln -s ../Puzzles.app/Contents/MacOS/Puzzles puzzles
+    - run: install -Dm755 $PROP puzzles
+      prop: |
+        #!/bin/sh
+
+        # add --help and --version flags
+        if [ "$1" = "--help" ]; then
+          echo "This is a simple wrapper to start the puzzles application."
+          exit 0
+        elif [ "$1" = "--version" ]; then
+          echo "puzzles {{version}}-pkgx"
+          exit 0
+        fi
+
+        cd "$(dirname "$(readlink -f "$0")")/.."
+        open Puzzles.app
+      working-directory: ${{prefix}}/bin
       if: darwin
   env:
     ARGS:
@@ -81,5 +96,7 @@ provides:
 test:
   - run: map --generate
     if: linux
-  - run: puzzles --help
+  - run:
+      - puzzles --help
+      - test "$(puzzles --version)" = "puzzles {{version}}-pkgx"
     if: darwin


### PR DESCRIPTION
This is my first time packaging anything for pkgx, so I do have a few questions:
1. The version number consists of a date in YYYYMMDD format and the first 7 seven characters of a Git hash (e.g. 20251021.790f585), which doesn't comply with semantic versioning and isn't accepted by BrewKit. My workaround is to remove the Git hash part, but the actual version number needs to be used in the distributable URL. How can I achieve this?
2. (Linux only) Do I have to add a build dependency on gnu.org/gcc to packages that use CMake, because this is what happens without that dependency:
```
ld.lld: error: cannot open crtbeginS.o: No such file or directory
ld.lld: error: unable to find library -lgcc
ld.lld: error: unable to find library -lgcc
ld.lld: error: cannot open crtendS.o: No such file or directory
cc: error: linker command failed with exit code 1 (use -v to see invocation)
 ```
3. (Linux only) The binaries use `HELP_DIR` to find the documentation, which is set to `~/.pkgx/chiark.greenend.org.uk/puzzles/v<version>+brewing` at build-time. Not only is it not relocatable, but it also doesn't work at run-time because `+brewing` directories are removed after the build. I can choose to omit the documentation from the package, but should I make it relocatable first?