### PR TITLE
new(notaryproject/notation): OCI artifact signing CLI (CNCF graduated)

### DIFF
--- a/projects/github.com/notaryproject/notation/package.yml
+++ b/projects/github.com/notaryproject/notation/package.yml
@@ -1,0 +1,31 @@
+distributable:
+  url: https://github.com/notaryproject/notation/archive/refs/tags/v{{ version.raw }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: notaryproject/notation/releases
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    go.dev: '*'
+
+  script:
+    - run: |
+        export CGO_ENABLED=0
+        MODULE=github.com/notaryproject/notation
+        LDFLAGS="-s -w -X ${MODULE}/internal/version.Version=v{{ version.raw }} -X ${MODULE}/internal/version.BuildMetadata="
+        go build -trimpath -ldflags "$LDFLAGS" -o "{{prefix}}/bin/notation" ./cmd/notation
+
+  skip: fix-patchelf
+
+test:
+  - notation version 2>&1 | grep -q {{ version.raw }}
+
+provides:
+  - bin/notation

--- a/projects/github.com/notaryproject/notation/package.yml
+++ b/projects/github.com/notaryproject/notation/package.yml
@@ -1,31 +1,26 @@
 distributable:
-  url: https://github.com/notaryproject/notation/archive/refs/tags/v{{ version.raw }}.tar.gz
+  url: https://github.com/notaryproject/notation/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
   github: notaryproject/notation/releases
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 build:
   dependencies:
-    go.dev: '*'
-
-  script:
-    - run: |
-        export CGO_ENABLED=0
-        MODULE=github.com/notaryproject/notation
-        LDFLAGS="-s -w -X ${MODULE}/internal/version.Version=v{{ version.raw }} -X ${MODULE}/internal/version.BuildMetadata="
-        go build -trimpath -ldflags "$LDFLAGS" -o "{{prefix}}/bin/notation" ./cmd/notation
-
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/notaryproject/notation/internal/version.Version={{ version.tag }}
+      - -X github.com/notaryproject/notation/internal/version.BuildMetadata=pkgx
+  script: go build -trimpath -ldflags "$GO_LDFLAGS" -o "{{prefix}}/bin/notation" ./cmd/notation
   skip: fix-patchelf
 
 test:
-  - notation version 2>&1 | grep -q {{ version.raw }}
+  - notation version 2>&1 | tee out
+  - grep {{ version.tag }} out
 
 provides:
   - bin/notation


### PR DESCRIPTION
## Summary

- Adds a new pantry recipe for [`notaryproject/notation`](https://github.com/notaryproject/notation) at `projects/github.com/notaryproject/notation/package.yml`.
- Notation is the CNCF-graduated CLI from the Notary Project (Notary v2) for signing and verifying OCI artifacts (container images, Helm charts, etc.).
- Single Go binary built from `./cmd/notation`. Version stamping wired through `internal/version.Version` / `BuildMetadata` per the upstream Makefile, with `BuildMetadata` cleared for tagged builds to match upstream's release-build behavior.
- `build.skip: fix-patchelf` per the standard Go-CLI pattern for relocatable bottles.
- Covers linux + darwin on x86-64 and aarch64.

## Test plan

- [ ] `pkgx +github.com/notaryproject/notation@1.3.2 notation version` on linux/x86-64
- [ ] `pkgx +github.com/notaryproject/notation@1.3.2 notation version` on linux/aarch64
- [ ] `pkgx +github.com/notaryproject/notation@1.3.2 notation version` on darwin/x86-64
- [ ] `pkgx +github.com/notaryproject/notation@1.3.2 notation version` on darwin/aarch64

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>