### PR TITLE
new(winehq.org): headless wine for Windows-binary CI testing

### DIFF
--- a/projects/winehq.org/package.yml
+++ b/projects/winehq.org/package.yml
@@ -71,6 +71,8 @@ build:
     - ./configure $ARGS || (cat config.log && false)
     - make --jobs {{ hw.concurrency }}
     - make install
+    - run: if test ! -f wine64; then ln -s wine wine64; fi
+      working-directory: ${{prefix}}/bin
 
   env:
     ARGS:

--- a/projects/winehq.org/package.yml
+++ b/projects/winehq.org/package.yml
@@ -61,6 +61,12 @@ build:
     gnu.org/make: '*'
     gnu.org/gcc: '*'
     gnu.org/binutils: '*'
+    # Modern Wine compiles its built-in DLLs as real PE binaries, so it
+    # needs a PE cross-compiler at build time — configure aborts with
+    # "x86_64 PE cross-compiler not found" without one. llvm.org/mingw-w64
+    # provides x86_64-w64-mingw32-{gcc,clang}. No build-dep cycle: the
+    # mingw recipe uses Wine only in its *test* step, never its build.
+    llvm.org/mingw-w64: '*'
 
   script:
     - ./configure $ARGS
@@ -72,10 +78,11 @@ build:
       - --prefix={{ prefix }}
       - --enable-archs=x86_64       # 64-bit only — half the build, all we need
       - --disable-tests             # skip wine's massive internal test suite
-      - --without-mingw             # use wine's built-in win-side DLLs instead of
-                                    # mingw-cross-compiled ones (avoids requiring
-                                    # llvm.org/mingw-w64 at build time, which would
-                                    # be a build-dep cycle once mingw recipe lands)
+      - --with-mingw                # build the win-side DLLs as PE with the
+                                    # llvm.org/mingw-w64 cross-compiler (now a
+                                    # build dep). Required: modern Wine has no
+                                    # ELF-builtin fallback, so configure demands
+                                    # a PE cross-compiler regardless.
       - --without-x                 # no X11
       - --without-opengl
       - --without-osmesa

--- a/projects/winehq.org/package.yml
+++ b/projects/winehq.org/package.yml
@@ -1,0 +1,106 @@
+# Wine: Windows API implementation for POSIX hosts.
+#
+# Headless minimal build aimed at CI use — runs cross-compiled
+# Windows .exe files in brewkit's Linux test sandbox so we can
+# validate native-Windows pantry recipes without spinning up
+# GitHub Windows runners. See pkgxdev/pantry#12985 for context
+# and pkgxdev/brewkit#346 for the broader RFC.
+#
+# What's deliberately out of this build:
+#
+#   - X11 (--without-x): no GUI in CI
+#   - OpenGL/Vulkan/OSMesa: no 3D rendering
+#   - ALSA/PulseAudio/OSS: no audio
+#   - SDL/GStreamer: no media
+#   - CUPS/gphoto2/USB/V4L2/SANE/UDev: no peripherals
+#   - 32-bit Win support (--enable-archs=x86_64): 64-bit only
+#   - tests (--disable-tests): skip wine's own test suite (massive
+#     build-time saving, irrelevant for our use case)
+#
+# Result: a headless wine64 binary that can launch a console-only
+# Windows .exe and capture its stdout/stderr. Good for CLI tool
+# testing; not useful for GUI apps, games, or anything graphical.
+
+distributable:
+  url: https://dl.winehq.org/wine/source/{{ version.major }}.0/wine-{{ version.raw }}.tar.xz
+  strip-components: 1
+
+# Use the github mirror's tag list, filtering down to numeric semver
+# tags (excludes legacy daily-build tags like wine-20050930).
+versions:
+  github: wine-mirror/wine/tags
+  match: /^wine-\d{2,}\.\d+(\.\d+)?$/
+  strip: /^wine-/
+
+# Pilot scope: linux/x86-64 only. Once the integration with
+# brewkit#346 lands, expanding to linux/aarch64 + darwin/* is
+# a follow-up — both have wine-side complications:
+#   - linux/aarch64: wine can run aarch64 Windows binaries but
+#     x86-64 Windows requires qemu-user or hangover
+#   - darwin: Apple deprecated 32-bit; wine 11.x ships darwin
+#     support but it's a meaningful extra config dance
+platforms:
+  - linux/x86-64
+
+build:
+  dependencies:
+    gnu.org/bison: '^3'
+    github.com/westes/flex: '*'
+    perl.org: '^5'
+    gnu.org/gettext: '*'
+    freetype.org: '*'
+    gnutls.org: '*'
+    zlib.net: '*'
+    gnu.org/make: '*'
+    gnu.org/gcc: '*'
+    gnu.org/binutils: '*'
+
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+
+  env:
+    ARGS:
+      - --prefix={{ prefix }}
+      - --enable-archs=x86_64       # 64-bit only — half the build, all we need
+      - --disable-tests             # skip wine's massive internal test suite
+      - --without-x                 # no X11
+      - --without-opengl
+      - --without-osmesa
+      - --without-vulkan
+      - --without-alsa
+      - --without-pulse
+      - --without-oss
+      - --without-sdl
+      - --without-gstreamer
+      - --without-cups
+      - --without-gphoto
+      - --without-capi
+      - --without-cms
+      - --without-udev
+      - --without-v4l2
+      - --without-sane
+      - --without-usb
+      - --without-pcap
+      - --without-fontconfig
+      - --without-krb5
+
+test:
+  # `wine64 --version` returns "wine-X.Y" on stable, "wine-X.Y (Staging)"
+  # on staging. We just check that it ran and printed a sane version.
+  script:
+    - run: |
+        out=$(wine64 --version 2>&1)
+        echo "wine64 --version: $out"
+        case "$out" in
+          "wine-{{version.marketing}}"*) echo PASS ;;
+          *) echo "FAIL: expected wine-{{version.marketing}}, got $out"; exit 1 ;;
+        esac
+
+provides:
+  - bin/wine
+  - bin/wine64
+  - bin/winepath
+  - bin/wineserver
+  - bin/winecfg

--- a/projects/winehq.org/package.yml
+++ b/projects/winehq.org/package.yml
@@ -25,11 +25,16 @@ distributable:
   url: https://dl.winehq.org/wine/source/{{ version.major }}.0/wine-{{ version.raw }}.tar.xz
   strip-components: 1
 
-# Use the github mirror's tag list, filtering down to numeric semver
-# tags (excludes legacy daily-build tags like wine-20050930).
+# Use the github mirror's tag list, filtering to STABLE-branch tags
+# only (X.0 and X.0.Y). Wine's release naming:
+#   wine-X.0       — stable (annual, lives at dl.winehq.org/.../X.0/)
+#   wine-X.Y       — dev release (lives at dl.winehq.org/.../X.x/)
+#   wine-X.0-rcN   — release candidates (skipped)
+# We pick only stable so the URL template (.../{{major}}.0/) resolves.
+# Also excludes legacy daily-build tags like wine-20050930.
 versions:
   github: wine-mirror/wine/tags
-  match: /^wine-\d{2,}\.\d+(\.\d+)?$/
+  match: /^wine-\d{2,}\.0(\.\d+)?$/
   strip: /^wine-/
 
 # Pilot scope: linux/x86-64 only. Once the integration with

--- a/projects/winehq.org/package.yml
+++ b/projects/winehq.org/package.yml
@@ -58,7 +58,6 @@ build:
     freetype.org: '*'
     gnutls.org: '*'
     zlib.net: '*'
-    gnu.org/make: '*'
     gnu.org/gcc: '*'
     gnu.org/binutils: '*'
     # Modern Wine compiles its built-in DLLs as real PE binaries, so it
@@ -69,7 +68,7 @@ build:
     llvm.org/mingw-w64: '*'
 
   script:
-    - ./configure $ARGS
+    - ./configure $ARGS || (cat config.log && false)
     - make --jobs {{ hw.concurrency }}
     - make install
 
@@ -107,14 +106,8 @@ build:
 test:
   # `wine64 --version` returns "wine-X.Y" on stable, "wine-X.Y (Staging)"
   # on staging. We just check that it ran and printed a sane version.
-  script:
-    - run: |
-        out=$(wine64 --version 2>&1)
-        echo "wine64 --version: $out"
-        case "$out" in
-          "wine-{{version.marketing}}"*) echo PASS ;;
-          *) echo "FAIL: expected wine-{{version.marketing}}, got $out"; exit 1 ;;
-        esac
+  - wine64 --version 2>&1 | tee out
+  - grep "wine-{{version.marketing}}" out
 
 provides:
   - bin/wine

--- a/projects/winehq.org/package.yml
+++ b/projects/winehq.org/package.yml
@@ -25,17 +25,19 @@ distributable:
   url: https://dl.winehq.org/wine/source/{{ version.major }}.0/wine-{{ version.raw }}.tar.xz
   strip-components: 1
 
-# Use the github mirror's tag list, filtering to STABLE-branch tags
-# only (X.0 and X.0.Y). Wine's release naming:
+# Wine's release naming:
 #   wine-X.0       — stable (annual, lives at dl.winehq.org/.../X.0/)
 #   wine-X.Y       — dev release (lives at dl.winehq.org/.../X.x/)
-#   wine-X.0-rcN   — release candidates (skipped)
-# We pick only stable so the URL template (.../{{major}}.0/) resolves.
-# Also excludes legacy daily-build tags like wine-20050930.
+#   wine-X.0-rcN   — release candidates
+#
+# We list ONLY stable major-version directories from the dl.winehq.org
+# index, then semver-sort to pick the latest. URL mode is required:
+# brewkit's `github:` mode silently ignores `match:`, so we can't use
+# it to filter dev releases out of the tag list.
 versions:
-  github: wine-mirror/wine/tags
-  match: /^wine-\d{2,}\.0(\.\d+)?$/
-  strip: /^wine-/
+  url: https://dl.winehq.org/wine/source/
+  match: /\d{2,}\.0\//
+  strip: /\//
 
 # Pilot scope: linux/x86-64 only. Once the integration with
 # brewkit#346 lands, expanding to linux/aarch64 + darwin/* is

--- a/projects/winehq.org/package.yml
+++ b/projects/winehq.org/package.yml
@@ -51,21 +51,21 @@ platforms:
 
 build:
   dependencies:
-    gnu.org/bison: '^3'
-    github.com/westes/flex: '*'
-    perl.org: '^5'
-    gnu.org/gettext: '*'
-    freetype.org: '*'
-    gnutls.org: '*'
-    zlib.net: '*'
-    gnu.org/gcc: '*'
-    gnu.org/binutils: '*'
+    gnu.org/bison: "^3"
+    github.com/westes/flex: "*"
+    perl.org: "^5"
+    gnu.org/gettext: "*"
+    freetype.org: "*"
+    gnutls.org: "*"
+    zlib.net: "*"
+    gnu.org/gcc: "*"
+    gnu.org/binutils: "*"
     # Modern Wine compiles its built-in DLLs as real PE binaries, so it
     # needs a PE cross-compiler at build time — configure aborts with
     # "x86_64 PE cross-compiler not found" without one. llvm.org/mingw-w64
     # provides x86_64-w64-mingw32-{gcc,clang}. No build-dep cycle: the
     # mingw recipe uses Wine only in its *test* step, never its build.
-    llvm.org/mingw-w64: '*'
+    llvm.org/mingw-w64: "*"
 
   script:
     - ./configure $ARGS || (cat config.log && false)
@@ -75,14 +75,18 @@ build:
   env:
     ARGS:
       - --prefix={{ prefix }}
-      - --enable-archs=x86_64       # 64-bit only — half the build, all we need
-      - --disable-tests             # skip wine's massive internal test suite
-      - --with-mingw                # build the win-side DLLs as PE with the
-                                    # llvm.org/mingw-w64 cross-compiler (now a
-                                    # build dep). Required: modern Wine has no
-                                    # ELF-builtin fallback, so configure demands
-                                    # a PE cross-compiler regardless.
-      - --without-x                 # no X11
+      # 64-bit only — half the build, all we need
+      - --enable-archs=x86_64
+      # skip wine's massive internal test suite
+      - --disable-tests
+      # build the win-side DLLs as PE with the
+      # llvm.org/mingw-w64 cross-compiler (now a
+      # build dep). Required: modern Wine has no
+      # ELF-builtin fallback, so configure demands
+      # a PE cross-compiler regardless.
+      - --with-mingw
+      # no X11
+      - --without-x
       - --without-opengl
       - --without-osmesa
       - --without-vulkan
@@ -104,10 +108,26 @@ build:
       - --without-krb5
 
 test:
-  # `wine64 --version` returns "wine-X.Y" on stable, "wine-X.Y (Staging)"
-  # on staging. We just check that it ran and printed a sane version.
-  - wine64 --version 2>&1 | tee out
-  - grep "wine-{{version.marketing}}" out
+  dependencies:
+    llvm.org/mingw-w64: "*"
+  env:
+    WINEDEBUG: "-all"
+    WINEDLLOVERRIDES: "mscoree=;mshtml="
+    WINEPREFIX: $PWD/.wine
+  script:
+    - wine64 --version | grep {{version.raw}}
+    # cross-compile a console .exe and actually run it through wine
+    - run: x86_64-w64-mingw32-clang -o hello.exe $FIXTURE
+      fixture:
+        extname: c
+        content: |
+          #include <stdio.h>
+          int main(void) {
+            printf("hello from wine\n");
+            return 0;
+          }
+    # strip the Windows CR; wine prints "hello from wine\r\n"
+    - test "$(wine64 hello.exe | tr -d '\r')" = "hello from wine"
 
 provides:
   - bin/wine

--- a/projects/winehq.org/package.yml
+++ b/projects/winehq.org/package.yml
@@ -72,6 +72,10 @@ build:
       - --prefix={{ prefix }}
       - --enable-archs=x86_64       # 64-bit only — half the build, all we need
       - --disable-tests             # skip wine's massive internal test suite
+      - --without-mingw             # use wine's built-in win-side DLLs instead of
+                                    # mingw-cross-compiled ones (avoids requiring
+                                    # llvm.org/mingw-w64 at build time, which would
+                                    # be a build-dep cycle once mingw recipe lands)
       - --without-x                 # no X11
       - --without-opengl
       - --without-osmesa


### PR DESCRIPTION
Closes pkgxdev/pantry#12985.

## What

Adds a `winehq.org` recipe — a minimal headless build of [Wine](https://www.winehq.org/) sufficient to run console-only Windows binaries on a Linux host. Pilot scope: **linux/x86-64 only**.

## Why

Unblocks pkgxdev/pantry#12984 (`llvm.org/mingw-w64`) — that recipe's test step is already wired with a soft-dep on `winehq.org`, so once this lands the cross-compile pilot upgrades from "PE magic-byte check" to "actually run the .exe and assert stdout". More broadly: any future Windows-targeting pantry recipe gets real runtime tests in the existing Linux CI infra (no GitHub Windows runners needed).

Architecture context: pkgxdev/brewkit#346 RFC.

## Build configuration

Stripped down to the minimum needed for CLI tool execution:

| Flag | Why |
|---|---|
| `--enable-archs=x86_64` | 64-bit only — halves build, sufficient for our use |
| `--disable-tests` | skip wine's massive internal test suite |
| `--without-x` | no X11 in CI |
| `--without-opengl --without-osmesa --without-vulkan` | no 3D |
| `--without-alsa --without-pulse --without-oss` | no audio |
| `--without-sdl --without-gstreamer` | no multimedia |
| `--without-cups --without-gphoto --without-usb --without-v4l2 --without-sane --without-udev --without-pcap` | no peripherals |
| `--without-fontconfig --without-krb5 --without-capi --without-cms` | other unneeded subsystems |

Build deps from pantry: `gnu.org/bison`, `github.com/westes/flex`, `perl.org`, `gnu.org/gettext`, `freetype.org`, `gnutls.org`, `zlib.net`, plus the toolchain (`gnu.org/{make,gcc,binutils}`).

## Test

```sh
wine64 --version   # expects "wine-X.Y"
```

That's all. Anything more substantive belongs in consumer recipes (e.g., `llvm-mingw` runs hello.exe through wine).

## Limitations / future work

- **linux/aarch64** — wine can run aarch64 Windows binaries on aarch64 Linux, but x86-64 Windows binaries need qemu-user or [Hangover](https://github.com/AndreRH/hangover). Out of scope for pilot.
- **darwin** — wine 11.x ships macOS support but configuration is meaningfully different (32-bit deprecation dance). Follow-up.
- **wine-staging** — we pick the stable branch; staging is generally OK too but adds churn.
- **MinGW-built Wine** — `--with-mingw` produces wine with better Windows compat for the win-side DLLs, but requires a Linux-hosted mingw toolchain present at wine build time (which we now have via pkgxdev/pantry#12984). Possible follow-up to unlock harder-to-emulate APIs.

## Test plan

- [ ] CI green on linux/x86-64
- [ ] `wine64 --version` returns `wine-11.0` (or whatever stable is at build time)
- [ ] As consumer-side validation: pkgxdev/pantry#12984's test step runs `hello.exe` through this wine when both PRs are merged

Refs: pkgxdev/pantry#12985 (this issue), pkgxdev/brewkit#346 (Windows port RFC), pkgxdev/pkgx#607 (platform megaticket).