### PR TITLE
fix(shellcheck): use semver range for libffi, add parallel builds

### DIFF
--- a/projects/shellcheck.net/package.yml
+++ b/projects/shellcheck.net/package.yml
@@ -9,7 +9,7 @@ provides:
   - bin/shellcheck
 
 dependencies:
-  sourceware.org/libffi: 3
+  sourceware.org/libffi: ^3
 
 build:
   dependencies:
@@ -18,7 +18,7 @@ build:
   script:
     - mkdir -p "{{prefix}}/bin"
     - cabal update
-    - cabal install $ARGS
+    - cabal install $ARGS --jobs
   env:
     ARGS:
       - --install-method=copy
@@ -28,4 +28,6 @@ test:
   fixture: |
     #!/bin/sh
     echo "Hello, world!"
-  script: shellcheck $FIXTURE
+  script:
+    - shellcheck --version
+    - shellcheck $FIXTURE

--- a/projects/shellcheck.net/package.yml
+++ b/projects/shellcheck.net/package.yml
@@ -15,6 +15,8 @@ build:
   dependencies:
     haskell.org: ~9.8
     haskell.org/cabal: ^3
+    linux:
+      gnu.org/binutils: ~2.44 # haskell is picky about linkers
   script:
     - mkdir -p "{{prefix}}/bin"
     - cabal update


### PR DESCRIPTION
## Summary
- Change `sourceware.org/libffi: 3` to `^3` for proper semver range
- Add `--jobs` flag to `cabal install` for parallel compilation
- Add `shellcheck --version` to test for version verification

## Test plan
- [ ] Local build blocked by brewkit spaces-in-path issue (`~/Library/Application Support/`) — relies on CI verification
- Changes are low-risk: semver convention fix, build parallelism, test improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)