### PR TITLE
new(gnu.org/gcc/v8): GCC 8 for legacy C++ projects

### DIFF
--- a/projects/gnu.org/gcc/v8/package.yml
+++ b/projects/gnu.org/gcc/v8/package.yml
@@ -20,32 +20,30 @@ versions:
   # Pin to the 8.x line — drop everything else.
   ignore:
     - /^[0-79]\./
-    - /^9\./
     - /^[1-9][0-9]/
 
 # Linux only. Darwin's old SDK situation makes gcc 8 hard to bring
 # up — users on darwin needing legacy C++ are better off with clang
 # from llvm.org which has its own legacy mode.
 platforms:
-  - linux/x86-64
-  - linux/aarch64
+  - linux
 
 dependencies:
-  gnu.org/binutils: '*'
+  gnu.org/binutils: "*"
   gnu.org/gmp: ~6
   gnu.org/mpfr: ~4
   gnu.org/mpc: ~1
   zlib.net: ^1.3
+  pkgx.sh: ">=1"
 
 build:
   dependencies:
     linux:
-      gnu.org/gcc: '*'   # bootstrap with current gcc
-    gnu.org/make: '*'
-    perl.org: '*'
-    gnu.org/patch: '*'
-    curl.se: '*'
-    github.com/westes/flex: '*'
+      gnu.org/gcc: "*" # bootstrap with current gcc
+    perl.org: "*"
+    gnu.org/patch: "*"
+    curl.se: "*"
+    github.com/westes/flex: "*"
 
   working-directory: build
   script:
@@ -57,12 +55,16 @@ build:
     # gcc symlinks expected by some build systems. This recipe lives
     # one level deeper than the main gnu.org/gcc (v8 subdir), so the
     # relative path to binutils needs `../../../../` (4 levels).
-    - run: |
-        cd "{{prefix}}/bin"
-        ln -sf gcc cc
-        ln -sf ../../../../binutils/v\*/bin/ar ar
-        ln -sf ../../../../binutils/v\*/bin/nm nm
-        ln -sf ../../../../binutils/v\*/bin/ranlib ranlib
+    - run:
+        - ln -sf gcc cc
+        - install -m755 $PROP ar
+        - install -m755 $PROP nm
+        - install -m755 $PROP ranlib
+      prop: |
+        #!/bin/sh
+        TOOL=$(basename "$0")
+        exec pkgx +gnu.org/binutils "$TOOL" "$@"
+      working-directory: "{{prefix}}/bin"
 
   env:
     ARGS:
@@ -80,20 +82,24 @@ build:
       CXXFLAGS: -fPIC
 
 test:
-  - gcc --version | grep -q "pkgx GCC {{version}}"
-  - gcc -dumpversion | grep -q "^8\."
+  - gcc --version | tee out
+  - grep "pkgx GCC {{version}}" out
+  - gcc -dumpversion | tee out
+  - grep "^8\." out
 
-provides:
-  - bin/ar
-  - bin/cc
-  - bin/c++
-  - bin/cpp
-  - bin/g++
-  - bin/gcc
-  - bin/gcc-ar
-  - bin/gcc-nm
-  - bin/gcc-ranlib
-  - bin/gcov
-  - bin/gfortran
-  - bin/nm
-  - bin/ranlib
+# it's not wise to publish these, since this is a legacy compiler.
+# if people want it, they'll invoke it explicitly.
+# provides:
+#   - bin/ar
+#   - bin/cc
+#   - bin/c++
+#   - bin/cpp
+#   - bin/g++
+#   - bin/gcc
+#   - bin/gcc-ar
+#   - bin/gcc-nm
+#   - bin/gcc-ranlib
+#   - bin/gcov
+#   - bin/gfortran
+#   - bin/nm
+#   - bin/ranlib

--- a/projects/gnu.org/gcc/v8/package.yml
+++ b/projects/gnu.org/gcc/v8/package.yml
@@ -60,9 +60,9 @@ build:
     - run: |
         cd "{{prefix}}/bin"
         ln -sf gcc cc
-        ln -sf ../../../../binutils/v*/bin/ar ar
-        ln -sf ../../../../binutils/v*/bin/nm nm
-        ln -sf ../../../../binutils/v*/bin/ranlib ranlib
+        ln -sf ../../../../binutils/v\*/bin/ar ar
+        ln -sf ../../../../binutils/v\*/bin/nm nm
+        ln -sf ../../../../binutils/v\*/bin/ranlib ranlib
 
   env:
     ARGS:

--- a/projects/gnu.org/gcc/v8/package.yml
+++ b/projects/gnu.org/gcc/v8/package.yml
@@ -1,0 +1,97 @@
+# GCC 8 — legacy version for old-vendored-C++ projects.
+#
+# Many projects vendoring older C++ libraries (RocksDB 6.3.x, old
+# MySQL 5.7, old InnoDB, pre-C++17 codebases generally) hit the
+# stricter copy-ctor / atomic / pair-construction rules introduced
+# in gcc 12+ libstdc++. They compile cleanly with gcc 8 which was
+# the last major to default to C++14 / gnu++14 ABI.
+#
+# Companion to gnu.org/gcc (latest) for cubefs.io, mysql.com/v5_7,
+# and other from-source recipes that can't easily be patched to
+# modern C++.
+
+distributable:
+  url: https://ftp.gnu.org/gnu/gcc/gcc-{{ version.raw }}/gcc-{{ version.raw }}.tar.xz
+  strip-components: 1
+
+versions:
+  github: gcc-mirror/gcc/tags
+  strip: /^releases\/gcc-/
+  # Pin to the 8.x line — drop everything else.
+  ignore:
+    - /^[0-79]\./
+    - /^9\./
+    - /^[1-9][0-9]/
+
+# Linux only. Darwin's old SDK situation makes gcc 8 hard to bring
+# up — users on darwin needing legacy C++ are better off with clang
+# from llvm.org which has its own legacy mode.
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+
+dependencies:
+  gnu.org/binutils: '*'
+  gnu.org/gmp: ~6
+  gnu.org/mpfr: ~4
+  gnu.org/mpc: ~1
+  zlib.net: ^1.3
+
+build:
+  dependencies:
+    linux:
+      gnu.org/gcc: '*'   # bootstrap with current gcc
+    gnu.org/make: '*'
+    perl.org: '*'
+    gnu.org/patch: '*'
+    curl.se: '*'
+    github.com/westes/flex: '*'
+
+  working-directory: build
+  script:
+    - ARGS=($ARGS --with-pkgversion="pkgx GCC {{version}}")
+    - ../configure "${ARGS[@]}"
+    - make --jobs {{ hw.concurrency }}
+    - make install
+
+    # gcc symlinks expected by some build systems
+    - run: |
+        cd "{{prefix}}/bin"
+        ln -sf gcc cc
+        ln -sf ../../../binutils/v*/bin/ar ar
+        ln -sf ../../../binutils/v*/bin/nm nm
+        ln -sf ../../../binutils/v*/bin/ranlib ranlib
+
+  env:
+    ARGS:
+      - --prefix={{ prefix }}
+      - --libdir={{ prefix }}/lib
+      - --enable-languages=c,c++,fortran
+      - --disable-bootstrap
+      - --disable-nls
+      - --disable-multilib
+      - --with-system-zlib
+      - --with-bugurl=https://github.com/pkgxdev/pantry/issues
+    linux/x86-64:
+      LDFLAGS: -fPIC
+      CFLAGS: -fPIC
+      CXXFLAGS: -fPIC
+
+test:
+  - gcc --version | grep -q "pkgx GCC {{version}}"
+  - gcc -dumpversion | grep -q "^8\."
+
+provides:
+  - bin/ar
+  - bin/cc
+  - bin/c++
+  - bin/cpp
+  - bin/g++
+  - bin/gcc
+  - bin/gcc-ar
+  - bin/gcc-nm
+  - bin/gcc-ranlib
+  - bin/gcov
+  - bin/gfortran
+  - bin/nm
+  - bin/ranlib

--- a/projects/gnu.org/gcc/v8/package.yml
+++ b/projects/gnu.org/gcc/v8/package.yml
@@ -54,13 +54,15 @@ build:
     - make --jobs {{ hw.concurrency }}
     - make install
 
-    # gcc symlinks expected by some build systems
+    # gcc symlinks expected by some build systems. This recipe lives
+    # one level deeper than the main gnu.org/gcc (v8 subdir), so the
+    # relative path to binutils needs `../../../../` (4 levels).
     - run: |
         cd "{{prefix}}/bin"
         ln -sf gcc cc
-        ln -sf ../../../binutils/v*/bin/ar ar
-        ln -sf ../../../binutils/v*/bin/nm nm
-        ln -sf ../../../binutils/v*/bin/ranlib ranlib
+        ln -sf ../../../../binutils/v*/bin/ar ar
+        ln -sf ../../../../binutils/v*/bin/nm nm
+        ln -sf ../../../../binutils/v*/bin/ranlib ranlib
 
   env:
     ARGS:


### PR DESCRIPTION
## Summary
- New recipe **gnu.org/gcc/v8** — GCC 8.x line, parallel to the latest gnu.org/gcc recipe.
- Many projects vendoring older C++ libraries (RocksDB 6.3.x in cubefs, InnoDB in MySQL 5.7, pre-C++17 codebases) hit gcc 12+'s stricter copy-ctor / std::atomic / std::pair-construction rules. They compile cleanly with gcc 8 (last default-C++14 major).
- This recipe enables follow-ups like #13050 (cubefs) and #13062 (mysql@5.7) to pin \`gnu.org/gcc/v8: '*'\` and compile their vendored old C++ from source — keeping the from-source promise without monkey-patching upstream sources.
- Linux only. Darwin's old-SDK situation makes gcc 8 hard to bring up, and llvm.org clang covers legacy on darwin.

## Why
\`pkgx +gnu.org/gcc^8\` currently returns \`ResolveError\` — no 8.x bottle exists. This PR adds the recipe so pantry CI builds and bottles gcc 8 for downstream legacy recipes.

## Test plan
- [ ] gcc 8.x builds on linux/x86-64 + linux/aarch64
- [ ] \`gcc --version\` reports "pkgx GCC 8.x.x"
- [ ] \`gcc -dumpversion\` starts with "8."
- [ ] Downstream test: cubefs.io can build RocksDB 6.3.6 with this gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)