### PR TITLE
fix(perl): relax LLVM version constraint from <17 to <19

### DIFF
--- a/projects/perl.org/package.yml
+++ b/projects/perl.org/package.yml
@@ -10,7 +10,7 @@ versions:
 build:
   dependencies:
     linux:
-      llvm.org: <17
+      llvm.org: <19
       gnu.org/make: '*'
   script: |
     ./Configure $ARGS


### PR DESCRIPTION
## Summary
- Relaxed LLVM build dependency on Linux from `<17` to `<19` to allow building with newer LLVM versions

## Test plan
- [ ] CI builds and tests pass on Linux
- [ ] Perl builds correctly with LLVM 17/18

> Local build blocked by brewkit spaces-in-path error (pre-existing environment issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)