### PR TITLE
Add pkgx manifest for just-mcp

### DIFF
--- a/projects/github.com/promptexecution/just-mcp/README.md
+++ b/projects/github.com/promptexecution/just-mcp/README.md
@@ -6,4 +6,4 @@ This pantry entry installs the Just MCP server built by `just-mcp` releases. The
 
 - Every release must publish the archives `just-mcp-x86_64-unknown-linux-gnu.tar.gz`, `just-mcp-aarch64-unknown-linux-gnu.tar.gz`, `just-mcp-x86_64-apple-darwin.tar.gz`, `just-mcp-aarch64-apple-darwin.tar.gz`, and `just-mcp-x86_64-pc-windows-msvc.tar.gz` so pkgx can download them per host/arch.
 - The manifest pulls the version from GitHub tags (it strips the leading `v`) and places the extracted binary under `${PKGX_DIR:-$HOME/.pkgx}/bin` (with `.exe` for Windows) so subsequent `pkgx just-mcp` invocations run the installed CLI.
-- Run `pkgx just-mcp --stdio --version` after merging the pantry PR to make sure the release assets are reachable.
+- Run `pkgx just-mcp --version` after merging the pantry PR to make sure the release assets are reachable.

--- a/projects/github.com/promptexecution/just-mcp/README.md
+++ b/projects/github.com/promptexecution/just-mcp/README.md
@@ -1,0 +1,9 @@
+# just-mcp pkgx package
+
+This pantry entry installs the Just MCP server built by `just-mcp` releases. The package manifest downloads a tarball whose name matches the target triple (`just-mcp-${target}.tar.gz`) from the GitHub release corresponding to the current tag (see `.github/workflows/build-binaries.yml` for the artifact names).
+
+## Packaging requirements
+
+- Every release must publish the archives `just-mcp-x86_64-unknown-linux-gnu.tar.gz`, `just-mcp-aarch64-unknown-linux-gnu.tar.gz`, `just-mcp-x86_64-apple-darwin.tar.gz`, `just-mcp-aarch64-apple-darwin.tar.gz`, and `just-mcp-x86_64-pc-windows-msvc.tar.gz` so pkgx can download them per host/arch.
+- The manifest pulls the version from GitHub tags (it strips the leading `v`) and places the extracted binary under `${PKGX_DIR:-$HOME/.pkgx}/bin` (with `.exe` for Windows) so subsequent `pkgx just-mcp` invocations run the installed CLI.
+- Run `pkgx just-mcp --stdio --version` after merging the pantry PR to make sure the release assets are reachable.

--- a/projects/github.com/promptexecution/just-mcp/package.yml
+++ b/projects/github.com/promptexecution/just-mcp/package.yml
@@ -1,0 +1,54 @@
+distributable:
+  url: https://github.com/PromptExecution/just-mcp/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: PromptExecution/just-mcp/tags
+  strip: /^v/
+
+description: Production-ready MCP server that exposes Justfile recipes over MCP.
+homepage: https://github.com/PromptExecution/just-mcp
+license: MIT
+
+build:
+  dependencies:
+    curl.se: '*'
+  working-directory: ${{prefix}}
+  script: |
+    case "{{hw.platform}}+{{hw.arch}}" in
+      linux+x86-64)
+        target="x86_64-unknown-linux-gnu"
+        ;;
+      linux+aarch64)
+        target="aarch64-unknown-linux-gnu"
+        ;;
+      darwin+x86-64)
+        target="x86_64-apple-darwin"
+        ;;
+      darwin+aarch64)
+        target="aarch64-apple-darwin"
+        ;;
+      windows+x86-64)
+        target="x86_64-pc-windows-msvc"
+        ;;
+      *)
+        echo "unsupported platform: {{hw.platform}}+{{hw.arch}}" >&2
+        exit 1
+        ;;
+    esac
+    archive="just-mcp-${target}.tar.gz"
+    curl -sSfL -o "$archive" "https://github.com/PromptExecution/just-mcp/releases/download/v{{version}}/${archive}"
+    tar -xzf "$archive"
+    mkdir -p {{ prefix }}/bin
+    if test "{{hw.platform}}" = "windows"; then
+      mv just-mcp.exe {{ prefix }}/bin/just-mcp.exe
+    else
+      mv just-mcp {{ prefix }}/bin/just-mcp
+    fi
+
+provides:
+  - bin/just-mcp
+  - bin/just-mcp.exe
+
+test: |
+  just-mcp --version

--- a/projects/github.com/promptexecution/just-mcp/package.yml
+++ b/projects/github.com/promptexecution/just-mcp/package.yml
@@ -1,53 +1,21 @@
 distributable:
-  url: https://github.com/PromptExecution/just-mcp/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/PromptExecution/just-mcp/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: PromptExecution/just-mcp/tags
-  strip: /^v/
 
 description: Production-ready MCP server that exposes Justfile recipes over MCP.
-homepage: https://github.com/PromptExecution/just-mcp
-license: MIT
 
 build:
   dependencies:
-    curl.se: '*'
-  working-directory: ${{prefix}}
-  script: |
-    case "{{hw.platform}}+{{hw.arch}}" in
-      linux+x86-64)
-        target="x86_64-unknown-linux-gnu"
-        ;;
-      linux+aarch64)
-        target="aarch64-unknown-linux-gnu"
-        ;;
-      darwin+x86-64)
-        target="x86_64-apple-darwin"
-        ;;
-      darwin+aarch64)
-        target="aarch64-apple-darwin"
-        ;;
-      windows+x86-64)
-        target="x86_64-pc-windows-msvc"
-        ;;
-      *)
-        echo "unsupported platform: {{hw.platform}}+{{hw.arch}}" >&2
-        exit 1
-        ;;
-    esac
-    archive="just-mcp-${target}.tar.gz"
-    curl -sSfL -o "$archive" "https://github.com/PromptExecution/just-mcp/releases/download/v{{version}}/${archive}"
-    tar -xzf "$archive"
-    mkdir -p {{ prefix }}/bin
-    if test "{{hw.platform}}" = "windows"; then
-      mv just-mcp.exe {{ prefix }}/bin/just-mcp.exe
-    else
-      mv just-mcp {{ prefix }}/bin/just-mcp
-    fi
+    rust-lang.org: '>=1.89'
+  script:
+    # missed version bump
+    - sed -i '1,20s/^version = ".*"$/version = "{{version}}"/' Cargo.toml
+    - cargo install --path . --root {{prefix}}
 
 provides:
   - bin/just-mcp
 
-test: |
-  just-mcp --version || just-mcp.exe --version
+test: test "$(just-mcp --version)" = "just-mcp {{version}}"

--- a/projects/github.com/promptexecution/just-mcp/package.yml
+++ b/projects/github.com/promptexecution/just-mcp/package.yml
@@ -48,7 +48,6 @@ build:
 
 provides:
   - bin/just-mcp
-  - bin/just-mcp.exe
 
 test: |
   just-mcp --version || just-mcp.exe --version

--- a/projects/github.com/promptexecution/just-mcp/package.yml
+++ b/projects/github.com/promptexecution/just-mcp/package.yml
@@ -51,4 +51,4 @@ provides:
   - bin/just-mcp.exe
 
 test: |
-  just-mcp --version
+  just-mcp --version || just-mcp.exe --version


### PR DESCRIPTION
## Summary
- add the pkgx pantry manifest so pkgx can install the just-mcp binary per host/arch
- document the release artifacts the manifest expects so CI upload remains compatible

## Testing
- not run (packaging change only)