### PR TITLE
new(WebAssembly/binaryen): wasm-opt toolchain (unblocks emscripten)

### DIFF
--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -90,5 +90,8 @@ provides:
   - bin/wasm-split
 
 test:
-  # wasm-opt prints `--version` to stderr in newer releases; merge 2>&1.
-  - wasm-opt --version 2>&1 | grep -i "version_{{version.raw}}"
+  # wasm-opt's --version output format has shifted across versions
+  # (older: "wasm-opt version_129"; newer: "wasm-opt 129.0"). Just
+  # verify the binary runs and prints something matching our raw
+  # numeric version, on either stream.
+  - wasm-opt --version 2>&1 | grep -i "{{version.raw}}"

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -90,4 +90,5 @@ provides:
   - bin/wasm-split
 
 test:
-  - wasm-opt --version | grep -i "wasm-opt"
+  # wasm-opt prints `--version` to stderr in newer releases; merge 2>&1.
+  - wasm-opt --version 2>&1 | grep -i "version_{{version.raw}}"

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -26,22 +26,42 @@ build:
     cmake.org: ^3
     gnu.org/make: '*'
     python.org: '*'
+    linux:
+      gnu.org/gcc: '*'    # for its modern libstdc++ headers — Nix-style
 
   working-directory: build
   script:
-    # binaryen 129 uses std::set::contains / std::map::contains (C++20).
-    # Two earlier iters tried CMAKE_CXX_STANDARD=20 then CMAKE_CXX_FLAGS=
-    # -std=c++20 — neither stuck because binaryen's CMakeLists pins per-
-    # target features with target_compile_features(cxx_std_17). Append
-    # -std=c++20 to brewkit's CXXFLAGS BEFORE cmake; CMake then copies
-    # it into CMAKE_CXX_FLAGS at first configure, and the per-target
-    # feature gets resolved against the OS env's -std (which clang
-    # picks up last-wins).
+    # binaryen 129's IR code uses std::set::contains / std::map::contains
+    # (added in C++20). Three earlier iters tried CMAKE_CXX_STANDARD=20,
+    # then CMAKE_CXX_FLAGS=-std=c++20, then CXXFLAGS=...-std=c++20 — none
+    # stuck. The real issue (nixpkgs's binaryen recipe ships an EMPTY
+    # cmakeFlags and works fine): clang ends up picking up the host's
+    # /usr/include/c++/12/ libstdc++ headers (Ubuntu 22.04, gcc 12),
+    # whose `<set>` / `<map>` don't expose `contains` even at -std=c++20
+    # because the host's libstdc++ predates the back-port.
+    #
+    # Fix the way Nix's cc-wrapper does it: prepend pkgx-gcc's libstdc++
+    # include dir via -isystem so clang resolves <set>/<map> against
+    # gcc 16's libstdc++ (which DOES expose contains via the
+    # __cpp_lib_set_contains feature-test macro).
     - run: |
-        export CXXFLAGS="${CXXFLAGS:-} -std=c++20"
+        GCC_PFX="{{deps.gnu.org/gcc.prefix}}"
+        # gcc's libstdc++ headers live at $prefix/include/c++/<version>
+        # (e.g. /opt/gnu.org/gcc/v16.1.0/include/c++/16.1.0/). Glob to
+        # find the actual version directory.
+        for d in "$GCC_PFX"/include/c++/*; do
+          [ -d "$d" ] && CXX_INC="$d" && break
+        done
+        export CXXFLAGS="${CXXFLAGS:-} -isystem $CXX_INC"
         cmake .. $ARGS
         make --jobs {{ hw.concurrency }}
         make install
+      if: linux
+    - run: |
+        cmake .. $ARGS
+        make --jobs {{ hw.concurrency }}
+        make install
+      if: darwin
   env:
     ARGS:
       - -DCMAKE_INSTALL_PREFIX={{prefix}}

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -37,6 +37,7 @@ build:
       - -DCMAKE_INSTALL_PREFIX={{prefix}}
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_TESTS=OFF
+      - -DBUILD_LLVM_DWARF=OFF
 
 provides:
   - bin/wasm-opt

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -8,27 +8,19 @@
 # emscripten pantry recipe (#13065) which needs wasm-opt on PATH.
 
 distributable:
-  url: https://github.com/WebAssembly/binaryen/archive/refs/tags/version_{{ version.raw }}.tar.gz
+  url: https://github.com/WebAssembly/binaryen/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
   github: WebAssembly/binaryen
   strip: /^version_/
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 build:
   dependencies:
     cmake.org: ^3
-    gnu.org/make: '*'
-    python.org: '*'
+    python.org: "*"
     linux:
-      gnu.org/gcc: '*'    # for its modern libstdc++ headers — Nix-style
-
+      gnu.org/gcc: 14 # for its modern libstdc++ headers — Nix-style
   working-directory: build
   script:
     # binaryen 129's IR code uses std::set::contains / std::map::contains
@@ -44,31 +36,27 @@ build:
     # include dir via -isystem so clang resolves <set>/<map> against
     # gcc 16's libstdc++ (which DOES expose contains via the
     # __cpp_lib_set_contains feature-test macro).
-    - run: |
-        GCC_PFX="{{deps.gnu.org/gcc.prefix}}"
+    - run:
         # gcc's libstdc++ headers live at $prefix/include/c++/<version>
         # (e.g. /opt/gnu.org/gcc/v16.1.0/include/c++/16.1.0/). Glob to
         # find the actual version directory.
-        for d in "$GCC_PFX"/include/c++/*; do
-          [ -d "$d" ] && CXX_INC="$d" && break
-        done
-        export CXXFLAGS="${CXXFLAGS:-} -isystem $CXX_INC"
+        - for d in "$GCC_PFX"/include/c++/*; do
+        - test -d "$d" && CXX_INC="$d" && break
+        - done
+        - export CXXFLAGS="${CXXFLAGS:-} -isystem $CXX_INC"
         # Static-link libstdc++ + libgcc into libbinaryen.so so the
         # resulting binaries don't depend on the host's libstdc++.so.6
         # at runtime. Without this, wasm-opt fails to start on Ubuntu
         # 22.04 with `version 'GLIBCXX_3.4.31' not found` (pkgx gcc 16's
         # libstdc++ is ABI-newer than what the runner ships).
-        export LDFLAGS="${LDFLAGS:-} -static-libstdc++ -static-libgcc"
-        cmake .. $ARGS
-        make --jobs {{ hw.concurrency }}
-        make install
       if: linux
-    - run: |
-        cmake .. $ARGS
-        make --jobs {{ hw.concurrency }}
-        make install
-      if: darwin
+    - cmake .. $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
   env:
+    linux:
+      GCC_PFX: "{{deps.gnu.org/gcc.prefix}}"
+      LDFLAGS: "$LDFLAGS -static-libstdc++ -static-libgcc"
     ARGS:
       - -DCMAKE_INSTALL_PREFIX={{prefix}}
       - -DCMAKE_BUILD_TYPE=Release
@@ -100,4 +88,5 @@ test:
   # (older: "wasm-opt version_129"; newer: "wasm-opt 129.0"). Just
   # verify the binary runs and prints something matching our raw
   # numeric version, on either stream.
-  - wasm-opt --version 2>&1 | grep -i "{{version.raw}}"
+  - wasm-opt --version 2>&1 | tee out
+  - grep -i "{{version.major}}" out

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -38,6 +38,13 @@ build:
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_TESTS=OFF
       - -DBUILD_LLVM_DWARF=OFF
+      # binaryen 119+ uses std::set::contains / std::map::contains
+      # (added in C++20). Default CMake target is C++17, so the
+      # build fails at src/ir/effects.h with
+      #   error: no member named 'contains' in 'std::set<wasm::Name>'
+      # Force C++20 explicitly.
+      - -DCMAKE_CXX_STANDARD=20
+      - -DCMAKE_CXX_STANDARD_REQUIRED=ON
 
 provides:
   - bin/wasm-opt

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -39,12 +39,13 @@ build:
       - -DBUILD_TESTS=OFF
       - -DBUILD_LLVM_DWARF=OFF
       # binaryen 119+ uses std::set::contains / std::map::contains
-      # (added in C++20). Default CMake target is C++17, so the
-      # build fails at src/ir/effects.h with
-      #   error: no member named 'contains' in 'std::set<wasm::Name>'
-      # Force C++20 explicitly.
-      - -DCMAKE_CXX_STANDARD=20
-      - -DCMAKE_CXX_STANDARD_REQUIRED=ON
+      # (added in C++20). The previous iter set CMAKE_CXX_STANDARD=20
+      # which didn't take effect — binaryen's CMakeLists.txt sets the
+      # standard per-target via target_compile_features(... cxx_std_17)
+      # which takes precedence over global CMAKE_CXX_STANDARD. Inject
+      # -std=c++20 directly via CXXFLAGS instead; clang's last-wins
+      # -std= resolution puts our 20 ahead of the per-target 17.
+      - -DCMAKE_CXX_FLAGS=-std=c++20
 
 provides:
   - bin/wasm-opt

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -29,23 +29,25 @@ build:
 
   working-directory: build
   script:
-    - cmake .. $ARGS
-    - make --jobs {{ hw.concurrency }}
-    - make install
+    # binaryen 129 uses std::set::contains / std::map::contains (C++20).
+    # Two earlier iters tried CMAKE_CXX_STANDARD=20 then CMAKE_CXX_FLAGS=
+    # -std=c++20 — neither stuck because binaryen's CMakeLists pins per-
+    # target features with target_compile_features(cxx_std_17). Append
+    # -std=c++20 to brewkit's CXXFLAGS BEFORE cmake; CMake then copies
+    # it into CMAKE_CXX_FLAGS at first configure, and the per-target
+    # feature gets resolved against the OS env's -std (which clang
+    # picks up last-wins).
+    - run: |
+        export CXXFLAGS="${CXXFLAGS:-} -std=c++20"
+        cmake .. $ARGS
+        make --jobs {{ hw.concurrency }}
+        make install
   env:
     ARGS:
       - -DCMAKE_INSTALL_PREFIX={{prefix}}
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_TESTS=OFF
       - -DBUILD_LLVM_DWARF=OFF
-      # binaryen 119+ uses std::set::contains / std::map::contains
-      # (added in C++20). The previous iter set CMAKE_CXX_STANDARD=20
-      # which didn't take effect — binaryen's CMakeLists.txt sets the
-      # standard per-target via target_compile_features(... cxx_std_17)
-      # which takes precedence over global CMAKE_CXX_STANDARD. Inject
-      # -std=c++20 directly via CXXFLAGS instead; clang's last-wins
-      # -std= resolution puts our 20 ahead of the per-target 17.
-      - -DCMAKE_CXX_FLAGS=-std=c++20
 
 provides:
   - bin/wasm-opt

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -67,7 +67,14 @@ build:
       - -DCMAKE_INSTALL_PREFIX={{prefix}}
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_TESTS=OFF
-      - -DBUILD_LLVM_DWARF=OFF
+      # Don't disable DWARF — binaryen's CMakeLists only adds the
+      # third_party/llvm-project/include to the search path when
+      # BUILD_LLVM_DWARF=ON, but `suffix_tree.h` includes
+      # `llvm/Support/Allocator.h` unconditionally. With DWARF OFF
+      # the build hits "Allocator.h: No such file" on every TU that
+      # transitively pulls suffix_tree.h. Net binary cost: ~2 MB
+      # extra in wasm-opt; worth it for a clean build.
+      # - -DBUILD_LLVM_DWARF=OFF
 
 provides:
   - bin/wasm-opt

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -53,6 +53,12 @@ build:
           [ -d "$d" ] && CXX_INC="$d" && break
         done
         export CXXFLAGS="${CXXFLAGS:-} -isystem $CXX_INC"
+        # Static-link libstdc++ + libgcc into libbinaryen.so so the
+        # resulting binaries don't depend on the host's libstdc++.so.6
+        # at runtime. Without this, wasm-opt fails to start on Ubuntu
+        # 22.04 with `version 'GLIBCXX_3.4.31' not found` (pkgx gcc 16's
+        # libstdc++ is ABI-newer than what the runner ships).
+        export LDFLAGS="${LDFLAGS:-} -static-libstdc++ -static-libgcc"
         cmake .. $ARGS
         make --jobs {{ hw.concurrency }}
         make install

--- a/projects/github.com/WebAssembly/binaryen/package.yml
+++ b/projects/github.com/WebAssembly/binaryen/package.yml
@@ -1,0 +1,55 @@
+# binaryen — WebAssembly compiler infrastructure and toolchain.
+#
+# Provides wasm-opt (the WebAssembly optimizer), wasm-as / wasm-dis,
+# wasm-merge, wasm2js. Required by emscripten at link time to produce
+# optimized .wasm output.
+#
+# Companion to emscripten.org — adding this here unblocks the
+# emscripten pantry recipe (#13065) which needs wasm-opt on PATH.
+
+distributable:
+  url: https://github.com/WebAssembly/binaryen/archive/refs/tags/version_{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: WebAssembly/binaryen
+  strip: /^version_/
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    cmake.org: ^3
+    gnu.org/make: '*'
+    python.org: '*'
+
+  working-directory: build
+  script:
+    - cmake .. $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTS=OFF
+
+provides:
+  - bin/wasm-opt
+  - bin/wasm-as
+  - bin/wasm-dis
+  - bin/wasm-merge
+  - bin/wasm2js
+  - bin/wasm-emscripten-finalize
+  - bin/wasm-ctor-eval
+  - bin/wasm-metadce
+  - bin/wasm-reduce
+  - bin/wasm-shell
+  - bin/wasm-split
+
+test:
+  - wasm-opt --version | grep -i "wasm-opt"


### PR DESCRIPTION
Part of the CNCF coverage + emscripten unblock batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)