### PR TITLE
+babashka.org bb

### DIFF
--- a/projects/babashka.org/package.yml
+++ b/projects/babashka.org/package.yml
@@ -1,0 +1,32 @@
+provides:
+  - bin/bb
+versions:
+  github: babashka/babashka
+build:
+  env:
+    BASE_URL: https://github.com/babashka/babashka/releases/download/v{{version}}
+    FILENAME_PREFIX: babashka-{{version}}-
+    darwin:
+      PLATFORM: macos
+    darwin/aarch64:
+      ARCH: aarch64
+    darwin/x86-64:
+      ARCH: amd64
+    linux:
+      PLATFORM: linux
+      SUFFIX: -static
+    linux/aarch64:
+      ARCH: aarch64
+    linux/x86-64:
+      ARCH: amd64
+  script: |
+    FILENAME="${FILENAME_PREFIX}${PLATFORM}-${ARCH}${SUFFIX}.tar.gz"
+    curl -L -o dist.tar.gz "${BASE_URL}/${FILENAME}"
+    tar xzf dist.tar.gz
+    mkdir -p {{prefix}}/bin
+    mv bb {{prefix}}/bin/bb
+    chmod +x {{prefix}}/bin/bb
+test:
+  script: |
+    bb --version | grep {{version}}
+    bb -e '(+ 1 2)' | grep 3

--- a/projects/babashka.org/package.yml
+++ b/projects/babashka.org/package.yml
@@ -1,32 +1,52 @@
+distributable: ~
+
+# TODO: build from source. Looks like it's using a bunch of stuff we
+# don't have packaged yet (like GraalVM and lein).
+# We should be able to bootstrap it from itself.
+warnings:
+  - vendored
+
 provides:
   - bin/bb
+
+interprets:
+  extensions: [clj, cljc, cljs]
+  args: bb
+
 versions:
   github: babashka/babashka
+
 build:
   env:
-    BASE_URL: https://github.com/babashka/babashka/releases/download/v{{version}}
+    BASE_URL: https://github.com/babashka/babashka/releases/download/{{version.tag}}
     FILENAME_PREFIX: babashka-{{version}}-
     darwin:
       PLATFORM: macos
-    darwin/aarch64:
-      ARCH: aarch64
-    darwin/x86-64:
-      ARCH: amd64
     linux:
       PLATFORM: linux
       SUFFIX: -static
-    linux/aarch64:
+    aarch64:
       ARCH: aarch64
-    linux/x86-64:
+    x86-64:
       ARCH: amd64
-  script: |
-    FILENAME="${FILENAME_PREFIX}${PLATFORM}-${ARCH}${SUFFIX}.tar.gz"
-    curl -L -o dist.tar.gz "${BASE_URL}/${FILENAME}"
-    tar xzf dist.tar.gz
-    mkdir -p {{prefix}}/bin
-    mv bb {{prefix}}/bin/bb
-    chmod +x {{prefix}}/bin/bb
+  script:
+    - curl -L "${BASE_URL}/${FILENAME_PREFIX}${PLATFORM}-${ARCH}${SUFFIX}.tar.gz" | tar zxvf -
+    - install -Dm755 bb {{prefix}}/bin/bb
+
 test:
-  script: |
-    bb --version | grep {{version}}
-    bb -e '(+ 1 2)' | grep 3
+  dependencies:
+    pkgx.sh: "*"
+  script:
+    - test "$(bb --version)" = "babashka v{{version}}"
+    - test "$(bb -e '(+ 1 2)')" = "3"
+    - run:
+        - chmod +x $FIXTURE
+        - test "$(bb $FIXTURE)" = "Hello, babashka!"
+        - test "$(pkgx $FIXTURE)" = "Hello, babashka!"
+        - test "$($FIXTURE)" = "Hello, babashka!"
+      fixture:
+        content: |
+          #!/usr/bin/env bb
+
+          (println "Hello, babashka!")
+        extname: clj


### PR DESCRIPTION
This changeset adds a `babashka.org` package which provides the `bb` executable, from pre-built releases (available from GitHub).

This allows `pkgx` users to successfully execute commands such as `pkgx bb -e '(println "hi")'`.

https://babashka.org

> Fast native Clojure scripting runtime
Avoid switching between Clojure and bash scripts. Enjoy your parens on the command line.

As you can see from the build script, the URL to the GitHub releases are version, platform, and architecture-specific so there is no `distributable` in this package manifest.