### PR TITLE
fix(uv): update dependency pins and improve test reliability

### DIFF
--- a/projects/astral.sh/uv/package.yml
+++ b/projects/astral.sh/uv/package.yml
@@ -13,14 +13,14 @@ companions:
   python.org: "*"
 
 dependencies:
-  libgit2.org: ~1.7 # links to libgit2.so.1.7
+  libgit2.org: '>=1.7<2'
 
 build:
   dependencies:
     linux:
       nixos.org/patchelf: ^0.18
       sqlite.org: "*" # as of v0.5.22, to build libz-ng-sys
-    cmake.org: ^3.28
+    cmake.org: '>=3.28'
     rust-lang.org/cargo: ^0
     maturin.rs: ^1.4.0
     info-zip.org/unzip: ^6
@@ -75,7 +75,11 @@ test:
           flask run --port $PORT &
           PID=$!
         # otherwise the server may not be ready
-        - sleep 10
+        - |
+          for i in $(seq 1 15); do
+            curl -sf 127.0.0.1:$PORT && break
+            sleep 1
+          done
         - test "$(curl 127.0.0.1:$PORT)" = "<p>Hello, World!</p>"
         # TODO need to install a signal handler or our build servers could be left with a running flask process
-        - kill $PID
+        - kill $PID || true


### PR DESCRIPTION
## Summary
- Widen `libgit2.org` from `~1.7` to `>=1.7<2` — allow current 1.8/1.9 ABI versions
- Widen `cmake.org` from `^3.28` to `>=3.28` — allow CMake 4.x (current stable)
- Replace `sleep 10` in test with retry loop for faster, more reliable test execution
- Add `|| true` to `kill $PID` to prevent test failure if process already exited

## Audit findings
- **Important**: `libgit2.org: ~1.7` blocks 1.8.x and 1.9.x (current is 1.9.2)
- **Important**: `cmake.org: ^3.28` blocks CMake 4.x (current is 4.2.3)
- **Minor**: `sleep 10` is fragile; retry loop is more robust

## Test plan
- [ ] Verify uv builds with libgit2 1.8+ or 1.9+
- [ ] Verify uv builds with CMake 4.x
- [ ] Verify test Flask server wait is reliable

🤖 Generated with [Claude Code](https://claude.com/claude-code)