### PR TITLE
fix(swift): add compilation test for better coverage

### DIFF
--- a/projects/swift.org/package.yml
+++ b/projects/swift.org/package.yml
@@ -135,4 +135,13 @@ provides:
     - bin/swift-test
     - bin/swiftc
 
-test: swift --version
+test:
+  script: |
+    swift --version
+
+    cat > hello.swift <<SWIFT
+    print("Hello from Swift")
+    SWIFT
+
+    swiftc hello.swift -o hello
+    test "$(./hello)" = "Hello from Swift"


### PR DESCRIPTION
## Summary
- Expand test from simple `swift --version` to include actual compilation and execution of a Swift program using `swiftc`

## Test plan
- [x] `bk build swift.org` — passes
- [x] `bk audit swift.org` — passes
- [x] `bk test swift.org` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)