### PR TITLE
fix(starship): update Rust build dep from >=1.60 to >=1.71

### DIFF
--- a/projects/starship.rs/package.yml
+++ b/projects/starship.rs/package.yml
@@ -12,7 +12,7 @@ versions:
 build:
   dependencies:
     cmake.org: ">=3.5"
-    rust-lang.org: ">=1.60"
+    rust-lang.org: ">=1.71"
     rust-lang.org/cargo: "*"
   script: cargo install --locked --path . --root {{prefix}}
 


### PR DESCRIPTION
## Summary
- Updated Rust build dependency from `>=1.60` to `>=1.71` to match current starship MSRV

## Test plan
- [ ] CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)