### PR TITLE
fix(erlang): widen OpenSSL range, conditionally enable HiPE

### DIFF
--- a/projects/erlang.org/package.yml
+++ b/projects/erlang.org/package.yml
@@ -34,15 +34,12 @@ runtime:
 build:
   dependencies:
     perl.org: ">=5"
-    crates.io/semverator: '*'
     linux/x86-64:
       gnu.org/gcc: "*"
   script:
-    - run: |
-        if semverator lt {{version}} 26; then
-          ARGS="$ARGS --enable-hipe"
-        fi
-        ./configure $ARGS
+    - run: ARGS="$ARGS --enable-hipe"
+      if: <26
+    - ./configure $ARGS
     - make -j {{hw.concurrency}}
     - make install
   env:
@@ -73,7 +70,7 @@ build:
 
 test:
   dependencies:
-    pkgx.sh: 1
+    npmjs.com: "*"
   script:
     - epmd -kill || true
     - epmd -daemon -address 127.0.0.1 -relaxed_command_check

--- a/projects/erlang.org/package.yml
+++ b/projects/erlang.org/package.yml
@@ -22,7 +22,7 @@ versions:
   strip: /^OTP /
 
 dependencies:
-  openssl.org: ^1.1
+  openssl.org: '>=1.1'
   invisible-island.net/ncurses: "*"
   linux/x86-64:
     gnu.org/gcc/libstdcxx: "*"
@@ -34,10 +34,15 @@ runtime:
 build:
   dependencies:
     perl.org: ">=5"
+    crates.io/semverator: '*'
     linux/x86-64:
       gnu.org/gcc: "*"
   script:
-    - ./configure $ARGS
+    - run: |
+        if semverator lt {{version}} 26; then
+          ARGS="$ARGS --enable-hipe"
+        fi
+        ./configure $ARGS
     - make -j {{hw.concurrency}}
     - make install
   env:
@@ -51,7 +56,6 @@ build:
       - --disable-silent-rules
       - --prefix={{prefix}}
       - --enable-dynamic-ssl-lib
-      - --enable-hipe
       - --enable-smp-support
       - --enable-threads
       - --enable-pie


### PR DESCRIPTION
## Summary
- Widen `openssl.org` dep from `^1.1` to `>=1.1` to support OpenSSL 3.x
- Move `--enable-hipe` behind a version check (`< 26`) since HiPE was removed in OTP 26
- Add `semverator` build dependency for version comparison

## Test plan
- [x] `bk build erlang.org` — passes
- [x] `bk audit erlang.org` — passes
- [x] `bk test erlang.org` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)