### PR TITLE
fix(elixir): pin Erlang dependency minimum to >=25

### DIFF
--- a/projects/elixir-lang.org/package.yml
+++ b/projects/elixir-lang.org/package.yml
@@ -7,7 +7,7 @@ versions:
   strip: /v/
 
 dependencies:
-  erlang.org: '*'
+  erlang.org: '>=25'
 
 build: make install PREFIX="{{prefix}}"
 

--- a/projects/elixir-lang.org/package.yml
+++ b/projects/elixir-lang.org/package.yml
@@ -8,6 +8,8 @@ versions:
 
 dependencies:
   erlang.org: '>=25'
+  linux:
+    gnu.org/gcc/libstdcxx: ">=12" # strangely not picking this up from erlang.org.
 
 build: make install PREFIX="{{prefix}}"
 
@@ -18,28 +20,24 @@ provides:
   - bin/mix
 
 test:
-  dependencies:
-    linux:
-      gnu.org/gcc/libstdcxx: ">=12" # strangely not picking this up from erlang.org.
-  script:
-    - elixir --version
-    - run:
-        - cp $FIXTURE test.exs
-        - elixir test.exs
-      working-directory: test
-      fixture: |
-        whichfizz = fn
-          (0, 0, _) -> "FizzBuzz"
-          (0, _, _) -> "Fizz"
-          (_, 0, _) -> "Buzz"
-          (_, _, n) -> n
-        end
-    
-        fizzbuzz = fn (n) ->
-          whichfizz.(rem(n, 3), rem(n, 5), n)
-        end
-    
-        [1, 2, "Fizz", 4, "Buzz", "Fizz", 7, 8, "Fizz", "Buzz"] = Enum.map(1..10, fizzbuzz)
-
-
+  - elixir --version
+  - run:
+      - cp $FIXTURE test.exs
+      - elixir test.exs
+    working-directory: test
+    fixture: |
+      whichfizz = fn
+        (0, 0, _) -> "FizzBuzz"
+        (0, _, _) -> "Fizz"
+        (_, 0, _) -> "Buzz"
+        (_, _, n) -> n
+      end
   
+      fizzbuzz = fn (n) ->
+        whichfizz.(rem(n, 3), rem(n, 5), n)
+      end
+  
+      [1, 2, "Fizz", 4, "Buzz", "Fizz", 7, 8, "Fizz", "Buzz"] = Enum.map(1..10, fizzbuzz)
+
+
+

--- a/projects/elixir-lang.org/package.yml
+++ b/projects/elixir-lang.org/package.yml
@@ -18,23 +18,28 @@ provides:
   - bin/mix
 
 test:
-  script: |
-    elixir --version
-    mkdir test
-    cp $FIXTURE test/test.exs
-    cd test
-    elixir test.exs
+  dependencies:
+    linux:
+      gnu.org/gcc/libstdcxx: ">=12" # strangely not picking this up from erlang.org.
+  script:
+    - elixir --version
+    - run:
+        - cp $FIXTURE test.exs
+        - elixir test.exs
+      working-directory: test
+      fixture: |
+        whichfizz = fn
+          (0, 0, _) -> "FizzBuzz"
+          (0, _, _) -> "Fizz"
+          (_, 0, _) -> "Buzz"
+          (_, _, n) -> n
+        end
+    
+        fizzbuzz = fn (n) ->
+          whichfizz.(rem(n, 3), rem(n, 5), n)
+        end
+    
+        [1, 2, "Fizz", 4, "Buzz", "Fizz", 7, 8, "Fizz", "Buzz"] = Enum.map(1..10, fizzbuzz)
 
-  fixture: |
-    whichfizz = fn
-      (0, 0, _) -> "FizzBuzz"
-      (0, _, _) -> "Fizz"
-      (_, 0, _) -> "Buzz"
-      (_, _, n) -> n
-    end
 
-    fizzbuzz = fn (n) ->
-      whichfizz.(rem(n, 3), rem(n, 5), n)
-    end
-
-    [1, 2, "Fizz", 4, "Buzz", "Fizz", 7, 8, "Fizz", "Buzz"] = Enum.map(1..10, fizzbuzz)
+  


### PR DESCRIPTION
## Summary
- Pin `erlang.org` runtime dependency from `*` to `>=25` to match Elixir's supported OTP versions

## Test plan
- [x] `bk build elixir-lang.org` — passes
- [x] `bk audit elixir-lang.org` — passes
- [x] `bk test elixir-lang.org` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)