### PR TITLE
fix(kotlin): pin JDK dependency minimum to >=8

### DIFF
--- a/projects/kotlinlang.org/package.yml
+++ b/projects/kotlinlang.org/package.yml
@@ -6,7 +6,7 @@ versions:
   github: JetBrains/kotlin
 
 dependencies:
-  openjdk.org: '*'
+  openjdk.org: '>=8'
 
 build:
   working-directory: kotlinc


### PR DESCRIPTION
## Summary
- Pinned openjdk.org dependency from `*` to `>=8` for explicit minimum version documentation

## Test plan
- [ ] CI builds and tests pass
- [ ] Kotlin builds correctly with JDK 8+

> Local build blocked by brewkit resolve-pkg error (pre-existing environment issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)