### PR TITLE
fix(maven): pin JDK minimum to >=8

### DIFF
--- a/projects/maven.apache.org/package.yml
+++ b/projects/maven.apache.org/package.yml
@@ -7,7 +7,7 @@ versions:
 warnings:
   - vendored
 dependencies:
-  openjdk.org: '*'
+  openjdk.org: '>=8'
 build:
   script:
     - rm bin/*.cmd


### PR DESCRIPTION
## Summary
- Pinned openjdk.org dependency from `*` to `>=8` for explicit minimum version

## Test plan
- [ ] CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)