### PR TITLE
new(opentelemetry-collector): OTEL Collector (CNCF graduated)

### DIFF
--- a/projects/github.com/open-telemetry/opentelemetry-collector/package.yml
+++ b/projects/github.com/open-telemetry/opentelemetry-collector/package.yml
@@ -1,0 +1,44 @@
+# OpenTelemetry Collector — vendor-agnostic telemetry pipeline (CNCF graduated).
+#
+# We build from open-telemetry/opentelemetry-collector-releases (not the
+# library repo of the same name): that's where the user-facing `otelcol`
+# distribution lives. The releases repo uses the OpenTelemetry Collector
+# Builder (OCB) to assemble + compile a binary from a pinned manifest
+# (distributions/otelcol/manifest.yaml), so we install OCB then run it.
+
+distributable:
+  url: https://github.com/open-telemetry/opentelemetry-collector-releases/archive/refs/tags/v{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: open-telemetry/opentelemetry-collector-releases
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    go.dev: '*'
+    gnu.org/coreutils: '*'
+
+  script:
+    - run: |
+        export CGO_ENABLED=0
+        export GOBIN="$PWD/.gobin"
+        mkdir -p "$GOBIN"
+        go install -trimpath -ldflags='-s -w' \
+          go.opentelemetry.io/collector/cmd/builder@v{{ version.raw }}
+        ( cd distributions/otelcol && "$GOBIN/builder" --config manifest.yaml )
+        install -Dm755 distributions/otelcol/_build/otelcol \
+          "{{prefix}}/bin/otelcol"
+
+  skip: fix-patchelf
+
+test:
+  - otelcol --version 2>&1 | grep -q {{ version.raw }}
+
+provides:
+  - bin/otelcol

--- a/projects/github.com/open-telemetry/opentelemetry-collector/package.yml
+++ b/projects/github.com/open-telemetry/opentelemetry-collector/package.yml
@@ -7,7 +7,7 @@
 # (distributions/otelcol/manifest.yaml), so we install OCB then run it.
 
 distributable:
-  url: https://github.com/open-telemetry/opentelemetry-collector-releases/archive/refs/tags/v{{ version.raw }}.tar.gz
+  url: https://github.com/open-telemetry/opentelemetry-collector-releases/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
@@ -16,32 +16,23 @@ versions:
   # version list (one tag per release).
   github: open-telemetry/opentelemetry-collector-releases/tags
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 build:
   dependencies:
-    go.dev: '*'
-    gnu.org/coreutils: '*'
-
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+    GOBIN: "$PWD/.gobin"
   script:
-    - run: |
-        export CGO_ENABLED=0
-        export GOBIN="$PWD/.gobin"
-        mkdir -p "$GOBIN"
-        go install -trimpath -ldflags='-s -w' \
-          go.opentelemetry.io/collector/cmd/builder@v{{ version.raw }}
-        ( cd distributions/otelcol && "$GOBIN/builder" --config manifest.yaml )
-        install -Dm755 distributions/otelcol/_build/otelcol \
-          "{{prefix}}/bin/otelcol"
-
+    - mkdir -p "$GOBIN"
+    - go install -trimpath -ldflags='-s -w' go.opentelemetry.io/collector/cmd/builder@{{ version.tag }}
+    - run: $GOBIN/builder --config manifest.yaml
+      working-directory: distributions/otelcol
+    - install -Dm755 distributions/otelcol/_build/otelcol "{{prefix}}/bin/otelcol"
   skip: fix-patchelf
 
 test:
-  - otelcol --version 2>&1 | grep -q {{ version.raw }}
+  - otelcol --version 2>&1 | tee out
+  - grep {{ version }} out
 
 provides:
   - bin/otelcol

--- a/projects/github.com/open-telemetry/opentelemetry-collector/package.yml
+++ b/projects/github.com/open-telemetry/opentelemetry-collector/package.yml
@@ -11,7 +11,10 @@ distributable:
   strip-components: 1
 
 versions:
-  github: open-telemetry/opentelemetry-collector-releases
+  # /releases endpoint times out (504) — the repo has 700+ releases
+  # across multiple distro tags. /tags is fast and gives us the same
+  # version list (one tag per release).
+  github: open-telemetry/opentelemetry-collector-releases/tags
 
 platforms:
   - linux/x86-64


### PR DESCRIPTION
## Summary
- Adds a pkgx recipe for the OpenTelemetry Collector (`otelcol`), a vendor-agnostic telemetry pipeline and CNCF graduated project.
- Built from `open-telemetry/opentelemetry-collector-releases` (where the user-facing distributions live) using the OpenTelemetry Collector Builder (OCB) against the pinned `distributions/otelcol/manifest.yaml` shipped in each tag.
- Static Go binary (`CGO_ENABLED=0`), `skip: fix-patchelf`, linux + darwin on x86-64/aarch64.

## Test plan
- [ ] `pkgx +github.com/open-telemetry/opentelemetry-collector otelcol --version` prints the expected version
- [ ] Build succeeds on linux/x86-64, linux/aarch64, darwin/x86-64, darwin/aarch64

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)