### PR TITLE
fix(yarn): unblock Node 24 LTS and fix test

### DIFF
--- a/projects/yarnpkg.com/package.yml
+++ b/projects/yarnpkg.com/package.yml
@@ -10,12 +10,12 @@ provides:
   - bin/yarnpkg
 
 dependencies:
-  nodejs.org: '*'
+  nodejs.org: '>=18.12'
 
 build:
   dependencies:
     classic.yarnpkg.com: ^1 # works and prevents bootstrapping issues
-    nodejs.org: '>=18.3<23'
+    nodejs.org: '>=18.12'
   script:
     - yarn install --immutable --mode=skip-build
     - yarn build:cli
@@ -33,4 +33,5 @@ test:
   script: |
     yarn --version
     yarnpkg --version
+    echo '{}' > package.json
     yarn add jquery


### PR DESCRIPTION
## Summary
- Remove `<23` Node.js upper bound from build deps — blocks Node 24 LTS (yarn 4.13.0 supports it)
- Tighten runtime Node.js dep to `>=18.12` (yarn's declared engine requirement)
- Fix test: `yarn add` in Berry/v4 requires a `package.json` present

## Audit findings
- **Critical**: Build dep `nodejs.org: '>=18.3<23'` blocks Node 24 LTS entirely
- **Critical**: Test runs `yarn add jquery` without `package.json` — fails with WorkspaceRequiredError in Berry/v4
- **Minor**: Runtime `nodejs.org: '*'` allowed incompatible Node versions

## Test plan
- [ ] Verify yarn builds with Node 24
- [ ] Verify `yarn add jquery` works in test with package.json present

🤖 Generated with [Claude Code](https://claude.com/claude-code)