### PR TITLE
fix(pre-commit): update Python dep range to 3.9-3.14

### DIFF
--- a/projects/pre-commit.com/package.yml
+++ b/projects/pre-commit.com/package.yml
@@ -7,7 +7,7 @@ versions:
   strip: /^v/
 
 dependencies:
-  python.org: '>=3.8<3.12'
+  python.org: '>=3.9<3.14'
 
 build:
   python-venv.sh {{prefix}}/bin/pre-commit


### PR DESCRIPTION
## Summary
- Update Python runtime dependency from `>=3.8<3.12` to `>=3.9<3.14` to drop EOL Python 3.8 and support Python 3.12/3.13

## Test plan
- [ ] Local test failed due to Python venv shebang mismatch (built with 3.13, shebang points to 3.11) — this appears to be a pre-existing brewkit `bkpyvenv` issue, not caused by this change
- Relies on CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)