### PR TITLE
new(socket_vmnet): github.com/lima-vm/socket_vmnet recipe (vmnet.framework bridge)

### DIFF
--- a/projects/github.com/lima-vm/socket_vmnet/package.yml
+++ b/projects/github.com/lima-vm/socket_vmnet/package.yml
@@ -10,7 +10,7 @@
 # Linux equivalent.
 
 distributable:
-  url: https://github.com/lima-vm/socket_vmnet/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/lima-vm/socket_vmnet/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
@@ -18,48 +18,39 @@ versions:
 
 # macOS only — vmnet.framework is Apple-specific.
 platforms:
-  - darwin/x86-64
-  - darwin/aarch64
+  - darwin
 
 build:
-  dependencies:
-    gnu.org/make: '*'
-    gnu.org/coreutils: '*'   # install(1)
+  env:
+    x86-64:
+      ARCH: x86_64
+    aarch64:
+      ARCH: arm64
   script:
-    # Map pkgx arch → Makefile's ARCH variable. Upstream Makefile
-    # checks for "arm64" / "x86_64" substrings in ARCH to set the
-    # `-arch` cflag + `--host` triple.
-    - run: |
-        case "{{hw.arch}}" in
-          x86-64)  export ARCH=x86_64 ;;
-          aarch64) export ARCH=arm64  ;;
-        esac
-        # VERSION normally comes from `git describe`; the source
-        # tarball has no .git so the Makefile falls back to "—".
-        # Override explicitly so the binary's embedded version is right.
-        make --jobs {{ hw.concurrency }} VERSION=v{{version}} all
+    # VERSION normally comes from `git describe`; the source
+    # tarball has no .git so the Makefile falls back to "—".
+    # Override explicitly so the binary's embedded version is right.
+    - make --jobs {{ hw.concurrency }} VERSION=v{{version}} all
 
     # Upstream's `make install` targets /opt/socket_vmnet with strict
     # ownership for a launchd setup. Pkgx bottles are user-owned;
     # we install binaries + docs into {{prefix}}, leaving the
     # sudoers/launchd templates as docs for users to wire up.
-    - run: |
-        mkdir -p "{{prefix}}/bin" "{{prefix}}/share/doc/socket_vmnet"
-        install -m755 socket_vmnet         "{{prefix}}/bin/"
-        install -m755 socket_vmnet_client "{{prefix}}/bin/"
-        cp README.md LICENSE               "{{prefix}}/share/doc/socket_vmnet/"
-        cp -R etc_sudoers.d launchd        "{{prefix}}/share/doc/socket_vmnet/"
+    - mkdir -p "{{prefix}}/bin" "{{prefix}}/share/doc/socket_vmnet"
+    - install -m755 socket_vmnet         "{{prefix}}/bin/"
+    - install -m755 socket_vmnet_client "{{prefix}}/bin/"
+    - cp README.md LICENSE               "{{prefix}}/share/doc/socket_vmnet/"
+    - cp -R etc_sudoers.d launchd        "{{prefix}}/share/doc/socket_vmnet/"
 
 test:
   # Full bridge functionality requires root + vmnet.framework setup
   # which we can't exercise from CI. Best we can do is check the
   # binary loads and shows --help / --version.
-  script:
-    # `--help` exits non-zero (usage goes to stderr, this is the binary's
-    # default behavior) so accept any exit code — we just want to confirm
-    # the binary loads and the OS can run it.
-    - (socket_vmnet --help 2>&1 || true) | head -5
-    - (socket_vmnet_client --help 2>&1 || true) | head -5
+  # `--help` exits non-zero (usage goes to stderr, this is the binary's
+  # default behavior) so accept any exit code — we just want to confirm
+  # the binary loads and the OS can run it.
+  - (socket_vmnet --help 2>&1 || true) | head -5
+  - (socket_vmnet_client --help 2>&1 || true) | head -5
 
 provides:
   - bin/socket_vmnet

--- a/projects/github.com/lima-vm/socket_vmnet/package.yml
+++ b/projects/github.com/lima-vm/socket_vmnet/package.yml
@@ -1,0 +1,63 @@
+# socket_vmnet — vmnet.framework bridge for unmodified rootless QEMU.
+#
+# Used by Lima, Colima, and standalone QEMU setups on macOS to give
+# VMs a real bridged network adapter without root privileges on the
+# QEMU process (socket_vmnet itself still needs to run as root to
+# create the vmnet.framework interface; that's typically done via
+# launchd or sudoers — see share/doc/socket_vmnet/ for templates).
+#
+# macOS-only by design — uses Apple's vmnet.framework which has no
+# Linux equivalent.
+
+distributable:
+  url: https://github.com/lima-vm/socket_vmnet/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: lima-vm/socket_vmnet
+
+# macOS only — vmnet.framework is Apple-specific.
+platforms:
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+    gnu.org/coreutils: '*'   # install(1)
+  script:
+    # Map pkgx arch → Makefile's ARCH variable. Upstream Makefile
+    # checks for "arm64" / "x86_64" substrings in ARCH to set the
+    # `-arch` cflag + `--host` triple.
+    - run: |
+        case "{{hw.arch}}" in
+          x86-64)  export ARCH=x86_64 ;;
+          aarch64) export ARCH=arm64  ;;
+        esac
+        # VERSION normally comes from `git describe`; the source
+        # tarball has no .git so the Makefile falls back to "—".
+        # Override explicitly so the binary's embedded version is right.
+        make --jobs {{ hw.concurrency }} VERSION=v{{version}} all
+
+    # Upstream's `make install` targets /opt/socket_vmnet with strict
+    # ownership for a launchd setup. Pkgx bottles are user-owned;
+    # we install binaries + docs into {{prefix}}, leaving the
+    # sudoers/launchd templates as docs for users to wire up.
+    - run: |
+        mkdir -p "{{prefix}}/bin" "{{prefix}}/share/doc/socket_vmnet"
+        install -m755 socket_vmnet         "{{prefix}}/bin/"
+        install -m755 client/socket_vmnet_client "{{prefix}}/bin/"
+        cp README.md LICENSE               "{{prefix}}/share/doc/socket_vmnet/"
+        cp -R etc_sudoers.d launchd        "{{prefix}}/share/doc/socket_vmnet/"
+
+test:
+  # Full bridge functionality requires root + vmnet.framework setup
+  # which we can't exercise from CI. Best we can do is check the
+  # binary loads and shows --help / --version.
+  script:
+    - socket_vmnet --help 2>&1 | head -5
+    - socket_vmnet_client --help 2>&1 | head -5
+
+provides:
+  - bin/socket_vmnet
+  - bin/socket_vmnet_client

--- a/projects/github.com/lima-vm/socket_vmnet/package.yml
+++ b/projects/github.com/lima-vm/socket_vmnet/package.yml
@@ -55,8 +55,11 @@ test:
   # which we can't exercise from CI. Best we can do is check the
   # binary loads and shows --help / --version.
   script:
-    - socket_vmnet --help 2>&1 | head -5
-    - socket_vmnet_client --help 2>&1 | head -5
+    # `--help` exits non-zero (usage goes to stderr, this is the binary's
+    # default behavior) so accept any exit code — we just want to confirm
+    # the binary loads and the OS can run it.
+    - (socket_vmnet --help 2>&1 || true) | head -5
+    - (socket_vmnet_client --help 2>&1 || true) | head -5
 
 provides:
   - bin/socket_vmnet

--- a/projects/github.com/lima-vm/socket_vmnet/package.yml
+++ b/projects/github.com/lima-vm/socket_vmnet/package.yml
@@ -46,7 +46,7 @@ build:
     - run: |
         mkdir -p "{{prefix}}/bin" "{{prefix}}/share/doc/socket_vmnet"
         install -m755 socket_vmnet         "{{prefix}}/bin/"
-        install -m755 client/socket_vmnet_client "{{prefix}}/bin/"
+        install -m755 socket_vmnet_client "{{prefix}}/bin/"
         cp README.md LICENSE               "{{prefix}}/share/doc/socket_vmnet/"
         cp -R etc_sudoers.d launchd        "{{prefix}}/share/doc/socket_vmnet/"
 


### PR DESCRIPTION
Closes a mainstream package coverage gap (see pkgxdev/pantry overall package coverage discussion). Draft until CI confirms green.

See commit message for design choices.