### PR TITLE
feat(matrix): allow pkg.yml to opt in to windows/x86-64

### DIFF
--- a/.github/scripts/get-matrix.ts
+++ b/.github/scripts/get-matrix.ts
@@ -27,13 +27,19 @@ if (ghout) {
 async function get_config(pkg: {project: string}) {
   let { platforms, test } = await hooks.usePantry().project(pkg).yaml()
   const get_platforms = (() => {
+    // Windows is intentionally NOT in the default-platforms list: a
+    // pkg.yml has to opt in by listing `windows/x86-64` explicitly,
+    // because brewkit doesn't run on Windows runners yet — see the PR
+    // description. Once brewkit supports Windows, the default list
+    // should grow `windows/x86-64`.
     if (!platforms) return ["linux/x86-64", "linux/aarch64", "darwin/x86-64", "darwin/aarch64"]
     if (isString(platforms)) platforms = [platforms]
     if (!isArray(platforms)) throw new Error(`invalid platform node: ${platforms}`)
     const rv = []
     for (const platform of platforms) {
-      if (platform.match(/^(linux|darwin)\/(aarch64|x86-64)$/)) rv.push(platform)
+      if (platform.match(/^(linux|darwin|windows)\/(aarch64|x86-64)$/)) rv.push(platform)
       else if (platform.match(/^(linux|darwin)$/)) rv.push(`${platform}/x86-64`, `${platform}/aarch64`)
+      else if (platform === "windows") rv.push("windows/x86-64") // no arm64 windows runners yet
       else throw new Error(`invalid platform: ${platform}`)
     }
     return rv
@@ -83,5 +89,19 @@ function get_matrix(platform: string) {
         "test-os": [os],
         "test-container": [null],
         tinyname: "*nix·ARM64"
-  }}}
+      }}
+    case 'windows/x86-64': {
+      // Hosted GitHub runner; no self-hosted Windows pool today.
+      // brewkit/build@v1 doesn't have a Windows code path — this case
+      // exists so a pkg.yml that opts in to `windows/x86-64` produces
+      // a buildable matrix entry, surfacing brewkit's gap with a real
+      // CI failure rather than a "invalid platform" throw at planning.
+      const os = "windows-latest"
+      return {
+        os, name,
+        "test-os": [os],
+        "test-container": [null],
+        tinyname: "win64"
+      }}
+  }
 }


### PR DESCRIPTION
Today get-matrix.ts throws "invalid platform" the moment a pkg.yml lists `windows/` anywhere. That's a hard ceiling on Windows enablement even at the discussion level — there's no way to materialise the gap in actual CI.

Open the door without changing default behaviour:

- Extend the per-platform regex to accept `(linux|darwin|windows)`. The default-platforms list (used when a pkg.yml omits `platforms:`) stays linux+darwin only. Existing packages get an identical matrix.
- Add a `case 'windows/x86-64'` to `get_matrix()` that targets the hosted `windows-latest` runner.
- Accept the shorthand `windows` (resolves to `windows/x86-64`; no arm64 Windows runners on GitHub Actions today).

This is intentionally a no-op for every package currently in the pantry — only a package that *explicitly* lists `platforms: [windows/x86-64]` is affected. Such a package will fail at `brewkit/build@v1` (which has no Windows codepath today), which is the point: it surfaces brewkit's gap as a real CI failure rather than a planning-time throw, and gives a place to discuss Windows enablement with concrete build logs.

## Why now

In pkgxdev/pkgm#87 I'm porting pkgm to Windows. The pkgm-side work is essentially done (per-user install_prefix to `%LOCALAPPDATA%\pkgm`, hardlink fallback for `symlink_with_overwrite`, `.cmd` stub wrappers, `PATH_SEP` awareness throughout).

Per [jhheider's reply](https://github.com/pkgxdev/pkgx/issues/607) on pkgxdev/pkgx#607, the v2 dist layout already has 15 toolchain-layer packages built for Windows (`bun.sh`, `cmake.org`, `curl.se`, `deno.land`, `git-scm.org`, `go.dev`, `libarchive.org`, `nasm.us`, `ninja-build.org`, `openssl.org`, `perl.org`, `python.org`, `rust-lang.org`, `sqlite.org`, `zlib.net`) — but the manifest pipeline that produced them was rolled back about a year ago. So `pkgm install <app>` on Windows can't end-to-end work today without that pipeline coming back online. This PR takes the next-smallest enabling step on the path: it lifts the planning-time veto on `windows/x86-64` so the brewkit-side conversation can happen with a concrete CI failure to point at, rather than getting cut short at "invalid platform".

This PR doesn't fix anything end-to-end. It removes the planning-level veto so brewkit/manifests work has a stable target.

## Refs

- pkgxdev/pkgx#607 — platform-support megaticket and the rolled-back-manifests context (per maintainer reply).
- pkgxdev/pkgm#87 — pkgm port to Windows (scaffolding pass, draft).
- libpkgx#48 + #49 — Windows support in libpkgx itself, merged Oct 2023 with one known FFI-lockfile caveat.