### PR TITLE
fix(zig): add version verification test step

### DIFF
--- a/projects/ziglang.org/package.yml
+++ b/projects/ziglang.org/package.yml
@@ -46,6 +46,7 @@ build:
     - cp -a zig-${PLATFORM}-{{ version }}/lib "{{ prefix }}"
 
 test:
+  - zig version
   - run: zig build-exe $FIXTURE --name hello
     if: <0.15
     fixture:

--- a/projects/ziglang.org/package.yml
+++ b/projects/ziglang.org/package.yml
@@ -46,7 +46,7 @@ build:
     - cp -a zig-${PLATFORM}-{{ version }}/lib "{{ prefix }}"
 
 test:
-  - zig version
+  - test "$(zig version)" = "{{version}}"
   - run: zig build-exe $FIXTURE --name hello
     if: <0.15
     fixture:


### PR DESCRIPTION
## Summary
- Added `zig version` test step to verify the installed binary reports correctly

## Test plan
- [ ] CI builds and tests pass
- [ ] `zig version` test correctly validates the installed version

> Local build blocked by brewkit spaces-in-path error (pre-existing environment issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)