### PR TITLE
fix(scala): fix typos and pin JDK minimum

### DIFF
--- a/projects/scala-lang.org/package.yml
+++ b/projects/scala-lang.org/package.yml
@@ -6,7 +6,7 @@
 warnings:
   - vendored
 
-interpretes:
+interprets:
   extensions: scala
   args: scala
 
@@ -16,13 +16,13 @@ provides:
   - bin/scala-cli
   - bin/sbtn
   - bin/amm
-  - scalafmt
+  - bin/scalafmt
 
 versions:
   github: scala/scala3
 
 dependencies:
-  openjdk.org: '*'
+  openjdk.org: '>=8'
 
 build:
   dependencies:


### PR DESCRIPTION
## Summary
- Fixed typo: `interpretes` → `interprets` in extensions key
- Fixed provides entry: `scalafmt` → `bin/scalafmt` (was missing `bin/` prefix)
- Pinned openjdk.org dependency from `*` to `>=8` for explicit minimum version

## Test plan
- [ ] CI builds and tests pass
- [ ] `scalafmt` binary is correctly provided at `bin/scalafmt`
- [ ] Scala works with JDK 8+

> Local build blocked by brewkit resolve-pkg error (pre-existing environment issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)