### PR TITLE
add openclaw v2026.2.24 package with openclaw-init wrapper

### DIFF
--- a/projects/github.com/openclaw/openclaw/openclaw-init
+++ b/projects/github.com/openclaw/openclaw/openclaw-init
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+openclaw-init: initialize OpenClaw config from a markdown manifest front matter.
+
+Usage:
+  openclaw-init <manifest.md> [--write-only] [--output <config.json>]
+  openclaw-init --help
+
+Options:
+  --write-only        Write config and exit without launching OpenClaw.
+  --output <path>     Config output path (default: ~/.openclaw/openclaw.json).
+
+Manifest format:
+  YAML front matter between the first two lines containing only `---`.
+USAGE
+}
+
+manifest=""
+write_only=0
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --write-only)
+      write_only=1
+      shift
+      ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --output requires a path" >&2
+        exit 2
+      fi
+      output="$2"
+      shift 2
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$manifest" ]]; then
+        echo "error: only one manifest path is supported" >&2
+        exit 2
+      fi
+      manifest="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$manifest" ]]; then
+  echo "error: missing manifest path" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "$manifest" ]]; then
+  echo "error: manifest not found: $manifest" >&2
+  exit 2
+fi
+
+default_output="${HOME}/.openclaw/openclaw.json"
+if [[ -z "$output" ]]; then
+  output="$default_output"
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "error: yq is required but not found in PATH" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but not found in PATH" >&2
+  exit 2
+fi
+if ! command -v sed >/dev/null 2>&1; then
+  echo "error: sed is required but not found in PATH" >&2
+  exit 2
+fi
+
+frontmatter="$(sed '/^--- *$/,/^--- *$/{ /^--- *$/d; p; }' "$manifest")"
+
+if [[ -z "${frontmatter//[[:space:]]/}" ]]; then
+  echo "error: no YAML front matter found in manifest" >&2
+  exit 2
+fi
+
+manifest_json="$(printf '%s\n' "$frontmatter" | yq -o=json '.')"
+
+jq_str() {
+  printf '%s' "$manifest_json" | jq -r "$1"
+}
+
+model="$(jq_str '.agent.model // .agent.model.primary // empty')"
+workspace="$(jq_str '.runtime.workspace // "."')"
+provider_key_env="$(jq_str '.auth.provider_api_key_env // empty')"
+
+if [[ -z "$model" ]]; then
+  echo "error: missing .agent.model in manifest" >&2
+  exit 2
+fi
+
+if [[ -n "$provider_key_env" ]]; then
+  provider_api_key="${!provider_key_env:-}"
+  if [[ -z "$provider_api_key" ]]; then
+    echo "error: required environment variable is not set: $provider_key_env" >&2
+    exit 2
+  fi
+fi
+
+config_json="$(
+  jq -n \
+    --arg model "$model" \
+    --arg workspace "$workspace" \
+    '{
+      agent: { model: $model },
+      agents: { defaults: { workspace: $workspace } }
+    }'
+)"
+
+mkdir -p "$(dirname "$output")"
+printf '%s\n' "$config_json" >"$output"
+chmod 600 "$output"
+
+echo "Wrote OpenClaw config: $output"
+
+if [[ "$write_only" -eq 1 ]]; then
+  exit 0
+fi
+
+if ! command -v openclaw >/dev/null 2>&1; then
+  echo "error: openclaw binary not found in PATH" >&2
+  exit 2
+fi
+
+if [[ "$output" != "$default_output" ]]; then
+  mkdir -p "$(dirname "$default_output")"
+  cp "$output" "$default_output"
+  chmod 600 "$default_output"
+fi
+
+launch_mode="$(jq_str '.launch.mode // "agent"')"
+first_message="$(jq_str '.launch.first_message // .launch.message // empty')"
+gateway_port="$(jq_str '.launch.gateway_port // empty')"
+
+case "$launch_mode" in
+  gateway)
+    if [[ -n "$gateway_port" ]]; then
+      exec openclaw gateway --port "$gateway_port"
+    else
+      exec openclaw gateway
+    fi
+    ;;
+  onboard)
+    exec openclaw onboard
+    ;;
+  agent|"")
+    if [[ -n "$first_message" ]]; then
+      exec openclaw agent --message "$first_message"
+    else
+      exec openclaw agent
+    fi
+    ;;
+  *)
+    echo "error: unsupported launch.mode: $launch_mode (expected agent, gateway, or onboard)" >&2
+    exit 2
+    ;;
+esac

--- a/projects/github.com/openclaw/openclaw/package.yml
+++ b/projects/github.com/openclaw/openclaw/package.yml
@@ -1,0 +1,60 @@
+distributable:
+  url: https://registry.npmjs.org/openclaw/-/openclaw-{{version}}.tgz
+  strip-components: 1
+
+display-name: openclaw
+
+versions:
+  npm: openclaw
+  ignore: 0.0.1
+
+provides:
+  - bin/openclaw
+  - bin/openclaw-init
+
+dependencies:
+  nodejs.org: "*"
+  github.com/mikefarah/yq: "*"
+  stedolan.github.io/jq: "*"
+  gnu.org/sed: "*"
+
+build:
+  dependencies:
+    nodejs.org: "*"
+    npmjs.com: "*"
+    linux:
+      cmake.org: 3
+  script:
+    - npm i $ARGS .
+    - install -Dm755 props/openclaw-init {{prefix}}/bin/openclaw-init
+  env:
+    ARGS:
+      - --global
+      - --prefix={{prefix}}
+      - --install-links
+      - --unsafe-perm
+
+test:
+  - openclaw --version | grep -q "{{version}}"
+  - run: openclaw help >/dev/null 2>&1 || true
+  - run: openclaw-init --help | grep -q "openclaw-init"
+  - run:
+      - export OPENAI_API_KEY="test-key"
+      - openclaw-init $FIXTURE --write-only --output ./openclaw.json
+      - test -f ./openclaw.json
+      - jq -e '.agent.model == "openai/gpt-5"' ./openclaw.json
+      - jq -e '.agents.defaults.workspace == "."' ./openclaw.json
+    fixture:
+      extname: md
+      content: |
+        ---
+        agent:
+          model: "openai/gpt-5"
+        auth:
+          provider_api_key_env: "OPENAI_API_KEY"
+        runtime:
+          workspace: "."
+        launch:
+          mode: "agent"
+          first_message: "Hello from OpenClaw!"
+        ---


### PR DESCRIPTION
Summary:
- add github.com/openclaw/openclaw pantry package backed by npm openclaw@2026.2.24
- provide bin/openclaw and bin/openclaw-init
- add openclaw-init helper to generate ~/.openclaw/openclaw.json from markdown front matter and optionally launch openclaw

Validation:
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-openclaw-data pkgx bk build github.com/openclaw/openclaw@2026.2.24
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-openclaw-data pkgx bk test github.com/openclaw/openclaw@2026.2.24
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-openclaw-data pkgx bk audit github.com/openclaw/openclaw@2026.2.24

Notes:
- local validation uses explicit pantry path env vars so brewkit resolves this new package from the working tree
- local validation uses XDG_DATA_HOME under /tmp to avoid brewkit build-dir path issues with spaces