### PR TITLE
new(buildah): github.com/containers/buildah recipe (OCI-image builder)

### DIFF
--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -48,11 +48,11 @@ build:
 
     # Buildah ships shell-completions + man pages — install them too.
     - mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
-    - if [ -d docs ] && ls docs/buildah*.1 >/dev/null 2>&1; then
+    - "if [ -d docs ] && ls docs/buildah*.1 >/dev/null 2>&1; then"
     -   cp docs/buildah*.1 "{{prefix}}/share/man/man1/" || true
     - fi
     - # Generate bash completion using the binary itself
-    - ${{prefix}}/bin/buildah completion bash > "{{prefix}}/share/bash-completion/completions/buildah" 2>/dev/null || true
+    - '${{prefix}}/bin/buildah completion bash > "{{prefix}}/share/bash-completion/completions/buildah" 2>/dev/null || true'
 
 test:
   # `buildah --version` returns "buildah version X.Y.Z (...)" — pin

--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -1,0 +1,79 @@
+# Buildah — OCI-image builder.
+#
+# Daemonless tool for building OCI/Docker container images. Same
+# family as podman (already in pantry); buildah focuses on the image
+# *building* side, podman on the image-running side.
+#
+# Linux-only: buildah uses Linux-specific syscalls (mount namespaces,
+# unshare, user namespaces, fs overlay) that have no macOS equivalent.
+
+distributable:
+  url: https://github.com/containers/buildah/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: containers/buildah/releases/tags
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+
+dependencies:
+  gnupg.org/gpgme: '*'
+  github.com/seccomp/libseccomp: '*'
+
+build:
+  dependencies:
+    go.dev: '*'
+    gnu.org/make: '*'
+    pkgconf.org: '*'         # build deps' pkg-config files
+    gnu.org/coreutils: '*'   # install(1)
+    gnu.org/sed: '*'
+  script:
+    # Buildah's Makefile auto-detects optional storage backends
+    # (btrfs, lvm/devmapper, ostree, libsubid) and adds build tags
+    # accordingly. We don't ship those in pantry, so we explicitly
+    # narrow the build to the minimum SECURITY + STORAGE set:
+    #
+    #   - seccomp (always — required for kernel-level container security)
+    #   - exclude_graphdriver_btrfs (no btrfs)
+    #   - exclude_graphdriver_devicemapper (no lvm)
+    #   - no ostree, no libsubid
+    #
+    # This still produces a functional buildah for the overlayfs +
+    # vfs storage backends, which is what most consumers want.
+    #
+    # Skip the hack/*.sh scripts that probe the host — they'd report
+    # "not installed" anyway and we want predictable output.
+    - run: |
+        export BUILDTAGS="seccomp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper containers_image_openpgp"
+        make --jobs {{ hw.concurrency }} \
+          GO_BUILD=go\ build \
+          buildah
+
+    - install -Dm755 bin/buildah "{{prefix}}/bin/buildah"
+
+    # Buildah ships shell-completions + man pages — install them too.
+    - run: |
+        mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
+        if [ -d docs ] && ls docs/buildah*.1 >/dev/null 2>&1; then
+          cp docs/buildah*.1 "{{prefix}}/share/man/man1/" || true
+        fi
+        # Generate bash completion using the binary itself
+        "{{prefix}}/bin/buildah" completion bash > "{{prefix}}/share/bash-completion/completions/buildah" 2>/dev/null || true
+
+test:
+  # `buildah --version` returns "buildah version X.Y.Z (...)" — pin
+  # against the marketing version since the trailing parens contain
+  # the git commit which we don't want to match against.
+  script:
+    - run: |
+        out=$(buildah --version 2>&1 | head -1)
+        echo "buildah --version: $out"
+        case "$out" in
+          "buildah version {{version}}"*) echo PASS ;;
+          *) echo "FAIL: expected v{{version}}, got $out"; exit 1 ;;
+        esac
+
+provides:
+  - bin/buildah

--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -16,6 +16,7 @@ versions:
 
 platforms:
   - linux
+
 dependencies:
   gnupg.org/gpgme: '*'
   github.com/seccomp/libseccomp: '*'
@@ -46,9 +47,8 @@ build:
 
     - install -Dm755 bin/buildah "{{prefix}}/bin/buildah"
 
-    # Buildah ships shell-completions + man pages — install them too.
+    # Buildah ships shell-completions — install them too.
     - mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
-    - cp docs/buildah*.1 "{{prefix}}/share/man/man1/" || true
     - # Generate bash completion using the binary itself
     - '${{prefix}}/bin/buildah completion bash > "{{prefix}}/share/bash-completion/completions/buildah" || true'
 

--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -26,7 +26,7 @@ build:
   dependencies:
     go.dev: '*'
     gnu.org/make: '*'
-    pkgconf.org: '*'         # build deps' pkg-config files
+    freedesktop.org/pkg-config: '*'   # build deps' pkg-config files
     gnu.org/coreutils: '*'   # install(1)
     gnu.org/sed: '*'
   script:

--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -49,8 +49,9 @@ build:
 
     # Buildah ships shell-completions — install them too.
     - mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
-    - # Generate bash completion using the binary itself
-    - '${{prefix}}/bin/buildah completion bash > "{{prefix}}/share/bash-completion/completions/buildah" || true'
+    # Generate bash completion using the binary itself
+    - run: ./buildah completion bash > "../share/bash-completion/completions/buildah"
+      working-directory: ${{prefix}}/bin
 
 test:
   # `buildah --version` returns "buildah version X.Y.Z (...)" — pin

--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -48,9 +48,7 @@ build:
 
     # Buildah ships shell-completions + man pages — install them too.
     - mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
-    - if [ -d docs ] && ls docs/buildah*.1; then
-    -   cp docs/buildah*.1 "{{prefix}}/share/man/man1/" || true
-    - fi
+    - cp docs/buildah*.1 "{{prefix}}/share/man/man1/" || true
     - # Generate bash completion using the binary itself
     - '${{prefix}}/bin/buildah completion bash > "{{prefix}}/share/bash-completion/completions/buildah" || true'
 

--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -48,11 +48,11 @@ build:
 
     # Buildah ships shell-completions + man pages — install them too.
     - mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
-    - "if [ -d docs ] && ls docs/buildah*.1 >/dev/null 2>&1; then"
+    - if [ -d docs ] && ls docs/buildah*.1; then
     -   cp docs/buildah*.1 "{{prefix}}/share/man/man1/" || true
     - fi
     - # Generate bash completion using the binary itself
-    - '${{prefix}}/bin/buildah completion bash > "{{prefix}}/share/bash-completion/completions/buildah" 2>/dev/null || true'
+    - '${{prefix}}/bin/buildah completion bash > "{{prefix}}/share/bash-completion/completions/buildah" || true'
 
 test:
   # `buildah --version` returns "buildah version X.Y.Z (...)" — pin

--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -47,12 +47,6 @@ build:
 
     - install -Dm755 bin/buildah "{{prefix}}/bin/buildah"
 
-    # Buildah ships shell-completions — install them too.
-    - mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
-    # Generate bash completion using the binary itself
-    - run: ./buildah completion bash > "../share/bash-completion/completions/buildah"
-      working-directory: ${{prefix}}/bin
-
 test:
   # `buildah --version` returns "buildah version X.Y.Z (...)" — pin
   # against the marketing version since the trailing parens contain

--- a/projects/github.com/containers/buildah/package.yml
+++ b/projects/github.com/containers/buildah/package.yml
@@ -8,16 +8,14 @@
 # unshare, user namespaces, fs overlay) that have no macOS equivalent.
 
 distributable:
-  url: https://github.com/containers/buildah/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/containers/buildah/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
   github: containers/buildah/releases/tags
 
 platforms:
-  - linux/x86-64
-  - linux/aarch64
-
+  - linux
 dependencies:
   gnupg.org/gpgme: '*'
   github.com/seccomp/libseccomp: '*'
@@ -25,10 +23,8 @@ dependencies:
 build:
   dependencies:
     go.dev: '*'
-    gnu.org/make: '*'
-    freedesktop.org/pkg-config: '*'   # build deps' pkg-config files
-    gnu.org/coreutils: '*'   # install(1)
-    gnu.org/sed: '*'
+  env:
+    BUILDTAGS: "seccomp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper containers_image_openpgp"
   script:
     # Buildah's Makefile auto-detects optional storage backends
     # (btrfs, lvm/devmapper, ostree, libsubid) and adds build tags
@@ -45,35 +41,30 @@ build:
     #
     # Skip the hack/*.sh scripts that probe the host — they'd report
     # "not installed" anyway and we want predictable output.
-    - run: |
-        export BUILDTAGS="seccomp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper containers_image_openpgp"
-        make --jobs {{ hw.concurrency }} \
-          GO_BUILD=go\ build \
-          buildah
+
+    - make --jobs {{ hw.concurrency }} GO_BUILD="go build" buildah
 
     - install -Dm755 bin/buildah "{{prefix}}/bin/buildah"
 
     # Buildah ships shell-completions + man pages — install them too.
-    - run: |
-        mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
-        if [ -d docs ] && ls docs/buildah*.1 >/dev/null 2>&1; then
-          cp docs/buildah*.1 "{{prefix}}/share/man/man1/" || true
-        fi
-        # Generate bash completion using the binary itself
-        "{{prefix}}/bin/buildah" completion bash > "{{prefix}}/share/bash-completion/completions/buildah" 2>/dev/null || true
+    - mkdir -p "{{prefix}}/share/man/man1" "{{prefix}}/share/bash-completion/completions"
+    - if [ -d docs ] && ls docs/buildah*.1 >/dev/null 2>&1; then
+    -   cp docs/buildah*.1 "{{prefix}}/share/man/man1/" || true
+    - fi
+    - # Generate bash completion using the binary itself
+    - ${{prefix}}/bin/buildah completion bash > "{{prefix}}/share/bash-completion/completions/buildah" 2>/dev/null || true
 
 test:
   # `buildah --version` returns "buildah version X.Y.Z (...)" — pin
   # against the marketing version since the trailing parens contain
   # the git commit which we don't want to match against.
-  script:
-    - run: |
-        out=$(buildah --version 2>&1 | head -1)
-        echo "buildah --version: $out"
-        case "$out" in
-          "buildah version {{version}}"*) echo PASS ;;
-          *) echo "FAIL: expected v{{version}}, got $out"; exit 1 ;;
-        esac
+  - out=$(buildah --version 2>&1 | head -1)
+  - 'echo "buildah --version: $out"'
+  - |
+    case "$out" in
+      "buildah version {{version}}"*) echo PASS ;;
+      *) echo "FAIL: expected v{{version}}, got $out"; exit 1 ;;
+    esac
 
 provides:
   - bin/buildah


### PR DESCRIPTION
Closes a mainstream package coverage gap (see pkgxdev/pantry overall package coverage discussion). Draft until CI confirms green.

See commit message for design choices.