### PR TITLE
new(zsync2): delta-update file transfer (used by AppImage)

### DIFF
--- a/projects/github.com/AppImageCommunity/zsync2/package.yml
+++ b/projects/github.com/AppImageCommunity/zsync2/package.yml
@@ -1,0 +1,64 @@
+# zsync2 — modernized rsync-like delta updates over HTTP.
+#
+# Fetches only the differences between a local file and a remote
+# version, using a control file (.zsync). Widely used by AppImage
+# for in-place updates without re-downloading the whole image.
+#
+# This is the C++17 rewrite of the original zsync; same on-the-wire
+# format, modern CMake build, libcurl + openssl + libssh2.
+
+distributable:
+  url: https://github.com/AppImageCommunity/zsync2/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: AppImageCommunity/zsync2
+  # Upstream releases as dated alphas (2.0.0-alpha-1-YYYYMMDD).
+  # Filter to those + transform to a parseable semver.
+  ignore:
+    - /^continuous$/
+  transform: |
+    v => {
+      const m = v.match(/^2\.0\.0-alpha-1-(\d{8})$/);
+      return m ? `2.0.0-alpha.${m[1]}` : undefined;
+    }
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+dependencies:
+  openssl.org: '*'
+  curl.se: '*'
+  libssh2.org: '*'
+  zlib.net: '*'
+  gnupg.org/libgcrypt: '*'
+
+build:
+  dependencies:
+    cmake.org: ^3
+    gnu.org/make: '*'
+    freedesktop.org/pkg-config: '*'
+    git-scm.org: '*'   # CMake submodule init for cpr
+
+  working-directory: build
+  script:
+    - cmake .. $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DUSE_SYSTEM_CURL=1
+      - -DBUILD_CPR_TESTS=0
+
+provides:
+  - bin/zsync2
+  - bin/zsyncmake2
+
+test:
+  - zsync2 -h 2>&1 | head -3 || true
+  - zsyncmake2 -h 2>&1 | head -3 || true

--- a/projects/github.com/AppImageCommunity/zsync2/package.yml
+++ b/projects/github.com/AppImageCommunity/zsync2/package.yml
@@ -55,6 +55,10 @@ build:
       - -DCMAKE_BUILD_TYPE=Release
       - -DUSE_SYSTEM_CURL=1
       - -DBUILD_CPR_TESTS=0
+      # off_t / long long mismatch in zsync.c:950 — modern clang
+      # promotes -Wincompatible-pointer-types from warning to error.
+      - -DCMAKE_C_FLAGS=-Wno-error=incompatible-pointer-types
+      - -DCMAKE_CXX_FLAGS=-Wno-error=incompatible-pointer-types
 
 provides:
   - bin/zsync2

--- a/projects/github.com/AppImageCommunity/zsync2/package.yml
+++ b/projects/github.com/AppImageCommunity/zsync2/package.yml
@@ -24,10 +24,10 @@ versions:
     }
 
 platforms:
+  # zsync2 src uses linux-only POSIX (st_mtim, statvfs) and explicitly
+  # marks openGzFile() as "TODO: implement for this platform" on darwin.
   - linux/x86-64
   - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
 
 dependencies:
   openssl.org: '*'

--- a/projects/github.com/AppImageCommunity/zsync2/package.yml
+++ b/projects/github.com/AppImageCommunity/zsync2/package.yml
@@ -13,14 +13,14 @@ distributable:
 
 versions:
   github: AppImageCommunity/zsync2
-  # Upstream releases as dated alphas (2.0.0-alpha-1-YYYYMMDD).
-  # Filter to those + transform to a parseable semver.
-  ignore:
-    - /^continuous$/
+  # Upstream releases as `2.0.0-alpha-1-YYYYMMDD` tags + a `continuous`
+  # tag. Transform to a semver-compatible string `2.0.0.YYYYMMDD` so
+  # pkgx parses it cleanly.
   transform: |
     v => {
+      if (v === 'continuous') return undefined;
       const m = v.match(/^2\.0\.0-alpha-1-(\d{8})$/);
-      return m ? `2.0.0-alpha.${m[1]}` : undefined;
+      return m ? `2.0.0.${m[1]}` : undefined;
     }
 
 platforms:

--- a/projects/github.com/AppImageCommunity/zsync2/package.yml
+++ b/projects/github.com/AppImageCommunity/zsync2/package.yml
@@ -23,44 +23,28 @@ versions:
       return m ? `2.0.0.${m[1]}` : undefined;
     }
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  # darwin builds via two source patches applied below — see darwin/
-  # script step. Limitation: compressed (.gz) seeds are unsupported on
-  # darwin (fopencookie is glibc-only; we return NULL, which falls back
-  # to fetching all blocks from the server).
-  - darwin/x86-64
-  - darwin/aarch64
-
 dependencies:
-  openssl.org: '*'
-  curl.se: '*'
-  libssh2.org: '*'
-  zlib.net: '*'
-  gnupg.org/libgcrypt: '*'
-  gnupg.org/libgpg-error: '*' # transitive pkg-config dep of libgcrypt
+  openssl.org: "*"
+  curl.se: "*"
+  libssh2.org: "*"
+  zlib.net: "*"
+  gnupg.org/libgcrypt: "*"
+  gnupg.org/libgpg-error: "*" # transitive pkg-config dep of libgcrypt
 
 build:
   dependencies:
     cmake.org: ^3
-    gnu.org/make: '*'
-    freedesktop.org/pkg-config: '*'
-    git-scm.org: '*'   # CMake submodule init for cpr
-
+    git-scm.org: "*" # CMake submodule init for cpr
   working-directory: build
   script:
     # darwin patches: st_mtim is glibc-only (darwin uses st_mtimespec);
     # openGzFile() #errors on non-Linux because fopencookie is glibc-only.
     # Returning NULL on darwin lets zsync fall back to fetching all
     # blocks when the seed is .gz (uncompressed seeds work normally).
-    - run: |
-        sed -i.bak \
-          -e 's|return fstat\.st_mtim\.tv_sec;|return fstat.st_mtimespec.tv_sec;|' \
-          ../src/zsutil.cpp
-        sed -i.bak \
-          -e 's|#error TODO: implement openGzFile() for this platform!|return NULL;|' \
-          ../src/zsclient.cpp
+    - run:
+        - sed -i -e 's|return fstat\.st_mtim\.tv_sec;|return fstat.st_mtimespec.tv_sec;|' zsutil.cpp
+        - "sed -i -e 's|#error TODO: implement openGzFile() for this platform!|return NULL;|' zsclient.cpp"
+      working-directory: ../src
       if: darwin
     - cmake .. $ARGS
     - make --jobs {{ hw.concurrency }}
@@ -81,5 +65,5 @@ provides:
   - bin/zsyncmake2
 
 test:
-  - zsync2 -h 2>&1 | head -3 || true
-  - zsyncmake2 -h 2>&1 | head -3 || true
+  - zsync2 -h
+  - zsyncmake2 -h

--- a/projects/github.com/AppImageCommunity/zsync2/package.yml
+++ b/projects/github.com/AppImageCommunity/zsync2/package.yml
@@ -35,6 +35,7 @@ dependencies:
   libssh2.org: '*'
   zlib.net: '*'
   gnupg.org/libgcrypt: '*'
+  gnupg.org/libgpg-error: '*' # transitive pkg-config dep of libgcrypt
 
 build:
   dependencies:

--- a/projects/github.com/AppImageCommunity/zsync2/package.yml
+++ b/projects/github.com/AppImageCommunity/zsync2/package.yml
@@ -24,10 +24,14 @@ versions:
     }
 
 platforms:
-  # zsync2 src uses linux-only POSIX (st_mtim, statvfs) and explicitly
-  # marks openGzFile() as "TODO: implement for this platform" on darwin.
   - linux/x86-64
   - linux/aarch64
+  # darwin builds via two source patches applied below — see darwin/
+  # script step. Limitation: compressed (.gz) seeds are unsupported on
+  # darwin (fopencookie is glibc-only; we return NULL, which falls back
+  # to fetching all blocks from the server).
+  - darwin/x86-64
+  - darwin/aarch64
 
 dependencies:
   openssl.org: '*'
@@ -46,6 +50,18 @@ build:
 
   working-directory: build
   script:
+    # darwin patches: st_mtim is glibc-only (darwin uses st_mtimespec);
+    # openGzFile() #errors on non-Linux because fopencookie is glibc-only.
+    # Returning NULL on darwin lets zsync fall back to fetching all
+    # blocks when the seed is .gz (uncompressed seeds work normally).
+    - run: |
+        sed -i.bak \
+          -e 's|return fstat\.st_mtim\.tv_sec;|return fstat.st_mtimespec.tv_sec;|' \
+          ../src/zsutil.cpp
+        sed -i.bak \
+          -e 's|#error TODO: implement openGzFile() for this platform!|return NULL;|' \
+          ../src/zsclient.cpp
+      if: darwin
     - cmake .. $ARGS
     - make --jobs {{ hw.concurrency }}
     - make install


### PR DESCRIPTION
C++17 rewrite of the classic zsync. Used by AppImage for in-place updates fetching only the diff between local and remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)