### PR TITLE
+aerc

### DIFF
--- a/projects/aerc-mail.org/package.yml
+++ b/projects/aerc-mail.org/package.yml
@@ -1,0 +1,29 @@
+distributable:
+  url: https://git.sr.ht/~rjarry/aerc/archive/{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://git.sr.ht/~rjarry/aerc/refs
+  match: /aerc\/archive\/\d+(\.\d+)+\.tar\.gz/
+  strip:
+    - /aerc\/archive\//
+    - /\.tar\.gz/
+
+provides:
+  - bin/aerc
+
+build:
+  dependencies:
+    go.dev: ^1.21
+    sr.ht/scdoc: "*"
+  script:
+    - make PREFIX="{{prefix}}" VERSION="{{version}}" --jobs {{hw.concurrency}}
+    - make install PREFIX="{{prefix}}"
+  env:
+    GO111MODULE: on
+    linux:
+      CGO_ENABLED: 1
+      GO_EXTLINK_ENABLED: 1
+
+test:
+  aerc -v | grep {{version}}

--- a/projects/aerc-mail.org/package.yml
+++ b/projects/aerc-mail.org/package.yml
@@ -17,7 +17,7 @@ build:
     go.dev: ^1.21
     sr.ht/scdoc: "*"
   script:
-    - make PREFIX="{{prefix}}" VERSION="{{version}}" --jobs {{hw.concurrency}}
+    - make PREFIX="{{prefix}}" SHAREDIR="~/.pkgx/aerc-mail.org/v{{version}}/share/aerc" LIBEXECDIR="~/.pkgx/aerc-mail.org/v{{version}}/libexec/aerc" VERSION="{{version}}" --jobs {{hw.concurrency}}
     - make install PREFIX="{{prefix}}"
   env:
     GO111MODULE: on

--- a/projects/aerc-mail.org/package.yml
+++ b/projects/aerc-mail.org/package.yml
@@ -14,16 +14,22 @@ provides:
 
 build:
   dependencies:
-    go.dev: ^1.21
+    go.dev: ~1.23.0
     sr.ht/scdoc: "*"
   script:
-    - make PREFIX="{{prefix}}" SHAREDIR="~/.pkgx/aerc-mail.org/v{{version}}/share/aerc" LIBEXECDIR="~/.pkgx/aerc-mail.org/v{{version}}/libexec/aerc" VERSION="{{version}}" --jobs {{hw.concurrency}}
-    - make install PREFIX="{{prefix}}"
+    - make $MAKE_ARGS --jobs {{hw.concurrency}}
+    - make install $MAKE_ARGS
   env:
     GO111MODULE: on
     linux:
       CGO_ENABLED: 1
       GO_EXTLINK_ENABLED: 1
+    MAKE_ARGS:
+      - PREFIX="{{prefix}}"
+      - SHAREDIR="~/.pkgx/aerc-mail.org/v{{version}}/share/aerc"
+      - LIBEXECDIR="~/.pkgx/aerc-mail.org/v{{version}}/libexec/aerc"
+      - VERSION="{{version}}"
 
 test:
-  aerc -v | grep {{version}}
+  - aerc -v | tee out
+  - grep {{version}} out


### PR DESCRIPTION
## Summary                                                                                                      
                                                                                                                  
  - What changed:                                                                                                 
    > Added new package `aerc-mail.org` to the pantry.  aerc is a terminal email client supporting IMAP, SMTP, Maildir, JMAP, and more.                                                                                        
  - Why:                                                                                                          
    > aerc was not available in the pkgx pantry.                                                                  
                                                                                                                  
  ## AI Intent                                                                                                  

  - Prompt or task statement:
    > Add the aerc package to the pkgx pantry, referencing the Homebrew formula for build details.
  - Scope of AI-assisted changes:                                                                                 
    > AI authored the `projects/aerc-mail.org/package.yml` file with human review.                  
                                                                                                                  
  ## Risk Assessment                                                                                              
                                                                                                                  
  - Risk level:                                                                                                 
    > low
  - Primary risks:
    > None significant. this is a new standalone package with no downstream dependents.                          
  - Compatibility impact:                                                                                         
    > None — additive only.                                                                                       
                                                                                                                  
  ## Rollback Plan                                                                                                
                                                                                                                
  - Revert path:
    > Revert the single commit removing `projects/aerc-mail.org/`.
  - Forward-fix path (if revert is not possible):                                                                 
    > N/A                                                                                                         
                                                                                                                  
  ## Validation                                                                                                   
                                                                                                                  
  - Local checks run:                                                                                           
    > `bk build aerc-mail.org` succeeded on macOS arm64, producing a working `aerc` v0.21.0 binary. 
  - CI checks expected:                                                                                           
    > Standard pantry CI build + test on Linux and macOS.                                                         
                                                                                                                  
  ## Internal/Public Boundary Check                                                                               
                                                                                                                  
  - [x] No internal-only data, private URLs, secrets, or private runbooks were                                    
        added.                                                                                                  
                     