### PR TITLE
fix(poetry): update build deps and remove stale test pin

### DIFF
--- a/projects/python-poetry.org/package.yml
+++ b/projects/python-poetry.org/package.yml
@@ -10,10 +10,7 @@ dependencies:
 
 build:
   dependencies:
-    python.org: ~3.11
-    cmake.org: ^3
-    linux:
-      rust-lang.org/cargo: "*" # for cryptographic bindings
+    python.org: ~3.13
   script:
     - bkpyvenv stage {{prefix}} {{version}}
     - ${{prefix}}/venv/bin/pip install .
@@ -25,8 +22,7 @@ test:
     - cd teaxyz
     - poetry config virtualenvs.in-project true
 
-    # 2.30.0 uses urllib2 which conflicts with boto3, at this time.
-    - poetry add requests==2.29.0
+    - poetry add requests
 
     - poetry add boto3
 


### PR DESCRIPTION
## Summary
- Bump Python build dep from `~3.11` (EOL) to `~3.13` (current stable)
- Remove `cmake.org: ^3` — no cmake-based dependencies in Poetry 2.x chain
- Remove `rust-lang.org/cargo` on Linux — cryptography ships pre-built manylinux wheels
- Remove stale `requests==2.29.0` pin in test — botocore no longer depends on requests

## Audit findings
- **Critical**: `cmake.org: ^3` is dead weight — no Poetry dep requires CMake
- **Important**: `python.org: ~3.11` uses EOL Python (security support ended Oct 2024)
- **Important**: `rust-lang.org/cargo` unnecessary — cryptography 40+ ships pre-built wheels
- **Important**: `requests==2.29.0` test pin based on stale urllib2/boto3 conflict (resolved in 2023)

## Test plan
- [ ] Verify Poetry installs with Python 3.13
- [ ] Verify build completes without cmake and cargo
- [ ] Verify `poetry add requests` (unpinned) and `poetry add boto3` work together

🤖 Generated with [Claude Code](https://claude.com/claude-code)