### PR TITLE
Add corgi

### DIFF
--- a/projects/github.com/Andriiklymiuk/corgi/package.yml
+++ b/projects/github.com/Andriiklymiuk/corgi/package.yml
@@ -3,6 +3,8 @@ distributable:
   strip-components: 1
 
 display-name: corgi
+description: Multi-service / db / tunnel orchestrator from a single yml file
+license: MIT
 
 versions:
   github: Andriiklymiuk/corgi
@@ -24,4 +26,4 @@ build:
 provides:
   - bin/corgi
 
-test: corgi -h
+test: test "$(corgi --version | head -1 | awk '{print $NF}')" = {{version}}

--- a/projects/github.com/Andriiklymiuk/corgi/package.yml
+++ b/projects/github.com/Andriiklymiuk/corgi/package.yml
@@ -1,0 +1,27 @@
+distributable:
+  url: https://github.com/Andriiklymiuk/corgi/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+display-name: corgi
+
+versions:
+  github: Andriiklymiuk/corgi
+  strip: /v/
+
+build:
+  dependencies:
+    go.dev: ^1.25
+  env:
+    CGO_ENABLED: 0
+    LDFLAGS:
+      - -s
+      - -w
+    linux:
+      LDFLAGS:
+        - -buildmode=pie
+  script: go build -v -ldflags="${LDFLAGS}" -o {{prefix}}/bin/corgi
+
+provides:
+  - bin/corgi
+
+test: corgi -h

--- a/projects/github.com/Andriiklymiuk/corgi/package.yml
+++ b/projects/github.com/Andriiklymiuk/corgi/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/Andriiklymiuk/corgi/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/Andriiklymiuk/corgi/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 display-name: corgi
@@ -8,20 +8,19 @@ license: MIT
 
 versions:
   github: Andriiklymiuk/corgi
-  strip: /v/
 
 build:
   dependencies:
     go.dev: ^1.25
   env:
     CGO_ENABLED: 0
-    LDFLAGS:
+    GO_LDFLAGS:
       - -s
       - -w
     linux:
-      LDFLAGS:
+      GO_LDFLAGS:
         - -buildmode=pie
-  script: go build -v -ldflags="${LDFLAGS}" -o {{prefix}}/bin/corgi
+  script: go build -v -ldflags="${GO_LDFLAGS}" -o {{prefix}}/bin/corgi
 
 provides:
   - bin/corgi


### PR DESCRIPTION
Adds [corgi](https://github.com/Andriiklymiuk/corgi) — a CLI orchestrator for multi-service / db / tunnel local environments from a single `corgi-compose.yml`. Spins up databases, runs services concurrently, opens webhook tunnels.

- Builds from source via Go 1.25
- Single binary, no runtime deps
- Tags use `v` prefix; `strip: /v/` handles it
- License: MIT

Test:
```
pkgx corgi -h
```