### PR TITLE
add open.longbridge.com (longbridge-terminal)

### DIFF
--- a/projects/open.longbridge.com/package.yml
+++ b/projects/open.longbridge.com/package.yml
@@ -1,0 +1,21 @@
+distributable:
+  url: https://github.com/longbridge/longbridge-terminal/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+display-name: longbridge
+
+provides:
+  - bin/longbridge
+
+versions:
+  github: longbridge/longbridge-terminal
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org: ^1.70
+    rust-lang.org/cargo: "*"
+  script: cargo install --locked --path . --root {{prefix}}
+
+test:
+  script: longbridge --version


### PR DESCRIPTION
## Summary

Adds [longbridge-terminal](https://github.com/longbridge/longbridge-terminal) — the AI-native CLI for Longbridge Securities.

- **Binary name**: `longbridge`
- **Language**: Rust (builds via `cargo install --locked`)
- **Latest release**: v0.22.1 (2026-05-22)
- **Homepage**: https://open.longbridge.com/docs/cli
- **Topics**: ai-native, cli, finance, financial-analysis, ratatui, tui

Supports HK / US / A-share / SG markets with real-time quotes, portfolio, trading, and fundamentals.

## Test

```sh
longbridge --version
```