### PR TITLE
new(ngPost): fast multi-threaded Usenet poster (closes #7916)

### DIFF
--- a/projects/github.com/mbruel/ngPost/package.yml
+++ b/projects/github.com/mbruel/ngPost/package.yml
@@ -48,11 +48,12 @@ test:
   - out=$(ngPost --help 2>&1 | head -3 || true)
   - echo "── ngPost --help head ──"
   - echo "$out"
-  - case "$out" in
-  -   *"{{version}}"*) echo "version PASS" ;;
-  -   *"ngPost"*)      echo "binary loads (version not in --help output)" ;;
-  -   *) echo "FAIL: unexpected output"; exit 1 ;;
-  - esac
+  - |
+    case "$out" in
+      *"{{version}}"*) echo "version PASS" ;;
+      *"ngPost"*)      echo "binary loads (version not in --help output)" ;;
+      *) echo "FAIL: unexpected output"; exit 1 ;;
+    esac
 
 provides:
   - bin/ngPost

--- a/projects/github.com/mbruel/ngPost/package.yml
+++ b/projects/github.com/mbruel/ngPost/package.yml
@@ -30,15 +30,19 @@ build:
 
   script:
     - run: |
+        # Disable HMI in the .pro: qmake CONFIG-= from command-line is
+        # processed BEFORE the .pro adds CONFIG+=use_hmi, so the override
+        # is reverted. Comment out the line in-place instead.
+        sed -i 's|^CONFIG  *+= *use_hmi|#&|' src/ngPost.pro
+
         cd src
-        # CONFIG-=use_hmi → CLI-only build. The .pro file's `use_hmi`
-        # branch adds Qt Gui + Widgets which would drag in fontconfig,
-        # X11, xcb, etc. on linux. Drop it for a slim server build.
-        qmake CONFIG-=use_hmi ngPost.pro
+        qmake ngPost.pro
         make --jobs {{ hw.concurrency }}
 
-    - install -Dm755 src/ngPost "{{prefix}}/bin/ngPost"
-    - install -Dm644 ngPost.conf "{{prefix}}/share/ngPost/ngPost.conf.sample"
+        # CWD propagates between script items in brewkit — keep the
+        # install in the same block so `ngPost` resolves correctly.
+        install -Dm755 ngPost "{{prefix}}/bin/ngPost"
+        install -Dm644 ../ngPost.conf "{{prefix}}/share/ngPost/ngPost.conf.sample"
 
 test:
   script:

--- a/projects/github.com/mbruel/ngPost/package.yml
+++ b/projects/github.com/mbruel/ngPost/package.yml
@@ -1,0 +1,59 @@
+# ngPost — fast multi-threaded CLI/GUI Usenet poster.
+#
+# C++/Qt5 NNTP client for uploading binaries to Usenet servers with
+# obfuscation and parallel connections. Built CLI-only by default
+# (CONFIG-=use_hmi) to avoid pulling Qt's GUI/X11 stack — the
+# interactive HMI is rarely used in server/headless contexts.
+#
+# Closes pantry#7916.
+
+distributable:
+  url: https://github.com/mbruel/ngPost/archive/refs/tags/v{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: mbruel/ngPost
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+dependencies:
+  qt.io: ^5      # Qt Core + Network — runtime libs needed by the binary
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+    gnu.org/coreutils: '*'   # install(1)
+
+  script:
+    - run: |
+        cd src
+        # CONFIG-=use_hmi → CLI-only build. The .pro file's `use_hmi`
+        # branch adds Qt Gui + Widgets which would drag in fontconfig,
+        # X11, xcb, etc. on linux. Drop it for a slim server build.
+        qmake CONFIG-=use_hmi ngPost.pro
+        make --jobs {{ hw.concurrency }}
+
+    - install -Dm755 src/ngPost "{{prefix}}/bin/ngPost"
+    - install -Dm644 ngPost.conf "{{prefix}}/share/ngPost/ngPost.conf.sample"
+
+test:
+  script:
+    # ngPost doesn't have a --version flag — it prints version when
+    # invoked with --help. Accept either path so future upstream
+    # changes don't silently break the test.
+    - run: |
+        out=$(ngPost --help 2>&1 | head -3 || true)
+        echo "── ngPost --help head ──"
+        echo "$out"
+        case "$out" in
+          *"{{version}}"*) echo "version PASS" ;;
+          *"ngPost"*)      echo "binary loads (version not in --help output)" ;;
+          *) echo "FAIL: unexpected output"; exit 1 ;;
+        esac
+
+provides:
+  - bin/ngPost

--- a/projects/github.com/mbruel/ngPost/package.yml
+++ b/projects/github.com/mbruel/ngPost/package.yml
@@ -14,11 +14,13 @@ distributable:
 versions:
   github: mbruel/ngPost
 
+# Linux only — darwin Qt5 build path is more brittle (different mkspecs,
+# Aqua vs X11 backend, codesign requirements) and the self-hosted darwin
+# runners don't expose logs via the GitHub API, making blind debugging
+# impractical. Keep darwin off until a follow-up addresses it.
 platforms:
   - linux/x86-64
   - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
 
 dependencies:
   qt.io: ^5      # Qt Core + Network — runtime libs needed by the binary

--- a/projects/github.com/mbruel/ngPost/package.yml
+++ b/projects/github.com/mbruel/ngPost/package.yml
@@ -31,12 +31,13 @@ build:
   - sed -i 's|^CONFIG  *+= *use_hmi|#&|' src/ngPost.pro
 
   - run: 
-    working-directory: src
     - qmake ngPost.pro
     - make --jobs {{ hw.concurrency }}
     # CWD propagates between script items in brewkit — keep the
     # install in the same block so `ngPost` resolves correctly.
     - install -Dm755 ngPost "{{prefix}}/bin/ngPost"
+    working-directory: src
+
   - install -Dm644 ngPost.conf "{{prefix}}/share/ngPost/ngPost.conf.sample"
 
 

--- a/projects/github.com/mbruel/ngPost/package.yml
+++ b/projects/github.com/mbruel/ngPost/package.yml
@@ -8,7 +8,7 @@
 # Closes pantry#7916.
 
 distributable:
-  url: https://github.com/mbruel/ngPost/archive/refs/tags/v{{ version.raw }}.tar.gz
+  url: https://github.com/mbruel/ngPost/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
@@ -19,47 +19,39 @@ versions:
 # runners don't expose logs via the GitHub API, making blind debugging
 # impractical. Keep darwin off until a follow-up addresses it.
 platforms:
-  - linux/x86-64
-  - linux/aarch64
+  - linux
 
 dependencies:
   qt.io: ^5      # Qt Core + Network — runtime libs needed by the binary
 
 build:
-  dependencies:
-    gnu.org/make: '*'
-    gnu.org/coreutils: '*'   # install(1)
+  # Disable HMI in the .pro: qmake CONFIG-= from command-line is
+  # processed BEFORE the .pro adds CONFIG+=use_hmi, so the override
+  # is reverted. Comment out the line in-place instead.
+  - sed -i 's|^CONFIG  *+= *use_hmi|#&|' src/ngPost.pro
 
-  script:
-    - run: |
-        # Disable HMI in the .pro: qmake CONFIG-= from command-line is
-        # processed BEFORE the .pro adds CONFIG+=use_hmi, so the override
-        # is reverted. Comment out the line in-place instead.
-        sed -i 's|^CONFIG  *+= *use_hmi|#&|' src/ngPost.pro
+  - run: 
+    working-directory: src
+    - qmake ngPost.pro
+    - make --jobs {{ hw.concurrency }}
+    # CWD propagates between script items in brewkit — keep the
+    # install in the same block so `ngPost` resolves correctly.
+    - install -Dm755 ngPost "{{prefix}}/bin/ngPost"
+  - install -Dm644 ngPost.conf "{{prefix}}/share/ngPost/ngPost.conf.sample"
 
-        cd src
-        qmake ngPost.pro
-        make --jobs {{ hw.concurrency }}
-
-        # CWD propagates between script items in brewkit — keep the
-        # install in the same block so `ngPost` resolves correctly.
-        install -Dm755 ngPost "{{prefix}}/bin/ngPost"
-        install -Dm644 ../ngPost.conf "{{prefix}}/share/ngPost/ngPost.conf.sample"
 
 test:
-  script:
-    # ngPost doesn't have a --version flag — it prints version when
-    # invoked with --help. Accept either path so future upstream
-    # changes don't silently break the test.
-    - run: |
-        out=$(ngPost --help 2>&1 | head -3 || true)
-        echo "── ngPost --help head ──"
-        echo "$out"
-        case "$out" in
-          *"{{version}}"*) echo "version PASS" ;;
-          *"ngPost"*)      echo "binary loads (version not in --help output)" ;;
-          *) echo "FAIL: unexpected output"; exit 1 ;;
-        esac
+  # ngPost doesn't have a --version flag — it prints version when
+  # invoked with --help. Accept either path so future upstream
+  # changes don't silently break the test.
+  - out=$(ngPost --help 2>&1 | head -3 || true)
+  - echo "── ngPost --help head ──"
+  - echo "$out"
+  - case "$out" in
+  -   *"{{version}}"*) echo "version PASS" ;;
+  -   *"ngPost"*)      echo "binary loads (version not in --help output)" ;;
+  -   *) echo "FAIL: unexpected output"; exit 1 ;;
+  - esac
 
 provides:
   - bin/ngPost


### PR DESCRIPTION
## Summary
- Adds **github.com/mbruel/ngPost** — C++/Qt5 NNTP client for uploading binaries to Usenet servers with obfuscation and parallel connections.
- CLI-only build via \`CONFIG-=use_hmi\` to keep the bottle slim — the HMI variant pulls Qt Gui + Widgets + fontconfig/X11/xcb on linux.
- Closes #7916.

## Test plan
- [ ] Build on all 4 platforms (linux x86-64/aarch64, darwin x86-64/aarch64)
- [ ] \`ngPost --help\` loads and prints version

🤖 Generated with [Claude Code](https://claude.com/claude-code)