### PR TITLE
feat(github.com/lima-vm/socket_vmnet): new package

### DIFF
--- a/projects/github.com/lima-vm/socket_vmnet/package.yml
+++ b/projects/github.com/lima-vm/socket_vmnet/package.yml
@@ -1,0 +1,34 @@
+distributable:
+  url: https://github.com/lima-vm/socket_vmnet/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: lima-vm/socket_vmnet
+
+platforms: [darwin]
+
+provides:
+  - bin/socket_vmnet
+  - bin/socket_vmnet_client
+
+build:
+  # The Makefile derives VERSION from `git describe`, which fails on a tarball
+  # (no .git/). We pass VERSION=v{{version}} explicitly so the build is
+  # reproducible and the binary embeds the right version string.
+  # ARCH is required to pick the right -arch flag and target triple.
+  script:
+    - make all VERSION=v{{version}} ARCH=$ARCH
+    - make install.bin PREFIX={{prefix}} VERSION=v{{version}} ARCH=$ARCH
+  env:
+    aarch64:
+      ARCH: arm64
+    x86-64:
+      ARCH: x86_64
+
+test:
+  # socket_vmnet's runtime path needs root (vmnet.framework) and a working
+  # macOS host bridge, neither available in the test sandbox, so we only
+  # validate the build artefacts. Full paths to avoid brewkit's "is not an
+  # explicit dependency" sandbox auto-fetch.
+  - test -x {{prefix}}/bin/socket_vmnet
+  - test -x {{prefix}}/bin/socket_vmnet_client


### PR DESCRIPTION
## Summary

Adds the `github.com/lima-vm/socket_vmnet` recipe.

`socket_vmnet` is a small C daemon that wraps Apple's `vmnet.framework` and exposes it over a Unix domain socket, so QEMU (and other VMs via FD passing) can use vmnet without themselves running as root. It is the network backbone of Lima's `shared` network and a key piece for Tart↔Lima VM coexistence on macOS Sequoia/Tahoe (where vmnet's bridge `PRIVATE` flag breaks VM↔VM at L2 inside the host).

Upstream: https://github.com/lima-vm/socket_vmnet

## Build notes

- The Makefile derives `VERSION` from `git describe`, which fails inside a release tarball (no `.git/`). The recipe passes `VERSION=v{{version}}` explicitly so the build is reproducible and the binary embeds the right version string.
- `ARCH` is required for the right `-arch` flag and target triple — set per pkgx arch (`arm64` / `x86_64`).
- macOS-only (`platforms: [darwin]`) — `vmnet.framework` is Apple-specific.

## Test plan

Sandbox can't exercise the daemon (vmnet.framework needs root and a working host bridge), so the test only validates the build artefacts:

```yaml
test:
  - test -x {{prefix}}/bin/socket_vmnet
  - test -x {{prefix}}/bin/socket_vmnet_client
```

This catches build failures, arch mismatches, and `install.bin` regressions, which is the dominant failure mode for this kind of small C project.

Real-world validation: I've been running this same `socket_vmnet` source for the last several weeks (1.2.2) as part of a [Tart↔Lima hybrid lab](https://github.com/tannevaled/socket-vmnet-shim) on macOS Tahoe 26.5, Apple Silicon — 3 Tart VMs + 3 Lima VMs on the same `192.168.105.0/24` daemon, full-mesh ping at 0% loss.