### PR TITLE
add pi.dev package with pi-init wrapper

### DIFF
--- a/projects/pi.dev/package.yml
+++ b/projects/pi.dev/package.yml
@@ -1,0 +1,55 @@
+distributable:
+  url: https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-{{version}}.tgz
+  strip-components: 1
+
+display-name: pi.dev
+
+versions:
+  npm: "@mariozechner/pi-coding-agent"
+
+provides:
+  - bin/pi
+  - bin/pi-init
+
+dependencies:
+  nodejs.org: ^20
+  github.com/mikefarah/yq: "*"
+  stedolan.github.io/jq: "*"
+  gnu.org/sed: "*"
+
+build:
+  dependencies:
+    nodejs.org: ^20
+    npmjs.com: "*"
+  script:
+    - npm i $ARGS .
+    - install -Dm755 props/pi-init {{prefix}}/bin/pi-init
+  env:
+    ARGS:
+      - --global
+      - --prefix={{prefix}}
+      - --install-links
+      - --unsafe-perm
+
+test:
+  - pi --version | grep -q "{{version}}"
+  - run: pi-init --help | grep -q "pi-init"
+  - run:
+      - export OPENAI_API_KEY="test-key"
+      - pi-init $FIXTURE --write-only --output ./settings.json
+      - test -f ./settings.json
+      - jq -e '.model == "openai/gpt-5"' ./settings.json
+      - jq -e '.api_key_env == "OPENAI_API_KEY"' ./settings.json
+    fixture:
+      extname: md
+      content: |
+        ---
+        agent:
+          model: "openai/gpt-5"
+        auth:
+          provider_api_key_env: "OPENAI_API_KEY"
+        runtime:
+          workspace: "."
+        launch:
+          mode: "interactive"
+        ---

--- a/projects/pi.dev/pi-init
+++ b/projects/pi.dev/pi-init
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+pi-init: initialize Pi settings from a markdown manifest front matter.
+
+Usage:
+  pi-init <manifest.md> [--write-only] [--output <settings.json>]
+  pi-init --help
+
+Options:
+  --write-only        Write settings and exit without launching Pi.
+  --output <path>     Settings output path (default: <workspace>/.pi/settings.json).
+
+Manifest format:
+  YAML front matter between the first two lines containing only `---`.
+USAGE
+}
+
+manifest=""
+write_only=0
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --write-only)
+      write_only=1
+      shift
+      ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --output requires a path" >&2
+        exit 2
+      fi
+      output="$2"
+      shift 2
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$manifest" ]]; then
+        echo "error: only one manifest path is supported" >&2
+        exit 2
+      fi
+      manifest="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$manifest" ]]; then
+  echo "error: missing manifest path" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "$manifest" ]]; then
+  echo "error: manifest not found: $manifest" >&2
+  exit 2
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "error: yq is required but not found in PATH" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but not found in PATH" >&2
+  exit 2
+fi
+if ! command -v sed >/dev/null 2>&1; then
+  echo "error: sed is required but not found in PATH" >&2
+  exit 2
+fi
+
+frontmatter="$(sed '/^--- *$/,/^--- *$/{ /^--- *$/d; p; }' "$manifest")"
+
+if [[ -z "${frontmatter//[[:space:]]/}" ]]; then
+  echo "error: no YAML front matter found in manifest" >&2
+  exit 2
+fi
+
+manifest_json="$(printf '%s\n' "$frontmatter" | yq -o=json '.')"
+
+jq_str() {
+  printf '%s' "$manifest_json" | jq -r "$1"
+}
+
+model="$(jq_str '.agent.model // .agent.model.primary // empty')"
+api_key_env="$(jq_str '.auth.provider_api_key_env // empty')"
+workspace="$(jq_str '.runtime.workspace // "."')"
+launch_mode="$(jq_str '.launch.mode // "interactive"')"
+
+if [[ -z "$model" ]]; then
+  echo "error: missing .agent.model in manifest" >&2
+  exit 2
+fi
+
+if [[ -n "$api_key_env" ]]; then
+  api_key_value="${!api_key_env:-}"
+  if [[ -z "$api_key_value" ]]; then
+    echo "error: required environment variable is not set: $api_key_env" >&2
+    exit 2
+  fi
+fi
+
+if [[ -z "$output" ]]; then
+  output="${workspace}/.pi/settings.json"
+fi
+
+settings_json="$(
+  jq -n \
+    --arg model "$model" \
+    --arg workspace "$workspace" \
+    --arg api_key_env "$api_key_env" \
+    --arg manifest "$manifest" \
+    '{
+      model: $model,
+      workspace: $workspace,
+      api_key_env: $api_key_env,
+      generated_by: "pi-init",
+      manifest: $manifest
+    }'
+)"
+
+mkdir -p "$(dirname "$output")"
+printf '%s\n' "$settings_json" >"$output"
+chmod 600 "$output"
+
+echo "Wrote Pi settings: $output"
+
+if [[ "$write_only" -eq 1 ]]; then
+  exit 0
+fi
+
+if ! command -v pi >/dev/null 2>&1; then
+  echo "error: pi binary not found in PATH" >&2
+  exit 2
+fi
+
+cd "$workspace"
+
+case "$launch_mode" in
+  interactive|"")
+    exec pi
+    ;;
+  resume)
+    exec pi -c
+    ;;
+  browse)
+    exec pi -r
+    ;;
+  no-session)
+    exec pi --no-session
+    ;;
+  *)
+    echo "error: unsupported launch.mode: $launch_mode (expected interactive, resume, browse, or no-session)" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Summary:
- add new pantry package pi.dev for @mariozechner/pi-coding-agent
- provide bin/pi and bin/pi-init
- add pi-init helper to generate Pi settings from markdown front matter and optionally launch Pi

Validation:
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-pi-data pkgx bk build -C pi.dev@0.55.1
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-pi-data pkgx bk test pi.dev@0.55.1
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-pi-data pkgx bk audit pi.dev@0.55.1

Notes:
- helper validates required API key env var when manifest declares auth.provider_api_key_env
- wrapper writes to <workspace>/.pi/settings.json by default