### PR TITLE
add xcodegen-init wrapper to XcodeGen package

### DIFF
--- a/projects/github.com/yonaskolb/XcodeGen/package.yml
+++ b/projects/github.com/yonaskolb/XcodeGen/package.yml
@@ -9,14 +9,47 @@ platforms:
 
 provides:
   - bin/xcodegen
+  - bin/xcodegen-init
+
+dependencies:
+  github.com/mikefarah/yq: "*"
+  stedolan.github.io/jq: "*"
 
 warnings:
   - vendored
 
 build:
   working-directory: ${{prefix}}/bin
-  script: cp "$SRCROOT"/xcodegen/bin/xcodegen .
+  script:
+    - cp "$SRCROOT"/xcodegen/bin/xcodegen .
+    - install -m755 "$SRCROOT"/props/xcodegen-init ./xcodegen-init
 
 test:
-  script: |
-    [[ "$(xcodegen --version)" = "Version: {{version}}" ]]
+  script:
+    - run: '[[ "$(xcodegen --version)" = "Version: {{version}}" ]]'
+    - run: xcodegen-init --help | grep -q xcodegen-init
+    - run: |
+        cat > ./manifest.md <<'EOF'
+        ---
+        project:
+          name: "SampleApp"
+        options:
+          bundleIdPrefix: "com.example"
+        target:
+          name: "SampleApp"
+          type: "application"
+          platform: "iOS"
+          deploymentTarget: "17.0"
+          sources:
+            - "Sources"
+        settings:
+          base:
+            SWIFT_VERSION: "5.10"
+        ---
+        EOF
+        mkdir -p ./Sources
+        xcodegen-init ./manifest.md --write-only --output ./project.yml
+        test -f ./project.yml
+        grep -q '^name: SampleApp$' ./project.yml
+        grep -q '^  SampleApp:$' ./project.yml
+        xcodegen dump --spec ./project.yml --type yaml >/dev/null

--- a/projects/github.com/yonaskolb/XcodeGen/package.yml
+++ b/projects/github.com/yonaskolb/XcodeGen/package.yml
@@ -25,32 +25,31 @@ build:
     - install -m755 "$SRCROOT"/props/xcodegen-init ./xcodegen-init
 
 test:
-  script:
-    - run: '[[ "$(xcodegen --version)" = "Version: {{version}}" ]]'
-    - run: xcodegen-init --help | grep -q xcodegen-init
-    - mkdir -p ./Sources
-    - run: xcodegen-init $FIXTURE --write-only --output ./project.yml
-      fixture:
-        extname: md
-        content: |
-          ---
-          project:
-            name: "SampleApp"
-          options:
-            bundleIdPrefix: "com.example"
-          target:
-            name: "SampleApp"
-            type: "application"
-            platform: "iOS"
-            deploymentTarget: "17.0"
-            sources:
-              - "Sources"
-          settings:
-            base:
-              SWIFT_VERSION: "5.10"
-          ---
-        
-    - test -f ./project.yml
-    - grep -q '^name: SampleApp$' ./project.yml
-    - grep -q '^  SampleApp:$' ./project.yml
-    - xcodegen dump --spec ./project.yml --type yaml >/dev/null
+  - '[[ "$(xcodegen --version)" = "Version: {{version}}" ]]'
+  - xcodegen-init --help | grep -q xcodegen-init
+  - mkdir -p ./Sources
+  - run: xcodegen-init $FIXTURE --write-only --output ./project.yml
+    fixture:
+      extname: md
+      content: |
+        ---
+        project:
+          name: "SampleApp"
+        options:
+          bundleIdPrefix: "com.example"
+        target:
+          name: "SampleApp"
+          type: "application"
+          platform: "iOS"
+          deploymentTarget: "17.0"
+          sources:
+            - "Sources"
+        settings:
+          base:
+            SWIFT_VERSION: "5.10"
+        ---
+      
+  - test -f ./project.yml
+  - 'grep -q "^name: SampleApp\$" ./project.yml'
+  - 'grep -q "^  SampleApp:\$" ./project.yml'
+  - xcodegen dump --spec ./project.yml --type yaml >/dev/null

--- a/projects/github.com/yonaskolb/XcodeGen/package.yml
+++ b/projects/github.com/yonaskolb/XcodeGen/package.yml
@@ -11,7 +11,7 @@ provides:
   - bin/xcodegen
   - bin/xcodegen-init
 
-dependencies:
+companions:
   github.com/mikefarah/yq: "*"
   stedolan.github.io/jq: "*"
 
@@ -28,28 +28,29 @@ test:
   script:
     - run: '[[ "$(xcodegen --version)" = "Version: {{version}}" ]]'
     - run: xcodegen-init --help | grep -q xcodegen-init
-    - run: |
-        cat > ./manifest.md <<'EOF'
-        ---
-        project:
-          name: "SampleApp"
-        options:
-          bundleIdPrefix: "com.example"
-        target:
-          name: "SampleApp"
-          type: "application"
-          platform: "iOS"
-          deploymentTarget: "17.0"
-          sources:
-            - "Sources"
-        settings:
-          base:
-            SWIFT_VERSION: "5.10"
-        ---
-        EOF
-        mkdir -p ./Sources
-        xcodegen-init ./manifest.md --write-only --output ./project.yml
-        test -f ./project.yml
-        grep -q '^name: SampleApp$' ./project.yml
-        grep -q '^  SampleApp:$' ./project.yml
-        xcodegen dump --spec ./project.yml --type yaml >/dev/null
+    - mkdir -p ./Sources
+    - run: xcodegen-init $FIXTURE --write-only --output ./project.yml
+      fixture:
+        extname: md
+        content: |
+          ---
+          project:
+            name: "SampleApp"
+          options:
+            bundleIdPrefix: "com.example"
+          target:
+            name: "SampleApp"
+            type: "application"
+            platform: "iOS"
+            deploymentTarget: "17.0"
+            sources:
+              - "Sources"
+          settings:
+            base:
+              SWIFT_VERSION: "5.10"
+          ---
+        
+    - test -f ./project.yml
+    - grep -q '^name: SampleApp$' ./project.yml
+    - grep -q '^  SampleApp:$' ./project.yml
+    - xcodegen dump --spec ./project.yml --type yaml >/dev/null

--- a/projects/github.com/yonaskolb/XcodeGen/xcodegen-init
+++ b/projects/github.com/yonaskolb/XcodeGen/xcodegen-init
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+xcodegen-init: initialize an XcodeGen project spec from markdown front matter.
+
+Usage:
+  xcodegen-init <manifest.md> [--write-only] [--output <project.yml>]
+  xcodegen-init --help
+
+Options:
+  --write-only        Write the project spec and exit without running XcodeGen.
+  --output <path>     Project spec output path (default: ./project.yml).
+
+Manifest format:
+  YAML front matter between the first two lines containing only `---`.
+USAGE
+}
+
+manifest=""
+write_only=0
+output="./project.yml"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --write-only)
+      write_only=1
+      shift
+      ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --output requires a path" >&2
+        exit 2
+      fi
+      output="$2"
+      shift 2
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$manifest" ]]; then
+        echo "error: only one manifest path is supported" >&2
+        exit 2
+      fi
+      manifest="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$manifest" ]]; then
+  echo "error: missing manifest path" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "$manifest" ]]; then
+  echo "error: manifest not found: $manifest" >&2
+  exit 2
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "error: yq is required but not found in PATH" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but not found in PATH" >&2
+  exit 2
+fi
+
+frontmatter="$(
+  awk '
+    BEGIN { sep=0 }
+    /^---[[:space:]]*$/ { sep+=1; if (sep == 2) exit; next }
+    sep == 1 { print }
+  ' "$manifest"
+)"
+
+if [[ -z "${frontmatter//[[:space:]]/}" ]]; then
+  echo "error: no YAML front matter found in manifest" >&2
+  exit 2
+fi
+
+manifest_json="$(printf '%s\n' "$frontmatter" | yq -o=json '.')"
+
+jq_str() {
+  printf '%s' "$manifest_json" | jq -r "$1"
+}
+
+jq_json() {
+  printf '%s' "$manifest_json" | jq -c "$1"
+}
+
+project_name="$(jq_str '.project.name // empty')"
+target_name="$(jq_str '.target.name // empty')"
+target_type="$(jq_str '.target.type // empty')"
+target_platform="$(jq_str '.target.platform // empty')"
+deployment_target="$(jq_str '.target.deploymentTarget // empty')"
+sources_json="$(jq_json '.target.sources // []')"
+bundle_id_prefix="$(jq_str '.options.bundleIdPrefix // empty')"
+minimum_version="$(jq_str '.options.minimumXcodeGenVersion // empty')"
+settings_base_json="$(jq_json '.settings.base // {}')"
+
+if [[ -z "$project_name" ]]; then
+  echo "error: missing .project.name in manifest" >&2
+  exit 2
+fi
+if [[ -z "$target_name" ]]; then
+  echo "error: missing .target.name in manifest" >&2
+  exit 2
+fi
+if [[ -z "$target_type" ]]; then
+  echo "error: missing .target.type in manifest" >&2
+  exit 2
+fi
+if [[ -z "$target_platform" ]]; then
+  echo "error: missing .target.platform in manifest" >&2
+  exit 2
+fi
+
+project_json="$(
+  jq -n \
+    --arg project_name "$project_name" \
+    --arg target_name "$target_name" \
+    --arg target_type "$target_type" \
+    --arg target_platform "$target_platform" \
+    --arg deployment_target "$deployment_target" \
+    --arg bundle_id_prefix "$bundle_id_prefix" \
+    --arg minimum_version "$minimum_version" \
+    --argjson sources "$sources_json" \
+    --argjson settings_base "$settings_base_json" \
+    '
+    {
+      name: $project_name,
+      targets: {
+        ($target_name): {
+          type: $target_type,
+          platform: $target_platform,
+          sources: $sources
+        }
+      }
+    }
+    | if $deployment_target != "" then
+        .targets[$target_name].deploymentTarget = $deployment_target
+      else . end
+    | if $bundle_id_prefix != "" or $minimum_version != "" then
+        .options = {}
+      else . end
+    | if $bundle_id_prefix != "" then
+        .options.bundleIdPrefix = $bundle_id_prefix
+      else . end
+    | if $minimum_version != "" then
+        .options.minimumXcodeGenVersion = $minimum_version
+      else . end
+    | if $settings_base != {} then
+        .targets[$target_name].settings = { base: $settings_base }
+      else . end
+    '
+)"
+
+mkdir -p "$(dirname "$output")"
+printf '%s\n' "$project_json" | yq -P >"$output"
+
+echo "Wrote XcodeGen spec: $output"
+
+if [[ "$write_only" -eq 1 ]]; then
+  exit 0
+fi
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "error: xcodegen binary not found in PATH" >&2
+  exit 2
+fi
+
+exec xcodegen generate --spec "$output"


### PR DESCRIPTION
Summary:
- add bin/xcodegen-init alongside the existing XcodeGen package
- add runtime deps for yq and jq used by the helper wrapper
- extend pantry tests to validate manifest-to-project.yml generation with XcodeGen parsing

Validation:
- GITHUB_TOKEN=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 PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-xcodegen-data pkgx bk build -C github.com/yonaskolb/XcodeGen@2.45.3
- GITHUB_TOKEN=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 PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-xcodegen-data pkgx bk test github.com/yonaskolb/XcodeGen@2.45.3
- GITHUB_TOKEN=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 PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry XDG_DATA_HOME=/tmp/pkgx-xcodegen-data pkgx bk audit github.com/yonaskolb/XcodeGen@2.45.3

Notes:
- latest upstream release verified: 2.45.3, published 2026-03-10
- xcodegen-init writes a minimal valid project spec from markdown front matter and can optionally run xcodegen generate