### PR TITLE
fix(pytest): update Python build dep range to 3.9-3.14

### DIFF
--- a/projects/pytest.org/package.yml
+++ b/projects/pytest.org/package.yml
@@ -11,7 +11,7 @@ dependencies:
 
 build:
   dependencies:
-    python.org: ">=3.7<3.12"
+    python.org: ">=3.9<3.14"
     git-scm.org: ^2
   script:
     - bkpyvenv stage {{prefix}} {{version}}


### PR DESCRIPTION
## Summary
- Update Python build dependency from `>=3.7<3.12` to `>=3.9<3.14` to drop EOL versions and support Python 3.12/3.13

## Test plan
- [x] `bk build pytest.org` — passes
- [x] `bk audit pytest.org` — passes
- [x] `bk test pytest.org` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)