### PR TITLE
new(valgrind.org): memory + threading debugger (closes #462)

### DIFF
--- a/projects/valgrind.org/package.yml
+++ b/projects/valgrind.org/package.yml
@@ -23,8 +23,7 @@ versions:
 # instrumentation unreliable, and the darwin runner failed here even
 # after a clean build. Skip darwin altogether.
 platforms:
-  - linux/x86-64
-  - linux/aarch64
+  - linux
 
 # valgrind bakes VALGRIND_LIB into the binary at configure time using
 # the +brewing prefix; after brewkit renames the install dir, the path
@@ -35,8 +34,6 @@ runtime:
 
 build:
   dependencies:
-    gnu.org/make: '*'
-    gnu.org/coreutils: '*'
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
     perl.org: '*'
@@ -63,4 +60,5 @@ provides:
   - bin/ms_print
 
 test:
-  - valgrind --version | grep "valgrind-{{version.raw}}"
+  - valgrind --version | tee out
+  - grep "valgrind-{{version.raw}}" out

--- a/projects/valgrind.org/package.yml
+++ b/projects/valgrind.org/package.yml
@@ -1,0 +1,59 @@
+# Valgrind — memory + threading debugger and profiler.
+#
+# Suite of debug/profile tools: memcheck (leak detector), helgrind
+# (race detector), cachegrind (cache profiler), callgrind (call
+# graph profiler), massif (heap profiler), and more.
+#
+# Closes pkgxdev/pantry#462.
+
+distributable:
+  url: https://sourceware.org/pub/valgrind/valgrind-{{ version.raw }}.tar.bz2
+  strip-components: 1
+
+versions:
+  url: https://sourceware.org/pub/valgrind/
+  match: /valgrind-\d+\.\d+\.\d+\.tar\.bz2/
+  strip:
+    - /^valgrind-/
+    - /\.tar\.bz2/
+
+# Valgrind requires Linux/x86-64, Linux/aarch64, or
+# Darwin/x86-64 (Apple Silicon support landed in 3.21 but is still
+# considered experimental — keep darwin/aarch64 off the list to
+# avoid silent breakage).
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+    gnu.org/coreutils: '*'
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
+    perl.org: '*'
+
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - --prefix={{ prefix }}
+      - --enable-only64bit
+      - --disable-tls
+
+provides:
+  - bin/valgrind
+  - bin/valgrind-listener
+  - bin/vgdb
+  - bin/callgrind_annotate
+  - bin/callgrind_control
+  - bin/cg_annotate
+  - bin/cg_diff
+  - bin/cg_merge
+  - bin/ms_print
+
+test:
+  - valgrind --version | grep "valgrind-{{version.raw}}"

--- a/projects/valgrind.org/package.yml
+++ b/projects/valgrind.org/package.yml
@@ -26,6 +26,13 @@ platforms:
   - linux/aarch64
   - darwin/x86-64
 
+# valgrind bakes VALGRIND_LIB into the binary at configure time using
+# the +brewing prefix; after brewkit renames the install dir, the path
+# no longer exists. Set runtime.env so pkgx exports the correct path.
+runtime:
+  env:
+    VALGRIND_LIB: ${{prefix}}/libexec/valgrind
+
 build:
   dependencies:
     gnu.org/make: '*'

--- a/projects/valgrind.org/package.yml
+++ b/projects/valgrind.org/package.yml
@@ -18,13 +18,13 @@ versions:
     - /\.tar\.bz2/
 
 # Valgrind requires Linux/x86-64, Linux/aarch64, or
-# Darwin/x86-64 (Apple Silicon support landed in 3.21 but is still
-# considered experimental — keep darwin/aarch64 off the list to
-# avoid silent breakage).
+# Linux only. Darwin support has been fragile since macOS 11 — Apple's
+# hardened runtime / codesign requirements make valgrind's ptrace-style
+# instrumentation unreliable, and the darwin runner failed here even
+# after a clean build. Skip darwin altogether.
 platforms:
   - linux/x86-64
   - linux/aarch64
-  - darwin/x86-64
 
 # valgrind bakes VALGRIND_LIB into the binary at configure time using
 # the +brewing prefix; after brewkit renames the install dir, the path


### PR DESCRIPTION
Memcheck, helgrind, callgrind, massif and other tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)