### PR TITLE
fix(mypy): fix build failure from pathspec 1.0 incompatibility

### DIFF
--- a/projects/mypy-lang.org/package.yml
+++ b/projects/mypy-lang.org/package.yml
@@ -10,7 +10,7 @@ dependencies:
 
 build:
   dependencies:
-    python.org: '>=3<3.12'
+    python.org: '>=3<3.14'
   env:
     MYPY_USE_MYPYC: 1
     MYPYC_OPT_LEVEL: 3

--- a/projects/mypy-lang.org/package.yml
+++ b/projects/mypy-lang.org/package.yml
@@ -16,7 +16,11 @@ build:
     MYPYC_OPT_LEVEL: 3
   script:
     - bkpyvenv stage {{prefix}} {{version}}
-    - ${{prefix}}/venv/bin/pip install .
+    # pathspec 1.0+ re-exports GitWildMatchPatternError as a deprecated alias,
+    # which fails mypy's attr-defined check during mypyc self-compilation.
+    # Install build deps manually with pathspec pinned, then build without isolation.
+    - ${{prefix}}/venv/bin/pip install "setuptools>=75.1.0" "pathspec>=0.9,<1" "typing_extensions>=4.6.0" "mypy_extensions>=1.0.0" "librt>=0.6.2" "types-psutil" "types-setuptools"
+    - ${{prefix}}/venv/bin/pip install --no-build-isolation .
     - bkpyvenv seal {{prefix}} mypy
     - run: |
         ln -s mypy mypyc


### PR DESCRIPTION
## Summary
- Update Python build dependency cap from `<3.12` to `<3.14` to support Python 3.12 and 3.13
- Fix build failure caused by pathspec 1.0+ re-exporting `GitWildMatchPatternError` as a deprecated alias, which fails mypy's strict `attr-defined` check during mypyc self-compilation
- Pre-install build dependencies with `pathspec<1` pinned and use `--no-build-isolation` to bypass PEP 517 isolated builds pulling in incompatible pathspec versions

**Note:** This branch also includes changes to npmjs.com, pnpm.io, and shellcheck.net from worktree agent commits. Only the mypy-lang.org changes are intended for this PR — the other packages have their own dedicated PRs.

## Test plan
- [x] `bk build mypy-lang.org` — passes (previously broken on both main and audit branch)
- [x] `bk audit mypy-lang.org` — passes
- [x] `bk test mypy-lang.org` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)