### PR TITLE
fix(goreleaser): update Go build dep from ^1.21 to ^1.23

### DIFF
--- a/projects/goreleaser.com/package.yml
+++ b/projects/goreleaser.com/package.yml
@@ -10,7 +10,7 @@ provides:
 
 build:
   dependencies:
-    go.dev: ^1.21
+    go.dev: ^1.23
   script: |
     go mod download
     mkdir -p "{{ prefix }}"/bin


### PR DESCRIPTION
## Summary
- Updated Go build dependency from `^1.21` to `^1.23` to match current goreleaser requirements

## Test plan
- [ ] CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)