### PR TITLE
fix(php): normalize libstdcxx pin to semver range, relax libzip

### DIFF
--- a/projects/php.net/package.yml
+++ b/projects/php.net/package.yml
@@ -18,7 +18,7 @@ dependencies:
   gnu.org/gettext: ^0
   gnu.org/gmp: ^6
   libsodium.org: "<1.0.19" # dylib version changed from 23 > 26
-  libzip.org: ~1.9
+  libzip.org: ^1.9
   github.com/kkos/oniguruma: ^6
   openssl.org: "*"
   pcre.org/v2: ">=10.30"
@@ -35,7 +35,7 @@ dependencies:
   ijg.org: ^9
   gnu.org/sed: ^4 # phpize requires this
   openldap.org: ^2 # since 8.1.31, 8.2.26, 8.3.14, 8.4.0
-  gnu.org/gcc/libstdcxx: 14
+  gnu.org/gcc/libstdcxx: ^14
   darwin:
     sourceware.org/bzip2: ^1
     zlib.net: ^1


### PR DESCRIPTION
## Summary
- Normalized `gnu.org/gcc/libstdcxx` dependency from exact pin `14` to semver range `^14`
- Relaxed `libzip.org` constraint from `~1.9` to `^1.9` to allow minor version updates

## Test plan
- [ ] CI builds and tests pass
- [ ] PHP builds correctly with libstdcxx 14.x and libzip 1.x

> Local build blocked by brewkit resolve-pkg error (pre-existing environment issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)