### PR TITLE
update opencode.ai to opencode-ai and add opencode-init wrapper

### DIFF
--- a/projects/opencode.ai/opencode-init
+++ b/projects/opencode.ai/opencode-init
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+opencode-init: initialize OpenCode launch context from markdown manifest front matter.
+
+Usage:
+  opencode-init <manifest.md> [--write-only] [--output <path.json>]
+  opencode-init --help
+
+Options:
+  --write-only        Write context file and exit without launching OpenCode.
+  --output <path>     Output path (default: ~/.opencode/init-context.json).
+
+Manifest format:
+  YAML front matter between the first two lines containing only `---`.
+USAGE
+}
+
+manifest=""
+write_only=0
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --write-only)
+      write_only=1
+      shift
+      ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --output requires a path" >&2
+        exit 2
+      fi
+      output="$2"
+      shift 2
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$manifest" ]]; then
+        echo "error: only one manifest path is supported" >&2
+        exit 2
+      fi
+      manifest="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$manifest" ]]; then
+  echo "error: missing manifest path" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "$manifest" ]]; then
+  echo "error: manifest not found: $manifest" >&2
+  exit 2
+fi
+
+if [[ -z "$output" ]]; then
+  output="${HOME}/.opencode/init-context.json"
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "error: yq is required but not found in PATH" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but not found in PATH" >&2
+  exit 2
+fi
+if ! command -v sed >/dev/null 2>&1; then
+  echo "error: sed is required but not found in PATH" >&2
+  exit 2
+fi
+
+frontmatter="$(sed '/^--- *$/,/^--- *$/{ /^--- *$/d; p; }' "$manifest")"
+
+if [[ -z "${frontmatter//[[:space:]]/}" ]]; then
+  echo "error: no YAML front matter found in manifest" >&2
+  exit 2
+fi
+
+manifest_json="$(printf '%s\n' "$frontmatter" | yq -o=json '.')"
+
+jq_str() {
+  printf '%s' "$manifest_json" | jq -r "$1"
+}
+
+model="$(jq_str '.agent.model // .agent.model.primary // empty')"
+workspace="$(jq_str '.runtime.workspace // "."')"
+api_key_env="$(jq_str '.auth.provider_api_key_env // empty')"
+launch_mode="$(jq_str '.launch.mode // "interactive"')"
+first_message="$(jq_str '.launch.first_message // .launch.message // empty')"
+
+if [[ -z "$model" ]]; then
+  echo "error: missing .agent.model in manifest" >&2
+  exit 2
+fi
+
+if [[ -n "$api_key_env" ]]; then
+  api_key_value="${!api_key_env:-}"
+  if [[ -z "$api_key_value" ]]; then
+    echo "error: required environment variable is not set: $api_key_env" >&2
+    exit 2
+  fi
+fi
+
+context_json="$(
+  jq -n \
+    --arg model "$model" \
+    --arg workspace "$workspace" \
+    --arg api_key_env "$api_key_env" \
+    --arg launch_mode "$launch_mode" \
+    --arg first_message "$first_message" \
+    --arg manifest "$manifest" \
+    '{
+      model: $model,
+      workspace: $workspace,
+      api_key_env: $api_key_env,
+      launch_mode: $launch_mode,
+      first_message: $first_message,
+      generated_by: "opencode-init",
+      manifest: $manifest
+    }'
+)"
+
+mkdir -p "$(dirname "$output")"
+printf '%s\n' "$context_json" >"$output"
+chmod 600 "$output"
+
+echo "Wrote OpenCode init context: $output"
+
+if [[ "$write_only" -eq 1 ]]; then
+  exit 0
+fi
+
+if ! command -v opencode >/dev/null 2>&1; then
+  echo "error: opencode binary not found in PATH" >&2
+  exit 2
+fi
+
+cd "$workspace"
+exec opencode

--- a/projects/opencode.ai/package.yml
+++ b/projects/opencode.ai/package.yml
@@ -1,91 +1,62 @@
 distributable:
-  url: https://github.com/sst/opencode/archive/refs/tags/{{version.tag}}.tar.gz
+  url: https://registry.npmjs.org/opencode-ai/-/opencode-ai-{{version}}.tgz
   strip-components: 1
 
 display-name: opencode
 
 versions:
-  github: sst/opencode
+  npm: opencode-ai
 
 platforms:
+  - linux/x86-64
   - darwin
-  - linux/x86-64 # FIXME: `sharp`'s postinstall runs for 6 hours until it's killed by CI
-
-build:
-  dependencies:
-    # bun.sh: =1.3.6 # constant drift. use pkgx.
-    stedolan.github.io/jq: "*" # extract bun version
-    pkgx.sh: "*" # use specific bun version
-    go.dev: "^1.24"
-    python.org: 3 # since 0.4.45 for node-gyp
-    npmjs.com: "*" # since 0.11.5 for husky
-  script:
-    - run: npm i -g husky
-      if: ">=0.11.5"
-    - run: npm i -g node-gyp
-      if: ">=1.0.144"
-
-    - mkdir -p packages/opencode/dist
-
-    # out-of-date lockfile frequently released
-    - run: rm bun.lock
-      if: <1
-
-    - $BUN install --production
-
-    # missing dep
-    - run: $BUN install semver
-      if: ">=1.1.28"
-
-    - run:
-        - go mod download
-        - go build -ldflags "$GO_LDFLAGS" -o ../opencode/dist/tui ./cmd/opencode/main.go
-      working-directory: packages/tui
-      if: <1
-
-    - run:
-        - $BUN build --define "OPENCODE_VERSION='{{version}}'" ./src/index.ts ./dist/tui --compile --minify --target=bun --outfile ./dist/opencode
-        - install -Dm755 ./dist/opencode {{prefix}}/bin/opencode
-      working-directory: packages/opencode
-      if: <1
-
-    - run:
-        - $BUN run ./script/build.ts --single
-        - install -Dm755 dist/opencode-{{hw.platform}}-$ARCH/bin/opencode {{prefix}}/bin/opencode
-      working-directory: packages/opencode
-      if: ">=1"
-
-    - run:
-        - file opencode
-        - otool -l opencode
-        - codesign --remove-signature opencode || true
-      working-directory: ${{prefix}}/bin
-      if: darwin
-
-  skip: fix-patchelf
-  env:
-    # fix version drift
-    BUN: "pkgx $(jq -r .packageManager package.json)"
-    PATH: $HOME/.local/bin:$PATH
-    GO_LDFLAGS:
-      - -s
-      - -w
-      - -X main.Version={{version}}
-    linux:
-      CXXFLAGS: $CXXFLAGS -std=c++20
-      GO_LDFLAGS:
-        - -buildmode=pie
-    # since v1
-    OPENCODE_CHANNEL: latest
-    OPENCODE_VERSION: ${{version}}
-    x86-64:
-      ARCH: x64
-    aarch64:
-      ARCH: arm64
 
 provides:
   - bin/opencode
+  - bin/opencode-init
+
+dependencies:
+  nodejs.org: "*"
+  github.com/mikefarah/yq: "*"
+  stedolan.github.io/jq: "*"
+  gnu.org/sed: "*"
+
+build:
+  dependencies:
+    nodejs.org: "*"
+    npmjs.com: "*"
+  script:
+    - npm i $ARGS .
+    - install -Dm755 props/opencode-init {{prefix}}/bin/opencode-init
+  env:
+    ARGS:
+      - --global
+      - --prefix={{prefix}}
+      - --install-links
+      - --unsafe-perm
 
 test:
   - opencode --version
-  - test "$(opencode --version)" = {{version}}
+  - opencode --version 2>&1 | grep "{{version}}"
+  - run: opencode --help >/dev/null 2>&1 || true
+  - run: opencode-init --help | grep -q "opencode-init"
+  - run:
+      - export OPENAI_API_KEY="test-key"
+      - opencode-init $FIXTURE --write-only --output ./opencode-init.json
+      - test -f ./opencode-init.json
+      - jq -e '.model == "openai/gpt-5"' ./opencode-init.json
+      - jq -e '.api_key_env == "OPENAI_API_KEY"' ./opencode-init.json
+    fixture:
+      extname: md
+      content: |
+        ---
+        agent:
+          model: "openai/gpt-5"
+        auth:
+          provider_api_key_env: "OPENAI_API_KEY"
+        runtime:
+          workspace: "."
+        launch:
+          mode: "interactive"
+          first_message: "Summarize this repository."
+        ---


### PR DESCRIPTION
Summary:
- migrate opencode.ai package source to current npm distribution opencode-ai
- update version source to npm opencode-ai (latest validated: 1.2.14)
- add bin/opencode-init helper wrapper for manifest-based setup and launch

Validation:
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-opencode-data pkgx bk build -C opencode.ai@1.2.14
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-opencode-data pkgx bk test opencode.ai@1.2.14
- PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-opencode-data pkgx bk audit opencode.ai@1.2.14

Notes:
- helper validates API key env vars from manifest auth.provider_api_key_env
- helper writes init context to ~/.opencode/init-context.json by default