### PR TITLE
new(knative/client): kn CLI for Knative serverless (CNCF incubating)

### DIFF
--- a/projects/github.com/knative/client/package.yml
+++ b/projects/github.com/knative/client/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/knative/client/archive/refs/tags/knative-v{{version}}.tar.gz
+  url: https://github.com/knative/client/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 display-name: kn
@@ -28,6 +28,6 @@ provides:
   - bin/kn
 
 test:
-  - '{{prefix}}/bin/kn version | tee out.log'
+  - kn version | tee out.log
   - grep "Version:" out.log
   - grep "v{{version}}" out.log

--- a/projects/github.com/knative/client/package.yml
+++ b/projects/github.com/knative/client/package.yml
@@ -1,0 +1,33 @@
+distributable:
+  url: https://github.com/knative/client/archive/refs/tags/knative-v{{version}}.tar.gz
+  strip-components: 1
+
+display-name: kn
+
+versions:
+  github: knative/client/releases
+  strip: /^knative-v/
+
+build:
+  dependencies:
+    go.dev: '*'
+  env:
+    CGO_ENABLED: '0'
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -X knative.dev/client/pkg/commands/version.Version=v{{version}}
+    linux:
+      GO_LDFLAGS:
+        - -buildmode=pie
+  script:
+    - go build -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/kn ./cmd/kn
+  skip: fix-patchelf
+
+provides:
+  - bin/kn
+
+test:
+  - '{{prefix}}/bin/kn version | tee out.log'
+  - grep "Version:" out.log
+  - grep "v{{version}}" out.log


### PR DESCRIPTION
## Summary
- Adds a new pkgx pantry recipe for [`knative/client`](https://github.com/knative/client) — the `kn` CLI for [Knative](https://knative.dev/), a CNCF incubating project for serverless workloads on Kubernetes.
- Builds the single Go binary `kn` from `./cmd/kn`, injecting `version.Version` via ldflags so `kn version` reports the pantry-resolved version.
- Versions are tracked via GitHub releases with `strip: /^knative-v/` since upstream tags use the `knative-vX.Y.Z` prefix; the source tarball URL is constructed accordingly.

Recipe lives at `projects/github.com/knative/client/package.yml` and follows the standard Go CLI pattern (compare with `projects/projectdiscovery.io/nuclei`, `projects/cloudnative-pg.io`, `projects/hetzner.com/hcloud`):
- `build.dependencies: go.dev: '*'`
- `CGO_ENABLED=0`, `-s -w` ldflags, plus `-buildmode=pie` on linux
- `build.skip: fix-patchelf`
- `provides: [bin/kn]`
- All four supported platforms (linux/darwin x x86-64/aarch64) — no `platforms:` restriction.

## Test plan
- [ ] `pkgx build github.com/knative/client` succeeds on linux/x86-64
- [ ] `pkgx build github.com/knative/client` succeeds on darwin/aarch64
- [ ] `kn version` prints `Version:      vX.Y.Z` matching the resolved version
- [ ] Version auto-discovery picks up new `knative-vX.Y.Z` releases and exposes them as `X.Y.Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)