### PR TITLE
fix(gradle): pin JDK minimum to >=8

### DIFF
--- a/projects/gradle.org/package.yml
+++ b/projects/gradle.org/package.yml
@@ -9,7 +9,7 @@ versions:
     - /-all\.zip/
 
 dependencies:
-  openjdk.org: '*'
+  openjdk.org: '>=8'
 
 build:
   working-directory: gradle-{{version.raw}}


### PR DESCRIPTION
## Summary
- Pinned openjdk.org dependency from `*` to `>=8` for explicit minimum version

## Test plan
- [ ] CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)