### PR TITLE
new(containerd/nerdctl): Docker-compat CLI for containerd

### DIFF
--- a/projects/github.com/containerd/nerdctl/package.yml
+++ b/projects/github.com/containerd/nerdctl/package.yml
@@ -8,22 +8,20 @@ versions:
   github: containerd/nerdctl/releases
 
 platforms:
-  - linux/x86-64
-  - linux/aarch64
+  - linux
 
 build:
   dependencies:
-    go.dev: '*'
-  script:
-    - go build -o {{prefix}}/bin/nerdctl ./cmd/nerdctl
+    go.dev: "*"
+  script: go build -ldflags="-s -w -X github.com/containerd/nerdctl/v2/pkg/version.Version={{version.tag}}" -o {{prefix}}/bin/nerdctl ./cmd/nerdctl
   skip: fix-patchelf
 
 provides:
   - bin/nerdctl
 
 test:
-  - test -x '{{prefix}}/bin/nerdctl'
   # `nerdctl --version` and `--help` both initialize a containerd
   # client and exit non-zero if no socket is reachable. `nerdctl -v`
   # short-flag prints version then exits cleanly.
-  - "'{{prefix}}/bin/nerdctl' -v 2>&1 | head -1 | grep nerdctl"
+  - ( nerdctl --version 2>&1 || true ) | tee out
+  - grep {{version}} out

--- a/projects/github.com/containerd/nerdctl/package.yml
+++ b/projects/github.com/containerd/nerdctl/package.yml
@@ -22,4 +22,8 @@ provides:
   - bin/nerdctl
 
 test:
-  - nerdctl --version | grep "nerdctl version {{version}}"
+  - test -x '{{prefix}}/bin/nerdctl'
+  # `nerdctl --version` and `--help` both initialize a containerd
+  # client and exit non-zero if no socket is reachable. `nerdctl -v`
+  # short-flag prints version then exits cleanly.
+  - "'{{prefix}}/bin/nerdctl' -v 2>&1 | head -1 | grep nerdctl"

--- a/projects/github.com/containerd/nerdctl/package.yml
+++ b/projects/github.com/containerd/nerdctl/package.yml
@@ -1,0 +1,25 @@
+distributable:
+  url: https://github.com/containerd/nerdctl/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+display-name: nerdctl
+
+versions:
+  github: containerd/nerdctl/releases
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+
+build:
+  dependencies:
+    go.dev: '*'
+  script:
+    - go build -o {{prefix}}/bin/nerdctl ./cmd/nerdctl
+  skip: fix-patchelf
+
+provides:
+  - bin/nerdctl
+
+test:
+  - nerdctl --version | grep "nerdctl version {{version}}"


### PR DESCRIPTION
## Summary

- Adds a recipe for [containerd/nerdctl](https://github.com/containerd/nerdctl), the Docker-compatible CLI for containerd (CNCF graduated project).
- Linux-only (`linux/x86-64`, `linux/aarch64`). nerdctl on macOS would require Lima, which is out of scope here.
- Build is a single `go build ./cmd/nerdctl` against `go.dev: '*'`.
- `build.skip: fix-patchelf` set because Go static binaries have no `.dynamic` section and trip the fix-patchelf pass.

## Test plan

- [ ] `pkgx +containerd.io/nerdctl nerdctl --version` prints `nerdctl version <version>`
- [ ] Bottle builds on `linux/x86-64`
- [ ] Bottle builds on `linux/aarch64`

Generated with [Claude Code](https://claude.com/claude-code)