### PR TITLE
Add some gnome-shell dependencies

### DIFF
--- a/projects/emersion.fr/libdisplay-info/package.yml
+++ b/projects/emersion.fr/libdisplay-info/package.yml
@@ -1,0 +1,33 @@
+distributable:
+  # returns 403
+  # url: https://gitlab.freedesktop.org/emersion/libdisplay-info/-/releases/{{version}}/downloads/libdisplay-info-{{version}}.tar.xz
+  # strip-components: 1
+  url: git+https://gitlab.freedesktop.org/emersion/libdisplay-info
+  ref: ${{version}}
+
+display-name: libdisplay-info
+
+versions:
+  gitlab: gitlab.freedesktop.org:emersion/libdisplay-info
+
+build:
+  dependencies:
+    github.com/vcrhonek/hwdata: '*'
+    mesonbuild.com: '>=0.57'
+    ninja-build.org: '>=1.8.2'
+  script: |
+    meson setup build $ARGS
+    meson compile -C build --jobs {{ hw.concurrency }}
+    meson install -C build
+  env:
+    ARGS:
+      - --buildtype=release
+      - --prefix={{prefix}}
+      - --libdir=lib
+
+provides:
+  - bin/di-edid-decode
+
+test: |
+  wget https://gitlab.freedesktop.org/emersion/libdisplay-info/-/raw/main/test/data/cvt.edid
+  di-edid-decode cvt.edid

--- a/projects/freedesktop.org/colord/package.yml
+++ b/projects/freedesktop.org/colord/package.yml
@@ -1,0 +1,59 @@
+distributable:
+  url: https://www.freedesktop.org/software/colord/releases/colord-{{version}}.tar.xz
+  strip-components: 1
+
+display-name: colord
+
+versions:
+  github: hughsie/colord/tags
+
+dependencies:
+  gnome.org/glib: '>=2.58'
+  gnome.org/libgudev: '*'
+  hughsie.com/libgusb: '>=0.2.7'
+  littlecms.com: '>=2.6'
+  sqlite.org: '>=3'
+  systemd.io: '*'
+
+# companions:
+#   debian.org/bash-completion: '>=2'
+
+build:
+  dependencies:
+    gnome.org/gobject-introspection: '*'
+    gnome.org/libxslt: '*'
+    gnome.org/vala: '*'
+    mesonbuild.com: '>=0.52'
+    ninja-build.org: '>=1.8.2'
+  script:
+    - patch -p1 < props/relocatable.patch
+    - meson setup build $ARGS
+    - meson compile -C build --jobs {{ hw.concurrency }}
+    - meson install -C build
+    - run: glib-compile-schemas .
+      working-directory: ${{prefix}}/share/glib-2.0/schemas
+  env:
+    ARGS:
+     - --buildtype=release
+     - --prefix={{prefix}}
+     - --libdir=lib
+     - -Dlibcolordcompat=true
+     - -Dargyllcms_sensor=false
+     - -Dvapi=true
+     - -Ddaemon=false
+     - -Dtests=false
+     - -Ddocs=false
+     - -Dman=false
+     - -Dbash_completion=false
+
+provides:
+  - bin/cd-create-profile
+  - bin/cd-fix-profile
+  - bin/cd-iccdump
+  - bin/cd-it8
+  - bin/colormgr
+
+test:
+  # I can't get dbus-daemon to work, so this is the next best thing
+  - run: './colord-session --verbose | grep "CdMain: lost name: org.freedesktop.ColorHelper"'
+    working-directory: ${{prefix}}/libexec

--- a/projects/freedesktop.org/colord/relocatable.patch
+++ b/projects/freedesktop.org/colord/relocatable.patch
@@ -1,0 +1,118 @@
+diff --git a/contrib/session-helper/cd-main.c b/contrib/session-helper/cd-main.c
+index 025b127..7d8ff73 100644
+--- a/contrib/session-helper/cd-main.c
++++ b/contrib/session-helper/cd-main.c
+@@ -66,7 +66,7 @@ typedef struct {
+ 	CdProfileQuality	 quality;
+ 	GCancellable		*cancellable;
+ 	gchar			*title;
+-	gchar			*basename;
++	gchar			*cd_main_private_basename;
+ 	gchar			*working_path;
+ } CdMainPrivate;
+ 
+@@ -800,6 +800,26 @@ cd_main_finished_quit_cb (gpointer user_data)
+ 	return G_SOURCE_REMOVE;
+ }
+ 
++#include <limits.h>
++#include <unistd.h>
++#include <libgen.h>
++#include <stdio.h>
++#include <string.h>
++
++char *get_prefix(char *suffix) {
++  char path[PATH_MAX], prefix[PATH_MAX];
++  int rv = readlink("/proc/self/exe", path, sizeof(path));
++  if (rv != -1) {
++    sprintf(prefix, "%s/%s/", dirname(dirname(path)), suffix);
++    return strdup(prefix);
++  } else {
++    return NULL;
++  }
++}
++
++#undef DATADIR
++#define DATADIR get_prefix("share")
++
+ static gboolean
+ cd_main_load_samples (CdMainPrivate *priv, GError **error)
+ {
+@@ -848,7 +868,7 @@ cd_main_write_colprof_files (CdMainPrivate *priv, GError **error)
+ 	if (!ret)
+ 		return FALSE;
+ 	data = g_strdup_printf ("%s\n%s", data_ti3, data_cal);
+-	filename_ti3 = g_strdup_printf ("%s.ti3", priv->basename);
++	filename_ti3 = g_strdup_printf ("%s.ti3", priv->cd_main_private_basename);
+ 	path_ti3 = g_build_filename (priv->working_path,
+ 				     filename_ti3,
+ 				     NULL);
+@@ -909,7 +929,7 @@ cd_main_import_profile (CdMainPrivate *priv, GError **error)
+ 	g_autofree gchar *path = NULL;
+ 	g_autoptr(GFile) file = NULL;
+ 
+-	filename = g_strdup_printf ("%s.icc", priv->basename);
++	filename = g_strdup_printf ("%s.icc", priv->cd_main_private_basename);
+ 	path = g_build_filename (priv->working_path,
+ 				 filename,
+ 				 NULL);
+@@ -959,7 +979,7 @@ cd_main_set_profile_metadata (CdMainPrivate *priv, GError **error)
+ 	g_autoptr(GFile) file = NULL;
+ 
+ 	/* get profile */
+-	profile_fn = g_strdup_printf ("%s.icc", priv->basename);
++	profile_fn = g_strdup_printf ("%s.icc", priv->cd_main_private_basename);
+ 	profile_path = g_build_filename (priv->working_path,
+ 					 profile_fn,
+ 					 NULL);
+@@ -1052,7 +1072,7 @@ cd_main_generate_profile (CdMainPrivate *priv, GError **error)
+ 	g_ptr_array_add (array, g_strdup_printf ("-C%s", CD_PROFILE_DEFAULT_COPYRIGHT_STRING));
+ 	g_ptr_array_add (array, g_strdup (cd_main_get_colprof_quality_arg (priv->quality)));
+ 	g_ptr_array_add (array, g_strdup ("-aG"));
+-	g_ptr_array_add (array, g_strdup (priv->basename));
++	g_ptr_array_add (array, g_strdup (priv->cd_main_private_basename));
+ 	g_ptr_array_add (array, NULL);
+ 
+ 	/* run the command */
+@@ -1493,7 +1513,7 @@ cd_main_set_basename (CdMainPrivate *priv)
+ 
+ 	/* make suitable filename */
+ 	g_strdelimit (str->str, "/\"*?", '_');
+-	priv->basename = g_string_free (str, FALSE);
++	priv->cd_main_private_basename = g_string_free (str, FALSE);
+ }
+ 
+ static gboolean
+@@ -1838,6 +1858,12 @@ cd_main_percentage_changed_cb (CdState *state,
+ 				       g_variant_new_uint32 (value));
+ }
+ 
++char *concat(char *string1, char *string2) {
++  char concat_string[strlen(string1) + strlen(string2)];
++  sprintf(concat_string, "%s%s", string1, string2);
++  return strdup(concat_string);
++}
++
+ int
+ main (int argc, char *argv[])
+ {
+@@ -1887,8 +1913,8 @@ main (int argc, char *argv[])
+ 	g_option_context_free (context);
+ 
+ 	/* load introspection from file */
+-	priv->introspection = cd_main_load_introspection (DATADIR "/dbus-1/interfaces/"
+-							  CD_SESSION_DBUS_INTERFACE ".xml",
++	priv->introspection = cd_main_load_introspection (concat(DATADIR, "/dbus-1/interfaces/"
++							  CD_SESSION_DBUS_INTERFACE ".xml"),
+ 							  &error);
+ 	if (priv->introspection == NULL) {
+ 		g_warning ("CdMain: failed to load introspection: %s",
+@@ -1955,7 +1981,7 @@ out:
+ 	if (priv->state != NULL)
+ 		g_object_unref (priv->state);
+ 	g_free (priv->working_path);
+-	g_free (priv->basename);
++	g_free (priv->cd_main_private_basename);
+ 	g_free (priv->title);
+ 	g_free (priv);
+ 	return retval;

--- a/projects/github.com/vcrhonek/hwdata/package.yml
+++ b/projects/github.com/vcrhonek/hwdata/package.yml
@@ -1,0 +1,17 @@
+distributable:
+  url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v{{version.marketing}}.tar.gz
+  strip-components: 1
+
+display-name: hwdata
+
+versions:
+  github: vcrhonek/hwdata
+
+build:
+  script: |
+    ./configure $ARGS
+    make --jobs {{ hw.concurrency }} install
+  env:
+    ARGS: --prefix={{prefix}}
+
+test: test $(pkg-config --modversion hwdata) = {{version.marketing}}

--- a/projects/gjs.guide/package.yml
+++ b/projects/gjs.guide/package.yml
@@ -1,0 +1,49 @@
+distributable:
+  url: https://download.gnome.org/sources/gjs/{{version.marketing}}/gjs-{{version}}.tar.xz
+  strip-components: 1
+
+display-name: gjs
+
+versions:
+  gitlab: gitlab.gnome.org:GNOME/gjs
+
+dependencies:
+  cairographics.org: '*'
+  gnome.org/glib: '>=2.86.0'
+  gnu.org/readline: '*'
+  sourceware.org/libffi: '*'
+  spidermonkey.dev: 140
+
+build:
+  dependencies:
+    gnome.org/gobject-introspection: '*'
+    mesonbuild.com: '>=1.4'
+    ninja-build.org: '>=1.8.2'
+  script: |
+    meson setup build $ARGS
+    meson compile -C build --jobs {{ hw.concurrency }}
+    meson install -C build
+  env:
+    ARGS:
+      --buildtype=release
+      --prefix={{prefix}}
+      --libdir=lib
+      -Dinstalled_tests=false
+      -Dskip_dbus_tests=true
+      -Dskip_gtk_tests=true
+      -Dprofiler=disabled
+
+provides:
+  - bin/gjs
+  - bin/gjs-console
+
+test:
+  script:
+    - run: gjs-console $FIXTURE
+      fixture:
+        extname: js
+        content: |
+          const GLib = imports.gi.GLib;
+          print(new GLib.String("Hello, world!").str);
+  env:
+    GI_TYPELIB_PATH: ${{deps.gnome.org/glib.prefix}}/lib/girepository-1.0

--- a/projects/gnome.org/desktop/package.yml
+++ b/projects/gnome.org/desktop/package.yml
@@ -1,0 +1,53 @@
+distributable:
+  url: https://download.gnome.org/sources/gnome-desktop/{{version.major}}/gnome-desktop-{{version.marketing}}.tar.xz
+  strip-components: 1
+
+display-name: gnome-desktop
+
+versions:
+  gitlab: gitlab.gnome.org:GNOME/gnome-desktop
+
+dependencies:
+  debian.org/iso-codes: '*'
+  freedesktop.org/fontconfig: '*'
+  freedesktop.org/XKeyboardConfig: '*'
+  gnome.org/gdk-pixbuf: '>=2.36.5'
+  gnome.org/glib: '>=2.53'
+  gnome.org/gsettings-desktop-schemas: '>=3.27'
+  gtk.org/gtk3: '>=3.3.6'
+  gtk.org/gtk4: '>=4.4'
+  systemd.io: '*'
+  xkbcommon.org: '*'
+  linux:
+    github.com/seccomp/libseccomp: '*'
+
+build:
+  dependencies:
+    gnome.org/gobject-introspection: '*'
+    itstool.org: '*'
+    mesonbuild.com: '>=0.56.2'
+    ninja-build.org: '>=1.8.2'
+  script: |
+    meson setup build $ARGS
+    meson compile -C build --jobs {{ hw.concurrency }}
+    meson install -C build
+  env:
+    ARGS:
+      --buildtype=release
+      --prefix={{prefix}}
+      --libdir=lib
+      -Ddebug_tools=false
+
+test:
+  - run: cc $FIXTURE -lgnome-desktop-4
+    fixture:
+      extname: c
+      contents: |
+        #include <gnome-desktop-4.0/libgnome-desktop/gnome-desktop-version.h>
+        #include <stdio.h>
+        
+        int main() {
+          printf("%d", gnome_get_platform_version());
+          return 0;
+        }
+  - test $(./a.out) = {{version.major}}

--- a/projects/gnome.org/evolution-data-server/package.yml
+++ b/projects/gnome.org/evolution-data-server/package.yml
@@ -1,0 +1,69 @@
+distributable:
+  url: https://download.gnome.org/sources/evolution-data-server/{{version.marketing}}/evolution-data-server-{{version}}.tar.xz
+  strip-components: 1
+
+display-name: evolution-data-server
+
+versions:
+  gitlab: gitlab.gnome.org:GNOME/evolution-data-server
+
+dependencies:
+  github.com/util-linux/util-linux: '>=2'
+  gnome.org/glib: '>=2.68'
+  gnome.org/json-glib: '>=1.0.4'
+  gnome.org/libsecret: '>=0.5'
+  gnome.org/libxml2: '*'
+  gtk.org/gtk3: '>=3.20'
+  gtk.org/gtk4: '>=4.4'
+  libical.github.io: '>=3.0.7'
+  libsoup.org: '>=3.1.1'
+  mozilla.org/nspr: '*'
+  mozilla.org/nss: '*'
+  openldap.org: '>=2'
+  oracle.com/berkeley-db: '*'
+  sqlite.org: '>=3.7.17'
+  unicode.org: '*'
+  zlib.net: '*'
+
+build:
+  dependencies:
+    cmake.org: '>=3.15'
+    gnu.org/gperf: '*'
+    nixos.org/patchelf: '*'
+  script:
+    - cmake . $ARGS
+    - cmake --build . --parallel {{ hw.concurrency }}
+    - cmake --install .
+    # Make RPATHs relative
+    - run: find -maxdepth 1 -type f ! -name 'libcamel-1.2.so.*' -exec patchelf --set-rpath '$ORIGIN/evolution-data-server' {} \;
+      working-directory: ${{prefix}}/lib
+    - run: find -mindepth 2 -type f -name '*.so' -exec patchelf --set-rpath '$ORIGIN/..' {} \;
+      working-directory: ${{prefix}}/lib/evolution-data-server
+    - run: find -maxdepth 1 -type f ! -name 'camel-*' -exec patchelf --set-rpath '$ORIGIN/../lib/evolution-data-server' {} \;
+      working-directory: ${{prefix}}/libexec
+    - run: find -maxdepth 1 -type f ! -name 'csv2vcard' -exec patchelf --set-rpath '$ORIGIN/../../lib/evolution-data-server' {} \;
+      working-directory: ${{prefix}}/libexec/evolution-data-server
+  env:
+    ARGS:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+      - -DENABLE_TESTS=OFF
+      - -DENABLE_OAUTH2_WEBKITGTK=OFF
+      - -DENABLE_OAUTH2_WEBKITGTK4=OFF
+      - -DENABLE_EXAMPLES=OFF
+      - -DENABLE_GOA=OFF
+      - -DENABLE_WEATHER=OFF
+      - -DENABLE_CANBERRA=OFF
+
+test:
+  - run: cc $FIXTURE $(pkg-config --cflags --libs libedataserver-1.2)
+    fixture:
+      extname: c
+      contents: |
+        #include <evolution-data-server/libedataserver/libedataserver.h>
+        
+        int main() {
+          printf("%s", e_util_generate_uid());
+          return 0;
+        }
+  - ./a.out

--- a/projects/gnome.org/gcr/package.yml
+++ b/projects/gnome.org/gcr/package.yml
@@ -1,0 +1,70 @@
+distributable:
+  url: https://download.gnome.org/sources/gcr/{{version.marketing}}/gcr-{{version}}.tar.xz
+  strip-components: 1
+
+display-name: gcr
+
+versions:
+  gitlab: gitlab.gnome.org:GNOME/gcr
+
+dependencies:
+  freedesktop.org/p11-kit: '>=0.19'
+  gnome.org/glib: '>=2.74'
+  gnome.org/libsecret: '>=0.20'
+  gnupg.org/libgcrypt: '>=1.2.2'
+  gtk.org/gtk4: '*'
+  systemd.io: '*'
+
+build:
+  dependencies:
+    gnome.org/gi-docgen: '*'
+    gnome.org/gobject-introspection: '*'
+    gnome.org/vala: '*'
+    gnupg.org: '*'
+    mesonbuild.com: '>=0.59'
+    ninja-build.org: '>=1.8.2'
+    openssh.com: '*'
+  script: |
+    meson setup build $ARGS
+    meson compile -C build --jobs {{ hw.concurrency }}
+    meson install -C build
+  env:
+    ARGS:
+      - --buildtype=release
+      - --prefix={{prefix}}
+      - --libdir=lib
+
+provides:
+  - bin/gcr-viewer-gtk4
+
+test:
+  - wget https://github.com/Pkcs11Interop/pkcs11-mock/releases/download/v2.0.0/pkcs11-mock-2.0.0.zip
+  - unzip pkcs11-mock-2.0.0.zip
+  - run: cc $FIXTURE $(pkg-config --cflags --libs gcr-4)
+    fixture:
+      extname: c
+      content: |
+        #define GCR_API_SUBJECT_TO_CHANGE
+        
+        #include <limits.h>
+        #include <unistd.h>
+        #include <stdio.h>
+        #include <gcr/gcr.h>
+        
+        int main() {
+          char cwd[PATH_MAX], module_path[PATH_MAX];
+          getcwd(cwd, sizeof(cwd));
+          sprintf(module_path, "%s/%s", cwd, "pkcs11-mock-2.0.0/bin/linux/pkcs11-mock-x64.so");
+          printf("Module path: %s\n", module_path);
+          gcr_pkcs11_add_module_from_file(module_path, NULL, NULL);
+          gcr_pkcs11_initialize(NULL, NULL);
+          GList *modules = gcr_pkcs11_get_modules();
+          GckModuleInfo *module_info = gck_module_get_info(modules->data);
+          printf("Module version: %d.%d\n", module_info->pkcs11_version_major, module_info->pkcs11_version_minor);
+          printf("Module manufacturer: %s\n", module_info->manufacturer_id);
+          printf("Module description: %s\n", module_info->library_description);
+          gck_module_info_free(module_info);
+          g_list_free(modules);
+          return 0;
+        }
+  - ./a.out

--- a/projects/gnome.org/libgudev/package.yml
+++ b/projects/gnome.org/libgudev/package.yml
@@ -1,0 +1,50 @@
+distributable:
+  url: https://download.gnome.org/sources/libgudev/{{version.major}}/libgudev-{{version.major}}.tar.xz
+  strip-components: 1
+
+display-name: libgudev
+
+dependencies:
+  gnome.org/glib: '>=2.38'
+  systemd.io: '>=251'
+
+versions:
+  gitlab: gitlab.gnome.org:GNOME/libgudev/tags
+
+build:
+  dependencies:
+    gnome.org/gobject-introspection: '*'
+    gnome.org/vala: '*'
+    mesonbuild.com: '>=0.53'
+    ninja-build.org: '>=1.8.2'
+  script: |
+    sed -i '/-export-dynamic/d' gudev/meson.build
+    meson setup build $ARGS
+    meson compile -C build --jobs {{ hw.concurrency }}
+    meson install -C build
+  env:
+    ARGS:
+      - --buildtype=release
+      - --prefix={{prefix}}
+      - --libdir=lib
+
+test:
+  - run: cc $FIXTURE $(pkg-config --cflags --libs gudev-1.0)
+    fixture:
+      extname: c
+      contents: |
+        #include <gudev/gudev.h>
+        #include <stdio.h>
+
+        int main() {
+          GUdevClient *client = g_udev_client_new(NULL);
+          GList *devices = g_udev_client_query_by_subsystem(client, NULL);
+          printf("Device name: %s\n", g_udev_device_get_name(devices->data));
+          printf("Device number: %s\n", g_udev_device_get_number(devices->data));
+          printf("Device path: %s\n", g_udev_device_get_sysfs_path(devices->data));
+          printf("Device subsystem: %s\n", g_udev_device_get_subsystem(devices->data));
+          g_list_free(devices);
+          g_object_unref(client);
+          return 0;
+        }
+  - ./a.out

--- a/projects/gnome.org/pango/package.yml
+++ b/projects/gnome.org/pango/package.yml
@@ -34,6 +34,7 @@ build:
       - -Dcairo=enabled
       - -Dfontconfig=enabled
       - -Dfreetype=enabled
+      - -Dintrospection=enabled
       - --buildtype=release
       - --prefix={{prefix}}
       - --libdir={{prefix}}/lib

--- a/projects/gtk.org/gtk4/package.yml
+++ b/projects/gtk.org/gtk4/package.yml
@@ -64,6 +64,7 @@ build:
       - -Dbuild-examples=false
       - -Dbuild-tests=false
       - -Dmedia-gstreamer=disabled
+      - -Dintrospection=enabled
     darwin:
       MESON_ARGS:
         - -Dx11-backend=false

--- a/projects/hughsie.com/libgusb/package.yml
+++ b/projects/hughsie.com/libgusb/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/hughsie/libgusb/releases/download/{{version}}/libgusb-{{version}}.tar.xz
+  strip-components: 1
+
+display-name: libgusb
+
+versions:
+  github: hughsie/libgusb
+
+dependencies:
+  gnome.org/glib: '>=2.44'
+  gnome.org/json-glib: '>=1.1.1'
+  libusb.info: '>=1.0.9'
+
+build:
+  dependencies:
+    gnome.org/gi-docgen: '>=2021.1'
+    gnome.org/gobject-introspection: '*'
+    gnome.org/vala: '*'
+    mesonbuild.com: '>=0.56'
+    ninja-build.org: '>=1.8.2'
+  script: |
+    meson setup build $ARGS
+    meson compile -C build --jobs {{ hw.concurrency }}
+    meson install -C build
+  env:
+    ARGS:
+      - --buildtype=release
+      - --prefix={{prefix}}
+      - --libdir=lib
+      - -Dtests=false
+
+provides:
+  - bin/gusbcmd
+
+test: gusbcmd show

--- a/projects/libical.github.io/package.yml
+++ b/projects/libical.github.io/package.yml
@@ -1,0 +1,46 @@
+distributable:
+  url: https://github.com/libical/libical/releases/download/v{{version}}/libical-{{version}}.tar.gz
+  strip-components: 1
+
+display-name: libical
+
+dependencies:
+  gnome.org/glib: '>=2.32'
+  gnome.org/libxml2: '>=2.7.3'
+  oracle.com/berkeley-db: '*'
+  unicode.org: '*'
+versions:
+  github: libical/libical
+
+build:
+  dependencies:
+    cmake.org: '>=3.5'
+    doxygen.nl: '*'
+  script: |
+    cmake . $ARGS
+    cmake --build . --parallel {{ hw.concurrency }}
+    cmake --install .
+  env:
+    ARGS:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+      - -DLIBICAL_BUILD_TESTING=OFF
+      - -DLIBICAL_BUILD_EXAMPLES=OFF
+      - -DBerkeleyDB_ROOT_DIR={{deps.oracle.com/berkeley-db.prefix}}
+      - -DICU_ROOT={{deps.unicode.org.prefix}}
+      - -DENABLE_GTK_DOC=OFF
+
+test:
+  - run: cc $FIXTURE -lical
+    fixture:
+      extname: c
+      content: |
+        #include <libical/ical.h>
+        #include <stdio.h>
+
+        int main() {
+          struct icaltimetype date = icaltime_today();
+          printf("%d-%02d-%02d", date.year, date.month, date.day);
+          return 0;
+        }
+  - test $(./a.out) = $(date -I)

--- a/projects/spidermonkey.dev/package.yml
+++ b/projects/spidermonkey.dev/package.yml
@@ -1,0 +1,53 @@
+distributable:
+  url: https://ftp.mozilla.org/pub/firefox/releases/{{version}}esr/source/firefox-{{version}}esr.source.tar.xz
+  strip-components: 1
+
+display-name: SpiderMonkey
+
+versions:
+  url: https://ftp.mozilla.org/pub/firefox/releases/
+  match: /\d+\.\d+(\.\d+)esr/
+  strip: /esr$/
+
+dependencies:
+  mozilla.org/nspr: '>=4.10'
+  # sourceware.org/libffi: '>3.0.9'
+  unicode.org: '>=76.1'
+  zlib.net: '>=1.2.3'
+
+build:
+  dependencies:
+    mozilla.org/cbindgen: '>=0.27.0'
+    python.org: '>=3<3.14'
+    rust-lang.org: '>=1.82'
+  script:
+    - sed -i '$i#define XP_UNIX' js/src/js-config.h.in
+    - run: cp $PROP mozconfig
+      prop: |
+        ac_add_options --enable-project=js
+        ac_add_options --prefix={{prefix}}
+        ac_add_options --disable-tests
+        ac_add_options --enable-strip
+        ac_add_options --with-system-zlib
+        ac_add_options --disable-debug-symbols
+        ac_add_options --enable-js-shell
+        ac_add_options --enable-jit
+        ac_add_options --enable-rust-simd
+        ac_add_options --with-system-icu
+        ac_add_options --with-system-nspr
+        # mozbuild.configure.options.InvalidOptionError: --with-system-ffi is not available in this configuration
+        # ac_add_options --with-system-ffi
+        ac_add_options --enable-optimize
+        ac_add_options --disable-jemalloc
+    - ./mach build --jobs {{ hw.concurrency }}
+    - ./mach install
+
+provides:
+  - bin/js{{version.major}}
+  - bin/js{{version.major}}-config
+
+test:
+  - run: js{{version.major}} $FIXTURE
+    fixture:
+      extname: js
+      contents: console.log("Hello, world!")


### PR DESCRIPTION
New packages:
* emersion.fr/libdisplay-info
* freedesktop.org/colord
* github.com/vcrhonek/hwdata
* gjs.guide
* gnome.org/desktop
* gnome.org/evolution-data-server
* gnome.org/gcr
* gnome.org/libgudev
* hughsie.com/libgusb
* libical.github.io
* spidermonkey.dev

This pull request adds some of the dependencies needed for #6013.

`pkgx di-edid-decode`, `pkgx colormgr`, `pkgx gjs`, etc. don't work after building their corresponding packages, even after setting `PKGX_PANTRY_PATH`. Setting `PKGX_PANTRY_DIR` instead causes this error:
```
Error: "PKGX_PANTRY_DIR is set, refusing to update pantry"
```

Packages such as [colord](https://github.com/hughsie/colord/blob/f5220d8ec5811f5ba20d3f0eb54f30a57df1bc22/data/meson.build#L10C3-L12C4) should not use the `bash-completion` pkg-config file to decide the installation directory of their Bash completion file(s). This is because the pkg-config file sets the completions directory to `~/.pkgx/debian.org/bash-completion/v2.11.0/share/bash-completion/completions` instead of the package's prefix, which causes the completion file(s) to be misplaced.

I can't get `dbus-daemon`/`dbus-run-session` to work, which is needed to run the colord daemon. When I ran `pkgx dbus-daemon --config-file=$HOME/.pkgx/freedesktop.org/dbus/v1.16.2/share/dbus-1/session.conf --fork --nopidfile --nosyslog`, I got this error:
```
dbus-daemon[11754]: Failed to start message bus: Failed to bind socket "/__w/pantry/pantry/homes/freedesktop.org__dbus-1.16.2/tmp/dbus-n7kogPHKGz": No such file or directory
```