### PR TITLE
fix(gcc): update GMP, MPFR, MPC dependency minimums

### DIFF
--- a/projects/gnu.org/gcc/package.yml
+++ b/projects/gnu.org/gcc/package.yml
@@ -8,9 +8,9 @@ versions:
 
 dependencies:
   gnu.org/binutils: "*" # linker needs `as`
-  gnu.org/gmp: ">=4.2"
-  gnu.org/mpfr: ">=2.4.0"
-  gnu.org/mpc: ">=0.8.0"
+  gnu.org/gmp: ">=4.3"
+  gnu.org/mpfr: ">=3.1"
+  gnu.org/mpc: ">=1.0"
   zlib.net: ^1.3
   darwin/x86-64: # since 15.1.0
     libisl.sourceforge.io: ^0


### PR DESCRIPTION
## Summary
- Update `gnu.org/gmp` minimum from `>=4.2` to `>=4.3`
- Update `gnu.org/mpfr` minimum from `>=2.4.0` to `>=3.1`
- Update `gnu.org/mpc` minimum from `>=0.8.0` to `>=1.0`
- Aligns dependency minimums with GCC 15's actual requirements

## Test plan
- [ ] `bk build` failed with pre-existing cross-compilation configure error (not caused by this change)
- [x] `bk audit gnu.org/gcc` — passes
- [x] `bk test gnu.org/gcc` — passes (using existing install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)