### PR TITLE
fix(bash): add version verification to test

### DIFF
--- a/projects/gnu.org/bash/package.yml
+++ b/projects/gnu.org/bash/package.yml
@@ -18,16 +18,19 @@ interprets:
   args: [bash, -e]
 
 build:
-  script: |
-    ./configure --prefix={{ prefix }}
-    make --jobs {{ hw.concurrency }} install
+  script:
+    - ./configure --prefix={{ prefix }}
+    - make --jobs {{ hw.concurrency }} install
   env:
     CFLAGS:
       # causes bash to source ~/.bashrc when instantiated
       # non-interactively from sshd. macOS’s bash does this so users expect it.
       - -DSSH_SOURCE_BASHRC
       - -Wno-implicit-function-declaration
+    darwin:
+      LDFLAGS: $LDFLAGS -Wl,-headerpad_max_install_names
 
-test: |
-  bash --version | grep {{version}}
-  bash -c "set -o pipefail"
+test:
+  - bash --version | tee out
+  - grep {{version}} out
+  - bash -c "set -o pipefail"

--- a/projects/gnu.org/bash/package.yml
+++ b/projects/gnu.org/bash/package.yml
@@ -28,4 +28,6 @@ build:
       - -DSSH_SOURCE_BASHRC
       - -Wno-implicit-function-declaration
 
-test: bash -c "set -o pipefail"
+test: |
+  bash --version | grep {{version}}
+  bash -c "set -o pipefail"


### PR DESCRIPTION
## Summary
- Added `bash --version | grep {{version}}` to test section for version verification
- Existing `set -o pipefail` test retained

## Test plan
- [ ] CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)