### PR TITLE
fix(dart): update Python build dependency cap to allow 3.12/3.13

### DIFF
--- a/projects/dart.dev/package.yml
+++ b/projects/dart.dev/package.yml
@@ -8,7 +8,7 @@ build:
     ninja-build.org: '*'
     rust-lang.org: '*'
     curl.se: '*'
-    python.org: '>=3<3.12'
+    python.org: '>=3<3.14'
     tukaani.org/xz: '*'
     git-scm.org: '*'
   script:


### PR DESCRIPTION
## Summary
- Updated Python build dependency cap from `<3.12` to `<3.14` to allow building with newer Python versions

## Test plan
- [ ] CI builds and tests pass
- [ ] Verify dart SDK builds correctly with Python 3.12/3.13

> Local build blocked by brewkit resolve-pkg error (pre-existing environment issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)