### PR TITLE
fix(biome): update Rust build dep minimum to >=1.83

### DIFF
--- a/projects/biomejs.dev/package.yml
+++ b/projects/biomejs.dev/package.yml
@@ -12,7 +12,7 @@ versions:
 build:
   working-directory: crates/biome_cli
   dependencies:
-    rust-lang.org: '>=1.65'
+    rust-lang.org: '>=1.83'
     rust-lang.org/cargo: '*'
   script: cargo install --locked --path . --root {{prefix}}
   env:


### PR DESCRIPTION
## Summary
- Update Rust build dependency from `>=1.65` to `>=1.83` to match upstream's current MSRV

## Test plan
- [x] `bk build biomejs.dev` — passes
- [x] `bk audit biomejs.dev` — passes
- [x] `bk test biomejs.dev` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)