### PR TITLE
fix(gnu.org/gcc): bottle the libc via --with-sysroot (addresses #8423)

### DIFF
--- a/projects/gnu.org/gcc/package.yml
+++ b/projects/gnu.org/gcc/package.yml
@@ -31,7 +31,13 @@ dependencies:
     # finds stdlib.h + crt*.o + libc.so.6 from the pkgx-integrated bottle
     # without needing host glibc-devel / libc6-dev. See #8423.
     # gcc's spec file embeds these paths via --with-sysroot below.
-    gnu.org/glibc: "*"
+    #
+    # Pin <2.38: glibc 2.38 introduced C23 symbol redirects
+    # (__isoc23_strtoul, __isoc23_*scanf, …) that the runner's older
+    # glibc lacks, so native gcc's own fixincl.c link fails with
+    # `undefined reference to __isoc23_strtoul`. Cross-builds were
+    # unaffected because they link against the sysroot's libc directly.
+    gnu.org/glibc: "<2.38"
     kernel.org/linux-headers: "*"
   darwin/x86-64: # since 15.1.0
     libisl.sourceforge.io: ^0

--- a/projects/gnu.org/gcc/package.yml
+++ b/projects/gnu.org/gcc/package.yml
@@ -210,14 +210,16 @@ build:
     linux:
       ARGS:
         - --disable-multilib
-        # Point gcc at the bottled glibc so its spec file embeds the
-        # search paths — end users don't need host glibc-devel and
-        # the build of gcc itself links against the same libc whose
-        # headers it includes (no __isoc23_strtoul-style mismatches).
+        # Install-time sysroot only: the built gcc embeds pkgx glibc
+        # paths so end-user `pkgx gcc test.c` finds stdlib.h + crt*.o.
+        # --with-build-sysroot is intentionally NOT set: configure
+        # tests need to run compiled programs at build time, which
+        # requires the host's dynamic linker (sysroot's ld-linux is
+        # at /opt/.../glibc/v.../lib not /lib so an embedded /lib/
+        # interp path won't resolve).
         - --with-sysroot={{deps.gnu.org/glibc.prefix}}
-        - --with-build-sysroot={{deps.gnu.org/glibc.prefix}}
         - --with-native-system-header-dir=/include
-        - --with-glibc-version=2.43
+        - --with-glibc-version=2.34
     linux/x86-64:
       LDFLAGS:
         - -pie

--- a/projects/gnu.org/gcc/package.yml
+++ b/projects/gnu.org/gcc/package.yml
@@ -26,6 +26,13 @@ dependencies:
   gnu.org/mpfr: ">=2.4.0"
   gnu.org/mpc: ">=0.8.0"
   zlib.net: ^1.3
+  linux:
+    # Bottle the libc the compiler targets so end-user `pkgx gcc test.c`
+    # finds stdlib.h + crt*.o + libc.so.6 from the pkgx-integrated bottle
+    # without needing host glibc-devel / libc6-dev. See #8423.
+    # gcc's spec file embeds these paths via --with-sysroot below.
+    gnu.org/glibc: "*"
+    kernel.org/linux-headers: "*"
   darwin/x86-64: # since 15.1.0
     libisl.sourceforge.io: ^0
 
@@ -197,6 +204,14 @@ build:
     linux:
       ARGS:
         - --disable-multilib
+        # Point gcc at the bottled glibc so its spec file embeds the
+        # search paths — end users don't need host glibc-devel and
+        # the build of gcc itself links against the same libc whose
+        # headers it includes (no __isoc23_strtoul-style mismatches).
+        - --with-sysroot={{deps.gnu.org/glibc.prefix}}
+        - --with-build-sysroot={{deps.gnu.org/glibc.prefix}}
+        - --with-native-system-header-dir=/include
+        - --with-glibc-version=2.43
     linux/x86-64:
       LDFLAGS:
         - -pie


### PR DESCRIPTION
## Summary
- Adds `gnu.org/glibc` + `kernel.org/linux-headers` as Linux runtime deps
- Configures gcc with `--with-sysroot={{deps.gnu.org/glibc.prefix}}`, `--with-build-sysroot=...`, `--with-native-system-header-dir=/include`, `--with-glibc-version=2.43`
- Result: gcc's spec file embeds the bottled-glibc paths; end-user `pkgx gcc test.c` finds `stdlib.h` + `crt*.o` + `libc.so.6` from the pkgx-integrated bottle, no host `glibc-devel` / `libc6-dev` needed (Fedora repro in #8423).

## Why this approach (vs #13084's first attempt)
- #13084 added glibc as a dep + a `runtime.env` exporting `CPATH`/`LIBRARY_PATH`. That:
  - clobbered brewkit's composed CPATH during gcc's own build → `gmp.h` not found at configure
  - and (in a later iteration) caused fixincl.c to link-fail with `undefined reference to __isoc23_strtoul` (compile saw bottled glibc 2.43 headers, link saw host glibc ~2.35).
- This PR uses gcc's own `--with-sysroot` mechanism instead — same libc backs both compile AND link, no env-var override.

## Pairs with
- #13083 (multi-arch triplet symlinks) — together fully close #8423.

## Test plan
- [ ] CI builds gcc on linux/x86-64 + linux/aarch64
- [ ] Verify `pkgx gcc -print-sysroot` returns the bottled glibc path
- [ ] Manual: on a stock Fedora without `glibc-devel`, `pkgx gcc test.c -o test` succeeds
- [ ] Darwin builds unchanged (sysroot args are linux-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)