### PR TITLE
fix(direnv): update Go build dep from ^1.18 to ^1.21

### DIFF
--- a/projects/direnv.net/package.yml
+++ b/projects/direnv.net/package.yml
@@ -10,7 +10,7 @@ provides:
 
 build:
   dependencies:
-    go.dev: ^1.18
+    go.dev: ^1.21
   script:
     - echo -n "{{version}}" >version.txt
     - make install PREFIX="{{ prefix }}" $EXTRA_ARGS


### PR DESCRIPTION
## Summary
- Updated Go build dependency from `^1.18` to `^1.21` to match current direnv requirements

## Test plan
- [ ] CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)