### PR TITLE
new(mingw-w64.org): Windows runtime libs (headers + CRT + winpthreads) — from source

### DIFF
--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -147,11 +147,15 @@ build:
 test:
   # Lib-only package — no binaries to invoke. Verify the expected
   # runtime files landed in their per-target subdirs.
+  #
+  # winpthreads ships its static lib under different names depending
+  # on the host libtool: linux installs `libpthread.a`, darwin's
+  # libtool produces `libwinpthread.lib` (PE-style). Accept either.
   script:
     - test -f "{{prefix}}/x86_64-w64-mingw32/include/windows.h"
     - test -f "{{prefix}}/x86_64-w64-mingw32/include/stdio.h"
     - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libmingw32.a"
     - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libmsvcrt.a"
-    - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libpthread.a"
+    - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libpthread.a" -o -f "{{prefix}}/x86_64-w64-mingw32/lib/libwinpthread.lib"
     - test -f "{{prefix}}/aarch64-w64-mingw32/include/windows.h"
     - test -f "{{prefix}}/aarch64-w64-mingw32/lib/libmingw32.a"

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -105,6 +105,10 @@ build:
           )
 
           # 3) winpthreads — pthread emulation on top of the CRT.
+          # version.rc includes <winver.h> which lives in mingw-w64
+          # headers; windres needs `-I` to find them. The configure's
+          # CC --sysroot covers C compiles but windres uses its own
+          # include path — pass via RCFLAGS.
           (
             mkdir -p build-winpthreads-$T
             cd build-winpthreads-$T
@@ -112,7 +116,8 @@ build:
               --prefix="{{prefix}}/$T" \
               --host="$T" \
               --enable-static \
-              --enable-shared
+              --enable-shared \
+              RCFLAGS="-I{{prefix}}/$T/include"
             make --jobs {{ hw.concurrency }}
             make install
           )

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -121,6 +121,15 @@ build:
           # headers; windres needs `-I` to find them. The configure's
           # CC --sysroot covers C compiles but windres uses its own
           # include path — pass via RCFLAGS.
+          #
+          # Build STATIC ONLY. The shared (DLL) link goes through
+          # libtool's PE/COFF "global_symbol_pipe" which configure
+          # constructs from probing nm output; with llvm-nm the probe
+          # ends up with an empty sed slot and emits a broken
+          # `llvm-nm ... |  | sed ...` pipeline (double pipe = shell
+          # syntax error). The static lib doesn't need that pipe.
+          # We can revisit shared once libtool's PE detection is fixed
+          # upstream.
           (
             mkdir -p build-winpthreads-$T
             cd build-winpthreads-$T
@@ -128,7 +137,7 @@ build:
               --prefix="{{prefix}}/$T" \
               --host="$T" \
               --enable-static \
-              --enable-shared \
+              --disable-shared \
               RCFLAGS="-I{{prefix}}/$T/include"
             make --jobs {{ hw.concurrency }}
             make install

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -61,6 +61,11 @@ build:
         export AR="llvm-ar"
         export RANLIB="llvm-ranlib"
         export DLLTOOL="llvm-dlltool"
+        # winpthreads compiles .rc resource files via libtool;
+        # libtool needs RC set to recognise the rc-compile path.
+        # Without it, libtool errors with "unrecognised option: '-i'".
+        export RC="llvm-windres"
+        export WINDRES="llvm-windres"
 
         for T in x86_64-w64-mingw32 aarch64-w64-mingw32; do
           echo "══════ building mingw-w64 for $T ══════"

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -60,7 +60,19 @@ build:
     - run: |
         export AR="llvm-ar"
         export RANLIB="llvm-ranlib"
+        export NM="llvm-nm"
+        export STRIP="llvm-strip"
         export DLLTOOL="llvm-dlltool"
+        export OBJDUMP="llvm-objdump"
+        export OBJCOPY="llvm-objcopy"
+        # libtool's nm-detection probe (`checking command to parse nm
+        # output from <CC> object... failed`) needs an nm that
+        # understands PE/COFF — the host's GNU nm refuses Windows
+        # objects, which collapses winpthreads' libtool link step.
+        # llvm-nm handles every object format LLVM does (incl. PE).
+        # Same logic for the rest: every binutil libtool probes has
+        # a PE/COFF-aware llvm-* counterpart, so wire them all.
+
         # winpthreads compiles .rc resource files via libtool;
         # libtool needs RC set to recognise the rc-compile path.
         # Without it, libtool errors with "unrecognised option: '-i'".

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -65,10 +65,9 @@ build:
         for T in x86_64-w64-mingw32 aarch64-w64-mingw32; do
           echo "══════ building mingw-w64 for $T ══════"
 
-          export CC="clang --target=$T"
-          export CXX="clang++ --target=$T"
-
-          # 1) Headers — install-only.
+          # 1) Headers FIRST — no CC dependency, just installs .h files.
+          # CRT/winpthreads configure scripts then probe <windows.h> via
+          # CC so headers must exist before --sysroot points at them.
           (
             mkdir -p build-headers-$T
             cd build-headers-$T
@@ -78,6 +77,11 @@ build:
               --enable-secure-api
             make install
           )
+
+          # Now headers exist at {{prefix}}/$T/include — point clang there
+          # via --sysroot. Matches what llvm-mingw upstream does.
+          export CC="clang --target=$T --sysroot={{prefix}}/$T"
+          export CXX="clang++ --target=$T --sysroot={{prefix}}/$T"
 
           # 2) CRT — the actual C runtime.
           (

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -17,7 +17,10 @@ distributable:
   strip-components: 1
 
 versions:
-  github: mingw-w64/mingw-w64
+  # Upstream only ships tags, not GitHub releases — force tags mode.
+  github: mingw-w64/mingw-w64/tags
+  strip:
+    - /^v/
 
 # Cross-compiler runtime — runs on any host that has clang+lld, so
 # the host platform set matches our viable cross-compile hosts.

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -13,34 +13,43 @@
 # driver scripts (`x86_64-w64-mingw32-clang`, etc.).
 
 distributable:
-  url: https://github.com/mingw-w64/mingw-w64/archive/refs/tags/v{{ version.raw }}.tar.gz
+  url: https://github.com/mingw-w64/mingw-w64/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
   # Upstream only ships tags, not GitHub releases — force tags mode.
   github: mingw-w64/mingw-w64/tags
-  strip:
-    - /^v/
-
-# Cross-compiler runtime — runs on any host that has clang+lld, so
-# the host platform set matches our viable cross-compile hosts.
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
 
 build:
   dependencies:
-    llvm.org: '*'              # clang (--target=*-w64-mingw32) + lld-link
-    gnu.org/make: '*'
-    gnu.org/coreutils: '*'
-    gnu.org/m4: '*'
-    gnu.org/autoconf: '*'
-    gnu.org/automake: '*'
-    gnu.org/libtool: '*'
-    gnu.org/sed: '*'
-    gnu.org/findutils: '*'
+    llvm.org: "*" # clang (--target=*-w64-mingw32) + lld-link
+    gnu.org/m4: "*"
+    gnu.org/autoconf: "*"
+    gnu.org/automake: "*"
+    gnu.org/libtool: "*"
+  env:
+    # libtool's nm-detection probe (`checking command to parse nm
+    # output from <CC> object... failed`) needs an nm that
+    # understands PE/COFF — the host's GNU nm refuses Windows
+    # objects, which collapses winpthreads' libtool link step.
+    # llvm-nm handles every object format LLVM does (incl. PE).
+    # Same logic for the rest: every binutil libtool probes has
+    # a PE/COFF-aware llvm-* counterpart, so wire them all.
+    AR: "llvm-ar"
+    RANLIB: "llvm-ranlib"
+    NM: "llvm-nm"
+    STRIP: "llvm-strip"
+    DLLTOOL: "llvm-dlltool"
+    OBJDUMP: "llvm-objdump"
+    OBJCOPY: "llvm-objcopy"
+    # winpthreads compiles .rc resource files via libtool;
+    # libtool needs RC set to recognise the rc-compile path.
+    # Without it, libtool errors with "unrecognised option: '-i'".
+    RC: "llvm-windres"
+    WINDRES: "llvm-windres"
+    TARGETS:
+      - x86_64-w64-mingw32
+      - aarch64-w64-mingw32
 
   script:
     # mingw-w64 is built per-target-arch (x86_64-w64-mingw32,
@@ -56,93 +65,65 @@ build:
     # Toolchain envvars: clang as CC, llvm-ar as AR, llvm-ranlib as
     # RANLIB. The configure scripts probe for $CC and friends, so
     # exporting them once at the top of the loop is enough.
+    - for T in $TARGETS; do
+    - echo "══════ building mingw-w64 for $T ══════"
 
-    - run: |
-        export AR="llvm-ar"
-        export RANLIB="llvm-ranlib"
-        export NM="llvm-nm"
-        export STRIP="llvm-strip"
-        export DLLTOOL="llvm-dlltool"
-        export OBJDUMP="llvm-objdump"
-        export OBJCOPY="llvm-objcopy"
-        # libtool's nm-detection probe (`checking command to parse nm
-        # output from <CC> object... failed`) needs an nm that
-        # understands PE/COFF — the host's GNU nm refuses Windows
-        # objects, which collapses winpthreads' libtool link step.
-        # llvm-nm handles every object format LLVM does (incl. PE).
-        # Same logic for the rest: every binutil libtool probes has
-        # a PE/COFF-aware llvm-* counterpart, so wire them all.
+    # 1) Headers FIRST — no CC dependency, just installs .h files.
+    # CRT/winpthreads configure scripts then probe <windows.h> via
+    # CC so headers must exist before --sysroot points at them.
+    - run:
+        - ../mingw-w64-headers/configure
+          --prefix="{{prefix}}/$T"
+          --host="$T"
+          --enable-secure-api
+          - make install
+      working-directory: build-headers-$T
 
-        # winpthreads compiles .rc resource files via libtool;
-        # libtool needs RC set to recognise the rc-compile path.
-        # Without it, libtool errors with "unrecognised option: '-i'".
-        export RC="llvm-windres"
-        export WINDRES="llvm-windres"
+    # Now headers exist at {{prefix}}/$T/include — point clang there
+    # via --sysroot. Matches what llvm-mingw upstream does.
+    - export CC="clang --target=$T --sysroot={{prefix}}/$T"
+    - export CXX="clang++ --target=$T --sysroot={{prefix}}/$T"
 
-        for T in x86_64-w64-mingw32 aarch64-w64-mingw32; do
-          echo "══════ building mingw-w64 for $T ══════"
+    # 2) CRT — the actual C runtime.
+    - run:
+        - |
+          case "$T" in
+            x86_64-*)  ENABLE_FLAGS="--disable-lib32 --enable-lib64" ;;
+            aarch64-*) ENABLE_FLAGS="--enable-libarm64 --disable-lib32 --disable-lib64" ;;
+          esac
+        - ../mingw-w64-crt/configure
+          --prefix="{{prefix}}/$T"
+          --host="$T"
+          $ENABLE_FLAGS
+        - make --jobs {{ hw.concurrency }}
+        - make install
+      working-directory: build-crt-$T
 
-          # 1) Headers FIRST — no CC dependency, just installs .h files.
-          # CRT/winpthreads configure scripts then probe <windows.h> via
-          # CC so headers must exist before --sysroot points at them.
-          (
-            mkdir -p build-headers-$T
-            cd build-headers-$T
-            ../mingw-w64-headers/configure \
-              --prefix="{{prefix}}/$T" \
-              --host="$T" \
-              --enable-secure-api
-            make install
-          )
-
-          # Now headers exist at {{prefix}}/$T/include — point clang there
-          # via --sysroot. Matches what llvm-mingw upstream does.
-          export CC="clang --target=$T --sysroot={{prefix}}/$T"
-          export CXX="clang++ --target=$T --sysroot={{prefix}}/$T"
-
-          # 2) CRT — the actual C runtime.
-          (
-            mkdir -p build-crt-$T
-            cd build-crt-$T
-            case "$T" in
-              x86_64-*)  ENABLE_FLAGS="--disable-lib32 --enable-lib64" ;;
-              aarch64-*) ENABLE_FLAGS="--enable-libarm64 --disable-lib32 --disable-lib64" ;;
-            esac
-            ../mingw-w64-crt/configure \
-              --prefix="{{prefix}}/$T" \
-              --host="$T" \
-              $ENABLE_FLAGS
-            make --jobs {{ hw.concurrency }}
-            make install
-          )
-
-          # 3) winpthreads — pthread emulation on top of the CRT.
-          # version.rc includes <winver.h> which lives in mingw-w64
-          # headers; windres needs `-I` to find them. The configure's
-          # CC --sysroot covers C compiles but windres uses its own
-          # include path — pass via RCFLAGS.
-          #
-          # Build STATIC ONLY. The shared (DLL) link goes through
-          # libtool's PE/COFF "global_symbol_pipe" which configure
-          # constructs from probing nm output; with llvm-nm the probe
-          # ends up with an empty sed slot and emits a broken
-          # `llvm-nm ... |  | sed ...` pipeline (double pipe = shell
-          # syntax error). The static lib doesn't need that pipe.
-          # We can revisit shared once libtool's PE detection is fixed
-          # upstream.
-          (
-            mkdir -p build-winpthreads-$T
-            cd build-winpthreads-$T
-            ../mingw-w64-libraries/winpthreads/configure \
-              --prefix="{{prefix}}/$T" \
-              --host="$T" \
-              --enable-static \
-              --disable-shared \
-              RCFLAGS="-I{{prefix}}/$T/include"
-            make --jobs {{ hw.concurrency }}
-            make install
-          )
-        done
+    # 3) winpthreads — pthread emulation on top of the CRT.
+    # version.rc includes <winver.h> which lives in mingw-w64
+    # headers; windres needs `-I` to find them. The configure's
+    # CC --sysroot covers C compiles but windres uses its own
+    # include path — pass via RCFLAGS.
+    #
+    # Build STATIC ONLY. The shared (DLL) link goes through
+    # libtool's PE/COFF "global_symbol_pipe" which configure
+    # constructs from probing nm output; with llvm-nm the probe
+    # ends up with an empty sed slot and emits a broken
+    # `llvm-nm ... |  | sed ...` pipeline (double pipe = shell
+    # syntax error). The static lib doesn't need that pipe.
+    # We can revisit shared once libtool's PE detection is fixed
+    # upstream.
+    - run:
+        - ../mingw-w64-libraries/winpthreads/configure
+          --prefix="{{prefix}}/$T"
+          --host="$T"
+          --enable-static
+          --disable-shared
+          RCFLAGS="-I{{prefix}}/$T/include"
+        - make --jobs {{ hw.concurrency }}
+        - make install
+      working-directory: build-winpthreads-$T
+    - done # for T in $TARGETS
 
 test:
   # Lib-only package — no binaries to invoke. Verify the expected
@@ -151,11 +132,10 @@ test:
   # winpthreads ships its static lib under different names depending
   # on the host libtool: linux installs `libpthread.a`, darwin's
   # libtool produces `libwinpthread.lib` (PE-style). Accept either.
-  script:
-    - test -f "{{prefix}}/x86_64-w64-mingw32/include/windows.h"
-    - test -f "{{prefix}}/x86_64-w64-mingw32/include/stdio.h"
-    - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libmingw32.a"
-    - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libmsvcrt.a"
-    - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libpthread.a" -o -f "{{prefix}}/x86_64-w64-mingw32/lib/libwinpthread.lib"
-    - test -f "{{prefix}}/aarch64-w64-mingw32/include/windows.h"
-    - test -f "{{prefix}}/aarch64-w64-mingw32/lib/libmingw32.a"
+  - test -f "{{prefix}}/x86_64-w64-mingw32/include/windows.h"
+  - test -f "{{prefix}}/x86_64-w64-mingw32/include/stdio.h"
+  - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libmingw32.a"
+  - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libmsvcrt.a"
+  - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libpthread.a" -o -f "{{prefix}}/x86_64-w64-mingw32/lib/libwinpthread.lib"
+  - test -f "{{prefix}}/aarch64-w64-mingw32/include/windows.h"
+  - test -f "{{prefix}}/aarch64-w64-mingw32/lib/libmingw32.a"

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -1,0 +1,119 @@
+# mingw-w64 — Windows runtime libraries for cross-compilation.
+#
+# Pure runtime: Windows API headers, C runtime (CRT), and threading
+# library (winpthreads). NOT a compiler — provides the *target-side*
+# libs that a Windows-targeting clang/gcc needs to actually produce
+# working .exe / .dll output. The compiler itself comes from
+# `llvm.org` (clang + lld-link).
+#
+# This recipe + llvm.org together let pkgx build a true from-source
+# Windows cross-toolchain — no vendored upstream binaries.
+#
+# Composed by `llvm.org/mingw-w64` which wraps clang into per-target
+# driver scripts (`x86_64-w64-mingw32-clang`, etc.).
+
+distributable:
+  url: https://github.com/mingw-w64/mingw-w64/archive/refs/tags/v{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: mingw-w64/mingw-w64
+
+# Cross-compiler runtime — runs on any host that has clang+lld, so
+# the host platform set matches our viable cross-compile hosts.
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    llvm.org: '*'              # clang (--target=*-w64-mingw32) + lld-link
+    gnu.org/make: '*'
+    gnu.org/coreutils: '*'
+    gnu.org/m4: '*'
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
+    gnu.org/libtool: '*'
+    gnu.org/sed: '*'
+    gnu.org/findutils: '*'
+
+  script:
+    # mingw-w64 is built per-target-arch (x86_64-w64-mingw32,
+    # aarch64-w64-mingw32). LLVM's clang supports both natively
+    # (LLVM is multi-target by default), so a single clang from
+    # pantry's llvm.org acts as the cross compiler for all targets.
+    #
+    # Build order per target:
+    #   1. mingw-w64-headers  (no compilation — just install .h files)
+    #   2. mingw-w64-crt      (the C runtime, compiled against (1))
+    #   3. mingw-w64-libraries/winpthreads  (pthreads-w32 emulation)
+    #
+    # Toolchain envvars: clang as CC, llvm-ar as AR, llvm-ranlib as
+    # RANLIB. The configure scripts probe for $CC and friends, so
+    # exporting them once at the top of the loop is enough.
+
+    - run: |
+        export AR="llvm-ar"
+        export RANLIB="llvm-ranlib"
+        export DLLTOOL="llvm-dlltool"
+
+        for T in x86_64-w64-mingw32 aarch64-w64-mingw32; do
+          echo "══════ building mingw-w64 for $T ══════"
+
+          export CC="clang --target=$T"
+          export CXX="clang++ --target=$T"
+
+          # 1) Headers — install-only.
+          (
+            mkdir -p build-headers-$T
+            cd build-headers-$T
+            ../mingw-w64-headers/configure \
+              --prefix="{{prefix}}/$T" \
+              --host="$T" \
+              --enable-secure-api
+            make install
+          )
+
+          # 2) CRT — the actual C runtime.
+          (
+            mkdir -p build-crt-$T
+            cd build-crt-$T
+            case "$T" in
+              x86_64-*)  ENABLE_FLAGS="--disable-lib32 --enable-lib64" ;;
+              aarch64-*) ENABLE_FLAGS="--enable-libarm64 --disable-lib32 --disable-lib64" ;;
+            esac
+            ../mingw-w64-crt/configure \
+              --prefix="{{prefix}}/$T" \
+              --host="$T" \
+              $ENABLE_FLAGS
+            make --jobs {{ hw.concurrency }}
+            make install
+          )
+
+          # 3) winpthreads — pthread emulation on top of the CRT.
+          (
+            mkdir -p build-winpthreads-$T
+            cd build-winpthreads-$T
+            ../mingw-w64-libraries/winpthreads/configure \
+              --prefix="{{prefix}}/$T" \
+              --host="$T" \
+              --enable-static \
+              --enable-shared
+            make --jobs {{ hw.concurrency }}
+            make install
+          )
+        done
+
+test:
+  # Lib-only package — no binaries to invoke. Verify the expected
+  # runtime files landed in their per-target subdirs.
+  script:
+    - test -f "{{prefix}}/x86_64-w64-mingw32/include/windows.h"
+    - test -f "{{prefix}}/x86_64-w64-mingw32/include/stdio.h"
+    - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libmingw32.a"
+    - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libmsvcrt.a"
+    - test -f "{{prefix}}/x86_64-w64-mingw32/lib/libpthread.a"
+    - test -f "{{prefix}}/aarch64-w64-mingw32/include/windows.h"
+    - test -f "{{prefix}}/aarch64-w64-mingw32/lib/libmingw32.a"

--- a/projects/mingw-w64.org/package.yml
+++ b/projects/mingw-w64.org/package.yml
@@ -76,7 +76,7 @@ build:
           --prefix="{{prefix}}/$T"
           --host="$T"
           --enable-secure-api
-          - make install
+        - make install
       working-directory: build-headers-$T
 
     # Now headers exist at {{prefix}}/$T/include — point clang there


### PR DESCRIPTION
Pure Windows runtime (headers + CRT + winpthreads), built from source for x86_64 + aarch64 targets. NOT a compiler — just the target-side libs.

Cross-compiled using pantry's existing llvm.org clang (`--target=*-w64-mingw32`).

Companion to pkgxdev/pantry#12984 which will be refactored to *compose* this runtime + pantry's llvm.org into the full Windows cross-toolchain (instead of vendoring upstream's prebuilt llvm-mingw).