### PR TITLE
fix(prettier): update Node.js and npm dependencies

### DIFF
--- a/projects/prettier.io/package.yml
+++ b/projects/prettier.io/package.yml
@@ -6,21 +6,19 @@ versions:
   npm: prettier
 
 dependencies:
-  nodejs.org: ^20
+  nodejs.org: ^22
 
 build:
   dependencies:
-    npmjs.com: ^10
+    npmjs.com: ^11
   script:
     npm i $ARGS .
   env:
     ARGS:
       - -ddd
       - --global
-      - --build-from-source
       - --prefix={{prefix}}
       - --install-links
-      - --unsafe-perm
 
 provides:
   - bin/prettier


### PR DESCRIPTION
## Summary
- Update runtime Node.js from `^20` to `^22` — Node 20 reaches EOL April 2026
- Update build npm from `^10` to `^11` — npm 11.x is current stable
- Remove `--build-from-source` — Prettier is pure JavaScript, no native components
- Remove `--unsafe-perm` — deprecated since npm 7, silently ignored

## Test plan
- [ ] Verify Prettier installs with Node 22 and npm 11
- [ ] Verify formatting works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)