### PR TITLE
new(keda.sh): event-driven autoscaling (CNCF graduated)

### DIFF
--- a/projects/keda.sh/package.yml
+++ b/projects/keda.sh/package.yml
@@ -1,0 +1,49 @@
+# KEDA — Kubernetes Event-Driven Autoscaling (CNCF graduated).
+#
+# Scales K8s deployments based on event sources (Kafka, RabbitMQ,
+# Prometheus, AWS SQS, GitHub Actions queue, etc.) rather than just
+# CPU/memory. Ships operator + adapter pods.
+#
+# This recipe builds the binaries; in practice you deploy via Helm.
+
+distributable:
+  url: https://github.com/kedacore/keda/archive/refs/tags/v{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: kedacore/keda
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    go.dev: '*'
+    gnu.org/coreutils: '*'
+
+  script:
+    - run: |
+        export CGO_ENABLED=0
+        LDFLAGS="-s -w -X github.com/kedacore/keda/v2/version.Version=v{{ version.raw }}"
+        for cmd in operator adapter webhooks; do
+          if [ -d "cmd/$cmd" ]; then
+            go build -trimpath -ldflags "$LDFLAGS" \
+              -o "bin/keda-$cmd" "./cmd/$cmd"
+          fi
+        done
+
+    - run: |
+        for bin in bin/*; do
+          install -Dm755 "$bin" "{{prefix}}/bin/$(basename "$bin")"
+        done
+
+test:
+  - test -x "{{prefix}}/bin/keda-operator"
+
+provides:
+  - bin/keda-operator
+  - bin/keda-adapter
+  - bin/keda-webhooks

--- a/projects/keda.sh/package.yml
+++ b/projects/keda.sh/package.yml
@@ -7,41 +7,30 @@
 # This recipe builds the binaries; in practice you deploy via Helm.
 
 distributable:
-  url: https://github.com/kedacore/keda/archive/refs/tags/v{{ version.raw }}.tar.gz
+  url: https://github.com/kedacore/keda/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
   github: kedacore/keda
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 build:
   dependencies:
-    go.dev: '*'
-    gnu.org/coreutils: '*'
-
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/kedacore/keda/v2/version.Version={{ version.tag }}
   script:
-    - run: |
-        export CGO_ENABLED=0
-        LDFLAGS="-s -w -X github.com/kedacore/keda/v2/version.Version=v{{ version.raw }}"
-        for cmd in operator adapter webhooks; do
-          if [ -d "cmd/$cmd" ]; then
-            go build -trimpath -ldflags "$LDFLAGS" \
-              -o "bin/keda-$cmd" "./cmd/$cmd"
-          fi
-        done
-
-    - run: |
-        for bin in bin/*; do
-          install -Dm755 "$bin" "{{prefix}}/bin/$(basename "$bin")"
-        done
+    - mkdir -p {{prefix}}/bin
+    - for cmd in operator adapter webhooks; do
+    - if [ ! -d "cmd/$cmd" ]; then continue; fi
+    - go build -trimpath -ldflags "$GO_LDFLAGS" -o "{{prefix}}/bin/keda-$cmd" "./cmd/$cmd"
+    - done
 
 test:
-  - test -x "{{prefix}}/bin/keda-operator"
+  - keda-operator --help
 
 provides:
   - bin/keda-operator


### PR DESCRIPTION
Part of the CNCF coverage batch. Go binary, CGO_ENABLED=0 for static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)