### PR TITLE
fix(mise): normalize OpenSSL and cmake dep ranges

### DIFF
--- a/projects/mise.jdx.dev/package.yml
+++ b/projects/mise.jdx.dev/package.yml
@@ -15,14 +15,14 @@ versions:
   ignore: [0.x.y, 1.x.y] # they moved to calver
 
 dependencies:
-  openssl.org: ^1.1 # newer mise after 1.35.2 versions require openssl
+  openssl.org: '>=1.1' # newer mise after 1.35.2 versions require openssl
   libgit2.org: ^1 # newer mise after 2024.5.12 versions require libgit2
 
 build:
   dependencies:
     rust-lang.org: ^1.78 # stdsimd changes
     rust-lang.org/cargo: '*'
-    cmake.org: 3 # as of 2025.9.13
+    cmake.org: ^3 # as of 2025.9.13
   script:
     - cargo install --locked --path . --root {{prefix}}
     # FIXME: <2024 isn't matching like it should. this should be split at 2024.1.0


### PR DESCRIPTION
## Summary
- Normalized OpenSSL dependency from `^1.1` to `>=1.1` to allow OpenSSL 3.x
- Normalized cmake dependency from exact `3` to `^3` for proper semver range

## Test plan
- [ ] CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)