### PR TITLE
new(git-scm.org/gui): git-gui + gitk (Top 300 #371)

### DIFF
--- a/projects/git-scm.org/gui/package.yml
+++ b/projects/git-scm.org/gui/package.yml
@@ -36,25 +36,46 @@ build:
   script:
     # Build just the git-gui and gitk subdirs — the main `git` binary
     # comes from git-scm.org which is a runtime dep.
+    #
+    # git-gui's Makefile installs into $(gitexecdir) (the wrapper) and
+    # $(sharedir)/git-gui/lib (Tcl sources). gitk-git installs the
+    # `gitk` wrapper into $(bindir) directly.
+    #
+    # TCLTK_PATH (path to wish) is baked into the generated wrapper
+    # scripts at `make` time — must be set for both subdirs.
     - run: |
         cd git-gui
-        make --jobs {{ hw.concurrency }} TCLTK_PATH={{deps.tcl-lang.org/tk.prefix}}/bin/wish
-        make install gg_install_dir={{prefix}}/libexec/git-core prefix={{prefix}}
+        make --jobs {{ hw.concurrency }} \
+          TCLTK_PATH={{deps.tcl-lang.org/tk.prefix}}/bin/wish
+        make install \
+          gitexecdir={{prefix}}/libexec/git-core \
+          sharedir={{prefix}}/share \
+          prefix={{prefix}} \
+          TCLTK_PATH={{deps.tcl-lang.org/tk.prefix}}/bin/wish
+
     - run: |
         cd gitk-git
-        make --jobs {{ hw.concurrency }}
-        make install gitexecdir={{prefix}}/libexec/git-core prefix={{prefix}}
+        make --jobs {{ hw.concurrency }} \
+          TCLTK_PATH={{deps.tcl-lang.org/tk.prefix}}/bin/wish \
+          TCL_PATH={{deps.tcl-lang.org.prefix}}/bin/tclsh
+        make install \
+          bindir={{prefix}}/bin \
+          sharedir={{prefix}}/share \
+          prefix={{prefix}} \
+          TCLTK_PATH={{deps.tcl-lang.org/tk.prefix}}/bin/wish \
+          TCL_PATH={{deps.tcl-lang.org.prefix}}/bin/tclsh
 
     - run: |
-        # symlink top-level wrappers so `git-gui` and `gitk` are on PATH
+        # git-gui installs as libexec/git-core/git-gui (so `git gui`
+        # dispatches to it); add a bin/ symlink so it's directly on
+        # PATH as well — matches debian's layout.
         mkdir -p {{prefix}}/bin
-        cd {{prefix}}/bin
-        ln -sf ../libexec/git-core/git-gui git-gui || true
-        ln -sf ../libexec/git-core/gitk gitk || true
+        ln -sf ../libexec/git-core/git-gui {{prefix}}/bin/git-gui
 
 test:
-  - test -f "{{prefix}}/libexec/git-core/git-gui"
-  - test -f "{{prefix}}/libexec/git-core/gitk"
+  - test -x "{{prefix}}/libexec/git-core/git-gui"
+  - test -x "{{prefix}}/bin/git-gui"
+  - test -x "{{prefix}}/bin/gitk"
 
 provides:
   - bin/git-gui

--- a/projects/git-scm.org/gui/package.yml
+++ b/projects/git-scm.org/gui/package.yml
@@ -1,0 +1,61 @@
+# git-gui + gitk — Tcl/Tk GUIs for git.
+#
+# Companion to git-scm.org which builds the main git binaries with
+# `NO_TCLTK=1`. This recipe re-uses the same git source but builds
+# only the git-gui/ and gitk-git/ subdirs against Tk.
+#
+# Provides bin/git-gui (commit/history GUI) and bin/gitk (history
+# visualizer). Both invoked via `git gui` and `gitk` once on PATH.
+#
+# Closes part of pkgxdev/pantry#99 (Top 300 holdout #371).
+
+distributable:
+  url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-{{version}}.tar.xz
+  strip-components: 1
+
+versions:
+  github: git/git/tags
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+dependencies:
+  git-scm.org: '*'
+  tcl-lang.org: '*'
+  tcl-lang.org/tk: '*'
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+    gnu.org/coreutils: '*'
+    gnu.org/gettext: '*'
+
+  script:
+    # Build just the git-gui and gitk subdirs — the main `git` binary
+    # comes from git-scm.org which is a runtime dep.
+    - run: |
+        cd git-gui
+        make --jobs {{ hw.concurrency }} TCLTK_PATH={{deps.tcl-lang.org/tk.prefix}}/bin/wish
+        make install gg_install_dir={{prefix}}/libexec/git-core prefix={{prefix}}
+    - run: |
+        cd gitk-git
+        make --jobs {{ hw.concurrency }}
+        make install gitexecdir={{prefix}}/libexec/git-core prefix={{prefix}}
+
+    - run: |
+        # symlink top-level wrappers so `git-gui` and `gitk` are on PATH
+        mkdir -p {{prefix}}/bin
+        cd {{prefix}}/bin
+        ln -sf ../libexec/git-core/git-gui git-gui || true
+        ln -sf ../libexec/git-core/gitk gitk || true
+
+test:
+  - test -f "{{prefix}}/libexec/git-core/git-gui"
+  - test -f "{{prefix}}/libexec/git-core/gitk"
+
+provides:
+  - bin/git-gui
+  - bin/gitk


### PR DESCRIPTION
Tcl/Tk GUIs for git. Depends on new tcl-lang.org/tk. Closes part of #99 (holdout #371).

🤖 Generated with [Claude Code](https://claude.com/claude-code)