### PR TITLE
fix(npm): pin nodejs.org dependency from * to ^20

### DIFF
--- a/projects/npmjs.com/package.yml
+++ b/projects/npmjs.com/package.yml
@@ -10,7 +10,7 @@ provides:
   - bin/npx
 
 dependencies:
-  nodejs.org: "*"
+  nodejs.org: ^20
 
 build:
   - run: ARGS="--install-links"


### PR DESCRIPTION
## Summary
- Pin `nodejs.org` runtime dependency from `*` (any version) to `^20` to avoid unexpected breakage on untested Node.js major versions

## Test plan
- [x] `bk build npmjs.com` — passes
- [x] `bk audit npmjs.com` — passes
- [x] `bk test npmjs.com` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)