### PR TITLE
new(MoltenVK): Vulkan→Metal layer (Top 300 #599)

### DIFF
--- a/projects/github.com/KhronosGroup/MoltenVK/package.yml
+++ b/projects/github.com/KhronosGroup/MoltenVK/package.yml
@@ -1,0 +1,46 @@
+# MoltenVK — Vulkan→Metal translation layer for Apple platforms.
+#
+# Implements a subset of the Vulkan API by translating to Apple's
+# Metal API. Required for running Vulkan apps (games, GPU compute,
+# Blender, etc.) on macOS.
+#
+# Closes part of pkgxdev/pantry#99 (Top 300 holdout #599).
+
+distributable:
+  url: https://github.com/KhronosGroup/MoltenVK/archive/refs/tags/v{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: KhronosGroup/MoltenVK
+
+# macOS-only — Metal doesn't exist elsewhere.
+platforms:
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+    cmake.org: '*'
+    python.org: '*'      # external dep fetch scripts use python
+
+  script:
+    # MoltenVK fetches its own external deps (SPIRV-Cross, glslang,
+    # cereal) via fetchDependencies. This is part of the upstream
+    # build flow; pkgx pantry's `external` git submodules approach
+    # would also work but is more invasive.
+    - ./fetchDependencies --macos
+    - make macos
+    - run: |
+        mkdir -p "{{prefix}}/lib" "{{prefix}}/include"
+        cp -R Package/Release/MoltenVK/dynamic/dylib/macOS/* "{{prefix}}/lib/"
+        cp -R Package/Release/MoltenVK/include/* "{{prefix}}/include/"
+
+test:
+  - test -f "{{prefix}}/lib/libMoltenVK.dylib"
+  - test -f "{{prefix}}/include/MoltenVK/mvk_vulkan.h"
+
+provides:
+  # Library-only package — no CLI binaries.
+  # Provides libMoltenVK.dylib for Vulkan loader at runtime.
+  []

--- a/projects/github.com/KhronosGroup/MoltenVK/package.yml
+++ b/projects/github.com/KhronosGroup/MoltenVK/package.yml
@@ -7,7 +7,7 @@
 # Closes part of pkgxdev/pantry#99 (Top 300 holdout #599).
 
 distributable:
-  url: https://github.com/KhronosGroup/MoltenVK/archive/refs/tags/v{{ version.raw }}.tar.gz
+  url: https://github.com/KhronosGroup/MoltenVK/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
@@ -15,15 +15,12 @@ versions:
 
 # macOS-only — Metal doesn't exist elsewhere.
 platforms:
-  - darwin/x86-64
-  - darwin/aarch64
+  - darwin
 
 build:
   dependencies:
-    gnu.org/make: '*'
     cmake.org: '*'
     python.org: '*'      # external dep fetch scripts use python
-
   script:
     # MoltenVK fetches its own external deps (SPIRV-Cross, glslang,
     # cereal) via fetchDependencies. This is part of the upstream
@@ -31,16 +28,10 @@ build:
     # would also work but is more invasive.
     - ./fetchDependencies --macos
     - make macos
-    - run: |
-        mkdir -p "{{prefix}}/lib" "{{prefix}}/include"
-        cp -R Package/Release/MoltenVK/dynamic/dylib/macOS/* "{{prefix}}/lib/"
-        cp -R Package/Release/MoltenVK/include/* "{{prefix}}/include/"
+    - mkdir -p "{{prefix}}/lib" "{{prefix}}/include"
+    - cp -R Package/Release/MoltenVK/dynamic/dylib/macOS/* "{{prefix}}/lib/"
+    - cp -R Package/Release/MoltenVK/include/* "{{prefix}}/include/"
 
 test:
   - test -f "{{prefix}}/lib/libMoltenVK.dylib"
   - test -f "{{prefix}}/include/MoltenVK/mvk_vulkan.h"
-
-provides:
-  # Library-only package — no CLI binaries.
-  # Provides libMoltenVK.dylib for Vulkan loader at runtime.
-  []

--- a/projects/github.com/KhronosGroup/MoltenVK/package.yml
+++ b/projects/github.com/KhronosGroup/MoltenVK/package.yml
@@ -19,8 +19,8 @@ platforms:
 
 build:
   dependencies:
-    cmake.org: '*'
-    python.org: '*'      # external dep fetch scripts use python
+    cmake.org: "*"
+    python.org: "*" # external dep fetch scripts use python
   script:
     # MoltenVK fetches its own external deps (SPIRV-Cross, glslang,
     # cereal) via fetchDependencies. This is part of the upstream
@@ -33,5 +33,14 @@ build:
     - cp -R Package/Release/MoltenVK/include/* "{{prefix}}/include/"
 
 test:
-  - test -f "{{prefix}}/lib/libMoltenVK.dylib"
-  - test -f "{{prefix}}/include/MoltenVK/mvk_vulkan.h"
+  - run: cc $FIXTURE -o test -lMoltenVK
+    fixture:
+      extname: c
+      content: |
+        #include <stdio.h>
+        #include <MoltenVK/mvk_vulkan.h>
+
+        int main() {
+          printf("Hello, world!");
+        }
+  - test "$(./test)" = "Hello, world!"


### PR DESCRIPTION
Library-only macOS package. Provides libMoltenVK.dylib via upstream's fetchDependencies + make macos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)