### PR TITLE
feat: add stable Next.js pantry recipe

### DIFF
--- a/projects/vercel.com/next/package.yml
+++ b/projects/vercel.com/next/package.yml
@@ -1,0 +1,24 @@
+distributable:
+  url: https://registry.npmjs.org/next/-/next-{{version}}.tgz
+  strip-components: 1
+
+display-name: next.js
+
+versions:
+  npm: next
+
+dependencies:
+  nodejs.org: ^20.9.0
+
+build:
+  dependencies:
+    npmjs.com: ^11
+  script:
+    - npm install --global --prefix={{prefix}} --install-links .
+
+provides:
+  - bin/next
+
+test:
+  - next --version | grep {{version}}
+  - next --help | grep -i usage


### PR DESCRIPTION
## Summary
- add a first-class pantry recipe at vercel.com/next
- track upstream stable Next.js from npm and expose the next CLI
- pin Node compatibility to the stable Next 16-compatible line

## Test Plan
- PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry pkgx bk test vercel.com/next
- PKGX_PANTRY_PATH=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry PKGX_PANTRY_DIR=/Users/timothytlewis/dev/codex/PKGX/repo_pkgx_workspace4/pantry pkgx +vercel.com/next -- next --version

with love from Tim