### PR TITLE
new(tug.org/texlive): TeX Live engines built from source

### DIFF
--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -14,9 +14,12 @@
 # bundles ~600MB of C/C++ source for ~50 engines + tools.
 
 distributable:
-  # version format is YYYYMMDD (TeXLive's release date). The directory
-  # is named by the year, the file by the full date.
-  url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/{{ version.major }}/texlive-{{ version.raw }}-source.tar.xz
+  # TeXLive releases annually; tarball filename is YYYYMMDD but the
+  # archive directory is just YYYY (e.g. 2026/). pkgx templating
+  # exposes {{ version.major }} which for an 8-digit version returns
+  # the whole `20260301` rather than the year — no year-only field
+  # exists. Hardcode the year and bump on next annual release.
+  url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2026/texlive-{{ version.raw }}-source.tar.xz
   strip-components: 1
 
 versions:

--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -101,7 +101,6 @@ build:
       - --with-system-fontconfig
       # Skip components that need extra deps (can add back if needed).
       - --disable-xindy            # needs CLISP
-      - --disable-texlive-build    # don't build the full tlpkg installer
       - --disable-dvisvgm          # needs xxhash + freetype-aware build
 
 test:

--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -80,8 +80,14 @@ build:
     # prefix. Same pattern as R / Octave.
     - run: |
         cd "{{prefix}}"
-        grep -rIl '+brewing' bin texmf-dist texmf-var 2>/dev/null \
-          | xargs -r sed -i 's|+brewing||g'
+        # Engines-only build: texmf-dist / texmf-var aren't installed.
+        # Walk every dir that actually exists. Use `|| true` so an
+        # empty grep result doesn't abort the script under set -e.
+        for d in bin share/texmf-dist share/texmf-var lib; do
+          [ -d "$d" ] || continue
+          grep -rIl '+brewing' "$d" 2>/dev/null \
+            | xargs -r sed -i 's|+brewing||g' || true
+        done
 
   env:
     ARGS:

--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -19,48 +19,57 @@ distributable:
   # exposes {{ version.major }} which for an 8-digit version returns
   # the whole `20260301` rather than the year — no year-only field
   # exists. Hardcode the year and bump on next annual release.
-  url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2026/texlive-{{ version.raw }}-source.tar.xz
-  strip-components: 1
+  - url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2027/texlive-{{ version.raw }}-source.tar.xz
+    strip-components: 1
+  - url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2026/texlive-{{ version.raw }}-source.tar.xz
+    strip-components: 1
+  - url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/texlive-{{ version.raw }}-source.tar.xz
+    strip-components: 1
+  - url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2024/texlive-{{ version.raw }}-source.tar.xz
+    strip-components: 1
 
 versions:
-  url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2026/
-  match: /texlive-\d{8}-source\.tar\.xz/
-  strip:
-    - /texlive-/
-    - /-source\.tar\.xz/
-
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
+  - url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2027/
+    match: /texlive-\d{8}-source\.tar\.xz/
+    strip:
+      - /texlive-/
+      - /-source\.tar\.xz/
+  - url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2026/
+    match: /texlive-\d{8}-source\.tar\.xz/
+    strip:
+      - /texlive-/
+      - /-source\.tar\.xz/
+  - url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/
+    match: /texlive-\d{8}-source\.tar\.xz/
+    strip:
+      - /texlive-/
+      - /-source\.tar\.xz/
+  - url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2024/
+    match: /texlive-\d{8}-source\.tar\.xz/
+    strip:
+      - /texlive-/
+      - /-source\.tar\.xz/
 
 dependencies:
   # Engine runtime dependencies.
-  freetype.org: '*'
-  libpng.org: '*'
-  cairographics.org: '*'
-  pixman.org: '*'
-  poppler.freedesktop.org: '*'
-  harfbuzz.org: '*'
-  gnu.org/gmp: '*'
-  gnu.org/mpfr: '*'
-  freedesktop.org/fontconfig: '*'
-  zlib.net: '*'
-  perl.org: '*'                # required at runtime (tlmgr is Perl)
+  freetype.org: "*"
+  libpng.org: "*"
+  cairographics.org: "*"
+  pixman.org: "*"
+  poppler.freedesktop.org: "*"
+  harfbuzz.org: "*"
+  gnu.org/gmp: "*"
+  gnu.org/mpfr: "*"
+  freedesktop.org/fontconfig: "*"
+  zlib.net: "*"
+  perl.org: "*" # required at runtime (tlmgr is Perl)
 
 build:
   dependencies:
-    gnu.org/make: '*'
-    gnu.org/coreutils: '*'
-    gnu.org/sed: '*'
-    gnu.org/findutils: '*'
-    gnu.org/grep: '*'
-    gnu.org/m4: '*'
-    perl.org: '*'                # build scripts need Perl
-    freedesktop.org/pkg-config: '*'
+    gnu.org/m4: "*"
+    perl.org: "*" # build scripts need Perl
     linux:
-      gnu.org/gcc: '*'
+      gnu.org/gcc: "*"
 
   # TeXLive source ships a `build` script at the root (file, not dir),
   # so `working-directory: build` (which mkdirs build/) collides. Use
@@ -78,22 +87,21 @@ build:
     # Strip +brewing from baked-in paths post-install — TeXLive's
     # web2c/texmf.cnf and tlmgr scripts hardcode the configure-time
     # prefix. Same pattern as R / Octave.
-    - run: |
-        cd "{{prefix}}"
+    - run:
         # Engines-only build: texmf-dist / texmf-var aren't installed.
         # Walk every dir that actually exists. Use `|| true` so an
         # empty grep result doesn't abort the script under set -e.
-        for d in bin share/texmf-dist share/texmf-var lib; do
-          [ -d "$d" ] || continue
-          grep -rIl '+brewing' "$d" 2>/dev/null \
-            | xargs -r sed -i 's|+brewing||g' || true
-        done
+        - for d in bin share/texmf-dist share/texmf-var lib; do
+        - test -d "$d" || continue
+        - grep -rIl '+brewing' "$d" 2>/dev/null | xargs -r sed -i 's|+brewing||g' || true
+        - done
+      working-directory: "{{prefix}}"
 
   env:
     ARGS:
       - --prefix={{ prefix }}
       - --datarootdir={{ prefix }}/share
-      - --disable-native-texlive-build  # use a tlpkg-free layout
+      - --disable-native-texlive-build # use a tlpkg-free layout
       - --enable-shared
       - --disable-static
       # Use pantry's system libs instead of TeXLive's vendored copies.
@@ -108,21 +116,22 @@ build:
       - --with-system-mpfr
       - --with-system-fontconfig
       # Skip components that need extra deps (can add back if needed).
-      - --disable-xindy            # needs CLISP
-      - --disable-dvisvgm          # needs xxhash + freetype-aware build
-      - --without-x                # xdvik needs Xaw widgets not in pantry
-      - --disable-xdvik            # belt+braces — same Xaw dependency
+      - --disable-xindy # needs CLISP
+      - --disable-dvisvgm # needs xxhash + freetype-aware build
+      - --without-x # xdvik needs Xaw widgets not in pantry
+      - --disable-xdvik # belt+braces — same Xaw dependency
 
 test:
   # Quick smoke tests on the major engines.
   script:
-    - run: |
-        out=$(tex --version 2>&1 | head -1)
-        echo "tex: $out"
-        case "$out" in
-          *"TeX"*) echo "tex PASS" ;;
-          *) echo "FAIL: $out"; exit 1 ;;
-        esac
+    - out=$(tex --version 2>&1 | head -1)
+    - 'echo "tex: $out"'
+
+    - case "$out" in
+    - '*"TeX"*) echo "tex PASS" ;;'
+    - '*) echo "FAIL: $out"; exit 1 ;;'
+    - esac
+
     - pdftex --version 2>&1 | head -1
     - xetex --version 2>&1 | head -1
     - luatex --version 2>&1 | head -1
@@ -140,7 +149,7 @@ provides:
   - bin/bibtex
   - bin/makeindex
   - bin/mktexlsr
-  - bin/tlmgr              # TeX Live Manager (Perl)
+  - bin/tlmgr # TeX Live Manager (Perl)
   - bin/kpsewhich
   # `biber` (Perl tool with extra modules) + `dvipdfm` (legacy, replaced
   # by dvipdfmx) + `kpathsea` (library, not a binary) intentionally

--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -136,12 +136,12 @@ provides:
   - bin/luatex
   - bin/luahbtex
   - bin/dvips
-  - bin/dvipdfm
   - bin/dvipdfmx
   - bin/bibtex
-  - bin/biber              # optional — may need extra deps
   - bin/makeindex
   - bin/mktexlsr
   - bin/tlmgr              # TeX Live Manager (Perl)
   - bin/kpsewhich
-  - bin/kpathsea
+  # `biber` (Perl tool with extra modules) + `dvipdfm` (legacy, replaced
+  # by dvipdfmx) + `kpathsea` (library, not a binary) intentionally
+  # omitted — install biber via `tlmgr install biber` if needed.

--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -62,8 +62,10 @@ build:
     linux:
       gnu.org/gcc: '*'
 
-  # TeXLive's configure refuses in-source builds — use a build/ subdir.
-  working-directory: build
+  # TeXLive source ships a `build` script at the root (file, not dir),
+  # so `working-directory: build` (which mkdirs build/) collides. Use
+  # a different name for the out-of-source build dir.
+  working-directory: pkgx-build
   script:
     # TeXLive's configure has many sub-projects (each engine has its
     # own). The top-level configure passes through to subdirs.

--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -62,13 +62,14 @@ build:
     linux:
       gnu.org/gcc: '*'
 
+  # TeXLive's configure refuses in-source builds — use a build/ subdir.
+  working-directory: build
   script:
     # TeXLive's configure has many sub-projects (each engine has its
     # own). The top-level configure passes through to subdirs.
     # --with-system-* makes texlive use pantry's libs instead of its
-    # vendored copies — keeps the bottle slim and lets pkgx manage
-    # the deps centrally.
-    - ./configure $ARGS
+    # vendored copies.
+    - ../configure $ARGS
     - make --jobs {{ hw.concurrency }}
     - make install
 

--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -1,0 +1,134 @@
+# TeX Live — comprehensive TeX/LaTeX distribution.
+#
+# Built from source via the `texlive-YYYYMMDD-source.tar.xz` release
+# bundle, which contains the *engines* (pdftex, xetex, luatex, dvips,
+# bibtex, makeindex, tlmgr, etc.). The macro packages (LaTeX, AMS,
+# beautifully-formatted whatever) are NOT bundled here — install them
+# via `tlmgr install <pkg>` after the bottle is set up.
+#
+# From-source over vendored — this builds the engines fresh against
+# pantry's freetype/cairo/poppler/harfbuzz instead of pulling the
+# precompiled binaries from the TeXLive installer.
+#
+# Build is heavy (~15-30 min on a fast runner) — texlive-source
+# bundles ~600MB of C/C++ source for ~50 engines + tools.
+
+distributable:
+  # version format is YYYYMMDD (TeXLive's release date). The directory
+  # is named by the year, the file by the full date.
+  url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/{{ version.major }}/texlive-{{ version.raw }}-source.tar.xz
+  strip-components: 1
+
+versions:
+  url: https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2026/
+  match: /texlive-\d{8}-source\.tar\.xz/
+  strip:
+    - /texlive-/
+    - /-source\.tar\.xz/
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+dependencies:
+  # Engine runtime dependencies.
+  freetype.org: '*'
+  libpng.org: '*'
+  cairographics.org: '*'
+  pixman.org: '*'
+  poppler.freedesktop.org: '*'
+  harfbuzz.org: '*'
+  gnu.org/gmp: '*'
+  gnu.org/mpfr: '*'
+  freedesktop.org/fontconfig: '*'
+  zlib.net: '*'
+  perl.org: '*'                # required at runtime (tlmgr is Perl)
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+    gnu.org/coreutils: '*'
+    gnu.org/sed: '*'
+    gnu.org/findutils: '*'
+    gnu.org/grep: '*'
+    gnu.org/m4: '*'
+    perl.org: '*'                # build scripts need Perl
+    freedesktop.org/pkg-config: '*'
+    linux:
+      gnu.org/gcc: '*'
+
+  script:
+    # TeXLive's configure has many sub-projects (each engine has its
+    # own). The top-level configure passes through to subdirs.
+    # --with-system-* makes texlive use pantry's libs instead of its
+    # vendored copies — keeps the bottle slim and lets pkgx manage
+    # the deps centrally.
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+
+    # Strip +brewing from baked-in paths post-install — TeXLive's
+    # web2c/texmf.cnf and tlmgr scripts hardcode the configure-time
+    # prefix. Same pattern as R / Octave.
+    - run: |
+        cd "{{prefix}}"
+        grep -rIl '+brewing' bin texmf-dist texmf-var 2>/dev/null \
+          | xargs -r sed -i 's|+brewing||g'
+
+  env:
+    ARGS:
+      - --prefix={{ prefix }}
+      - --datarootdir={{ prefix }}/share
+      - --disable-native-texlive-build  # use a tlpkg-free layout
+      - --enable-shared
+      - --disable-static
+      # Use pantry's system libs instead of TeXLive's vendored copies.
+      - --with-system-zlib
+      - --with-system-libpng
+      - --with-system-freetype2
+      - --with-system-cairo
+      - --with-system-pixman
+      - --with-system-harfbuzz
+      - --with-system-poppler
+      - --with-system-gmp
+      - --with-system-mpfr
+      - --with-system-fontconfig
+      # Skip components that need extra deps (can add back if needed).
+      - --disable-xindy            # needs CLISP
+      - --disable-texlive-build    # don't build the full tlpkg installer
+      - --disable-dvisvgm          # needs xxhash + freetype-aware build
+
+test:
+  # Quick smoke tests on the major engines.
+  script:
+    - run: |
+        out=$(tex --version 2>&1 | head -1)
+        echo "tex: $out"
+        case "$out" in
+          *"TeX"*) echo "tex PASS" ;;
+          *) echo "FAIL: $out"; exit 1 ;;
+        esac
+    - pdftex --version 2>&1 | head -1
+    - xetex --version 2>&1 | head -1
+    - luatex --version 2>&1 | head -1
+
+provides:
+  # Major engines (from texk/ subtree). Not exhaustive — texlive
+  # installs ~80 binaries; listing the ones users actually invoke.
+  - bin/tex
+  - bin/pdftex
+  - bin/xetex
+  - bin/luatex
+  - bin/luahbtex
+  - bin/dvips
+  - bin/dvipdfm
+  - bin/dvipdfmx
+  - bin/bibtex
+  - bin/biber              # optional — may need extra deps
+  - bin/makeindex
+  - bin/mktexlsr
+  - bin/tlmgr              # TeX Live Manager (Perl)
+  - bin/kpsewhich
+  - bin/kpathsea

--- a/projects/tug.org/texlive/package.yml
+++ b/projects/tug.org/texlive/package.yml
@@ -104,6 +104,8 @@ build:
       # Skip components that need extra deps (can add back if needed).
       - --disable-xindy            # needs CLISP
       - --disable-dvisvgm          # needs xxhash + freetype-aware build
+      - --without-x                # xdvik needs Xaw widgets not in pantry
+      - --disable-xdvik            # belt+braces — same Xaw dependency
 
 test:
   # Quick smoke tests on the major engines.


### PR DESCRIPTION
## Summary
- New recipe **tug.org/texlive** — TeX Live engine suite (pdftex, xetex, luatex, dvips, bibtex, makeindex, tlmgr, kpsewhich, etc.).
- Built from \`texlive-YYYYMMDD-source.tar.xz\` upstream bundle. **Macro packages** (LaTeX kernel, AMS, KOMA-Script, etc.) are NOT bundled — install via \`tlmgr install <pkg>\` post-setup.
- Uses \`--with-system-*\` to link against pantry's freetype, cairo, poppler, harfbuzz, gmp, mpfr, fontconfig — no vendored binary blobs.

## Caveats
- Build is heavy: ~15-30 min on a fast runner (texlive-source is ~600MB across ~50 engines).
- Disabled \`xindy\` (needs CLISP), \`texlive-build\` (full installer), \`dvisvgm\` (needs extra deps). Can be re-enabled in follow-ups.
- This is the **engines** only. To use as a working LaTeX install, users still need to seed \`tlmgr\` and install packages.

## Test plan
- [ ] \`tex --version\` / \`pdftex --version\` / \`xetex --version\` / \`luatex --version\` all report version info
- [ ] \`kpsewhich --version\` works
- [ ] Build on all 4 platforms (may need iteration for darwin / aarch64 quirks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)