### PR TITLE
fix(obscura): hermetic file:// test (closes #13095)

### DIFF
--- a/projects/github.com/h4ckf0r0day/obscura/package.yml
+++ b/projects/github.com/h4ckf0r0day/obscura/package.yml
@@ -25,10 +25,10 @@ test:
   # Switch to a hermetic check: feed obscura a `file://` URL pointing
   # at a fixture we generate in the test step. Still exercises the
   # URL-fetch + `--eval` JS execution paths, no network required.
-  - run: |
-      cat > test.html <<'HTML'
-      <!doctype html><html><head><title>pkgx-test</title></head>
-      <body><h1 id="msg">hello from obscura</h1></body></html>
-      HTML
-      out=$(obscura fetch "file://$(pwd)/test.html" --eval 'document.title')
-      echo "$out" | grep -q pkgx-test
+  - run: out=$(obscura fetch "file://$FIXTURE" --eval 'document.title')
+    fixture:
+      extname: html
+      content: |
+        <!doctype html><html><head><title>pkgx-test</title></head>
+        <body><h1 id="msg">hello from obscura</h1></body></html>
+  - echo "$out" | grep -q pkgx-test

--- a/projects/github.com/h4ckf0r0day/obscura/package.yml
+++ b/projects/github.com/h4ckf0r0day/obscura/package.yml
@@ -16,5 +16,19 @@ build:
   script: cargo install --locked --root {{prefix}} --path crates/obscura-cli --bin obscura --bin obscura-worker
 
 test:
-  - obscura fetch https://pkgx.dev/ --eval document.title | tee out
-  - grep -i pkgx out
+  # The previous test invoked `obscura fetch https://pkgx.dev/` —
+  # which depends on outbound network from the CI sandbox. Several
+  # of the linux test images (ubuntu / debian:buster-slim) either
+  # block egress or briefly couldn't reach pkgx.dev, firing #13095
+  # with "Network error: Failed to navigate to https://pkgx.dev/".
+  #
+  # Switch to a hermetic check: feed obscura a `file://` URL pointing
+  # at a fixture we generate in the test step. Still exercises the
+  # URL-fetch + `--eval` JS execution paths, no network required.
+  - run: |
+      cat > test.html <<'HTML'
+      <!doctype html><html><head><title>pkgx-test</title></head>
+      <body><h1 id="msg">hello from obscura</h1></body></html>
+      HTML
+      out=$(obscura fetch "file://$(pwd)/test.html" --eval 'document.title')
+      echo "$out" | grep -q pkgx-test


### PR DESCRIPTION
## Summary

The current test calls `obscura fetch https://pkgx.dev/` which depends on outbound network from each linux test-distro container. The ubuntu test image either blocks egress or hit a transient pkgx.dev outage; the failure
> Network error: Failed to navigate to https://pkgx.dev/

has been auto-firing #13095 on every retry.

Generate a tiny HTML fixture in the test step and feed obscura a `file://` URL pointing at it. Still exercises the URL-fetch + `document.title` `--eval` JS path; no network needed.

Closes #13095.

## Test plan

- [ ] CI green on `*nix64` / `*nix·ARM64` / `²` / `x64`
- [ ] Verify all four test-distro variants now pass (ubuntu / archlinux:base / debian:buster-slim were cancelled-or-failed before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)