### PR TITLE
feat: add github.com/raskell-io/hx

### DIFF
--- a/projects/github.com/raskell-io/hx/package.yml
+++ b/projects/github.com/raskell-io/hx/package.yml
@@ -1,0 +1,25 @@
+distributable:
+  url: https://github.com/raskell-io/hx/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+display-name: hx
+
+versions:
+  github: raskell-io/hx
+
+provides:
+  - bin/hx
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.85'
+    rust-lang.org/cargo: '*'
+    freedesktop.org/pkg-config: '*'
+    openssl.org: ^1.1
+  script:
+    - cargo install --root={{prefix}} --locked --path=crates/hx-cli
+
+test:
+  script:
+    - hx --version | grep {{version}}
+    - hx doctor

--- a/projects/github.com/raskell-io/hx/package.yml
+++ b/projects/github.com/raskell-io/hx/package.yml
@@ -10,16 +10,18 @@ versions:
 provides:
   - bin/hx
 
+companions:
+  haskell.org: "*"
+  haskell.org/cabal: "*"
+
 build:
   dependencies:
     rust-lang.org: '>=1.85'
     rust-lang.org/cargo: '*'
-    freedesktop.org/pkg-config: '*'
     openssl.org: ^1.1
-  script:
-    - cargo install --root={{prefix}} --locked --path=crates/hx-cli
+  script: cargo install --root={{prefix}} --locked --path=crates/hx-cli
 
 test:
-  script:
-    - hx --version | grep {{version}}
-    - hx doctor
+  - hx --version | tee out
+  - grep {{version}} out
+  - hx doctor


### PR DESCRIPTION
hx is a CLI for Haskell that wraps ghc/cabal/ghcup into something less painful.

- Homepage: https://github.com/raskell-io/hx
- License: MIT
- Written in Rust