### PR TITLE
Fix Erlang `rootdir` relocation with test

### DIFF
--- a/projects/erlang.org/package.yml
+++ b/projects/erlang.org/package.yml
@@ -74,6 +74,7 @@ test:
   script:
     - epmd -kill || true
     - epmd -daemon -address 127.0.0.1 -relaxed_command_check
+    - env -u ERL_ROOTDIR erl -version
     - run: test "$(escript $FIXTURE 10)" = "factorial 10 = 3628800"
       fixture:
         extname: erl

--- a/projects/erlang.org/package.yml
+++ b/projects/erlang.org/package.yml
@@ -45,7 +45,8 @@ build:
     # Surface dyn_erl so the launcher's self-relocation fallback works through
     # the bin/erl symlink (without it, the script falls through to the hardcoded
     # build-time ROOTDIR and fails outside pkgx env).
-    - cd {{prefix}}/bin && ln -s ../lib/erlang/erts-*/bin/dyn_erl dyn_erl
+    - run: ln -s ../lib/erlang/erts-*/bin/dyn_erl dyn_erl
+      working-directory: ${{prefix}}/bin
   env:
     CC: cc
     CXX: c++

--- a/projects/erlang.org/package.yml
+++ b/projects/erlang.org/package.yml
@@ -42,6 +42,10 @@ build:
     - ./configure $ARGS
     - make -j {{hw.concurrency}}
     - make install
+    # Surface dyn_erl so the launcher's self-relocation fallback works through
+    # the bin/erl symlink (without it, the script falls through to the hardcoded
+    # build-time ROOTDIR and fails outside pkgx env).
+    - cd {{prefix}}/bin && ln -s ../lib/erlang/erts-*/bin/dyn_erl dyn_erl
   env:
     CC: cc
     CXX: c++


### PR DESCRIPTION
## Summary

- What changed: Adds a `bin/dyn_erl` symlink (into `lib/erlang/erts-*/bin/dyn_erl`) so the upstream Erlang launcher's self-relocation fallback fires through the existing `bin/erl` symlink. Also adds a `bk test` regression check for the same.
- Why: Without it, `bin/erl` falls through to a build-time hardcoded `ROOTDIR=/opt/erlang.org/v...+brewing/lib/erlang` and exits 126 whenever it's invoked outside a `pkgx`/`dev` env (i.e. without `ERL_ROOTDIR` set). Currently masked by `runtime.env.ERL_ROOTDIR` for in-pkgx consumers, but breaks IDE-launched LSPs (e.g. [Expert](https://github.com/elixir-lang/expert)) and any consumer that bundles its own ERTS.

## AI Intent

- Prompt or task statement: Originally was debugging an Elixir LSP (Expert) that failed with status 126 in a pkgx-managed project. After tracing the root cause to this packaging decision, I asked the assistant to help diagnose and verify a fix.
- Scope of AI-assisted changes: Assistant inspected `projects/erlang.org/package.yml` and the upstream OTP launcher script, identified the `dyn_erl` lookup miss through the `bin/erl` symlink. We verified the fix manually against the existing local install first, then assistant drafted the recipe edits, the we verified tests pass. The the commit messages and this PR body has been altered by the assistant as well. Author reviewed each step and ran builds/tests locally.

## Risk Assessment

- Risk level: low
- Primary risks:
  - This PR adds two commits: one that adds a failing test, the next implementing the behavior. To some, this is a risk in that if commit 2 is reverted it would leave a failing test in place. Can squash into a single commit is desired, just let me know.
  - `dyn_erl` has shipped in OTP for many major versions, but if a build targets an OTP version that doesn't include it, the glob `lib/erlang/erts-*/bin/dyn_erl` won't match and `ln` would fail the build. I suppose we could add a guard if it ever surfaces?
  - The launcher's tier-3 fallback is the contract all this relies on, so if OTP changes that behavior in a future release, this fix and the test will need to follow. I have a hard time imagining that as a realistic scenario though.
- Compatibility impact: Purely additive. `runtime.env.ERL_ROOTDIR` is left in place, so existing in-pkgx consumers see identical behavior. Out-of-pkgx consumers that previously saw failures now work.

## Rollback Plan

- Revert path: Revert both commits (test + fix). No state, no users locked into anything new
- Forward-fix path (if revert is not possible): Maybe the symlinking could break and we gate that logic? It could maybe be a `run:` block with `if:` conditional.


## Validation

- Local checks run:
    - Manually reproduced the symptom: `env -i PATH=/usr/bin:/bin ~/.pkgx/erlang.org/v28.3.0/bin/erl -version` → exit 126 with `erlexec: No such file or directory` referencing the `+brewing` build path.
    - Manually applied the fix (created the `bin/dyn_erl` symlink in the existing install) and re-ran: `Erlang ... emulator version 16.2`, exit 0. Same for `erlc`, `escript`, `dialyzer`; verified downstream `elixir` resolves correctly.
    - Test commit is structured to fail without the fix and pass with it, to demonstrate the contract.
    - `bk build` / `bk test` / `bk audit` run locally, all run clean (`bk test` failing on 1st commit, passing on 2nd)
- CI checks expected: `bk build erlang.org` + `bk test erlang.org` on supported platforms. Test commit (HEAD~1) should fail if run; HEAD should pass. Existing factorial test continues to pass at both commits.

## Internal/Public Boundary Check

- [x] No internal-only data, private URLs, secrets, or private runbooks were added.
