### PR TITLE
new(external-secrets.io): sync secrets from external stores (CNCF graduated)

### DIFF
--- a/projects/external-secrets.io/package.yml
+++ b/projects/external-secrets.io/package.yml
@@ -5,44 +5,34 @@
 # CNCF graduated — the standard way to keep K8s secrets out of git.
 
 distributable:
-  url: https://github.com/external-secrets/external-secrets/archive/refs/tags/v{{ version.raw }}.tar.gz
+  url: https://github.com/external-secrets/external-secrets/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
   github: external-secrets/external-secrets
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 build:
   dependencies:
-    go.dev: '*'
-    gnu.org/coreutils: '*'
-
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/external-secrets/external-secrets/pkg/version.Version={{ version.tag }}
   script:
-    - run: |
-        export CGO_ENABLED=0
-        LDFLAGS="-s -w -X github.com/external-secrets/external-secrets/pkg/version.Version=v{{ version.raw }}"
-        for cmd in controller esoctl; do
-          if [ -d "cmd/$cmd" ]; then
-            go build -trimpath -ldflags "$LDFLAGS" \
-              -o "bin/$cmd" "./cmd/$cmd"
-          fi
-        done
-        # Rename `controller` → `external-secrets` and `esoctl` keeps name
-        [ -f bin/controller ] && mv bin/controller bin/external-secrets
-
-    - run: |
-        for bin in bin/*; do
-          install -Dm755 "$bin" "{{prefix}}/bin/$(basename "$bin")"
-        done
+    - mkdir -p {{prefix}}/bin
+    - for cmd in controller esoctl; do
+    - if test ! -d "cmd/$cmd"; then continue; fi
+    - go build -trimpath -ldflags "$GO_LDFLAGS" -o "{{prefix}}/bin/$cmd" "./cmd/$cmd"
+    - chmod +x {{prefix}}/bin/$cmd
+    - done
+    # Rename `controller` → `external-secrets` and `esoctl` keeps name
+    - run: test -f controller && mv controller external-secrets
+      working-directory: ${{prefix}}/bin
 
 test:
-  - test -x "{{prefix}}/bin/external-secrets"
-  - test -x "{{prefix}}/bin/esoctl"
+  - esoctl --help
 
 provides:
   - bin/external-secrets

--- a/projects/external-secrets.io/package.yml
+++ b/projects/external-secrets.io/package.yml
@@ -1,0 +1,49 @@
+# external-secrets — sync secrets from external stores (CNCF graduated).
+#
+# Pulls secret values from Vault, AWS Secrets Manager, GCP Secret
+# Manager, Azure Key Vault, etc. and syncs them as native K8s Secrets.
+# CNCF graduated — the standard way to keep K8s secrets out of git.
+
+distributable:
+  url: https://github.com/external-secrets/external-secrets/archive/refs/tags/v{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: external-secrets/external-secrets
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    go.dev: '*'
+    gnu.org/coreutils: '*'
+
+  script:
+    - run: |
+        export CGO_ENABLED=0
+        LDFLAGS="-s -w -X github.com/external-secrets/external-secrets/pkg/version.Version=v{{ version.raw }}"
+        for cmd in controller esoctl; do
+          if [ -d "cmd/$cmd" ]; then
+            go build -trimpath -ldflags "$LDFLAGS" \
+              -o "bin/$cmd" "./cmd/$cmd"
+          fi
+        done
+        # Rename `controller` → `external-secrets` and `esoctl` keeps name
+        [ -f bin/controller ] && mv bin/controller bin/external-secrets
+
+    - run: |
+        for bin in bin/*; do
+          install -Dm755 "$bin" "{{prefix}}/bin/$(basename "$bin")"
+        done
+
+test:
+  - test -x "{{prefix}}/bin/external-secrets"
+  - test -x "{{prefix}}/bin/esoctl"
+
+provides:
+  - bin/external-secrets
+  - bin/esoctl


### PR DESCRIPTION
Part of the CNCF coverage batch. Go binary, CGO_ENABLED=0 for static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)