### PR TITLE
fix(mysql): pin build gcc ^14 to match runtime libstdcxx

### DIFF
--- a/projects/mysql.com/package.yml
+++ b/projects/mysql.com/package.yml
@@ -22,8 +22,19 @@ dependencies:
   developers.yubico.com/libfido2: ^1
   linux:
     # llvm cannot find #include <bit>
-    # use our libstdc++ instead
-    gnu.org/gcc/libstdcxx: 14
+    # use our libstdc++ instead.
+    #
+    # IMPORTANT: keep this in sync with the build-time `gnu.org/gcc`
+    # version below — if build uses gcc 16 but runtime ships libstdcxx
+    # 14, mysqld ends up referencing GLIBCXX_3.4.35 symbols (gcc 16
+    # only) that the runtime libstdc++.so.6 (gcc 14) doesn't expose,
+    # and `mysqld --no-defaults --help` at install-test time fails
+    # with `version 'GLIBCXX_3.4.35' not found (required by mysqld)`.
+    # nixpkgs solves this structurally via cc-wrapper auto-propagating
+    # stdenv.cc.cc.lib into RUNPATH; arch via lockstep rebuild of
+    # gcc-libs with every gcc bump. We don't have either, so the two
+    # version constraints must literally match.
+    gnu.org/gcc/libstdcxx: ^14
 
 build:
   dependencies:
@@ -31,8 +42,10 @@ build:
     gnu.org/bison: ">=3.0.4"
     linux:
       # llvm cannot find #include <bit>
-      # use our libstdc++ instead
-      gnu.org/gcc: "*"
+      # use our libstdc++ instead.
+      # Pin to the same major as runtime libstdcxx above so the
+      # binary's GLIBCXX_3.4.x symver references resolve at runtime.
+      gnu.org/gcc: ^14
   working-directory: build
   script:
     # https://www.mail-archive.com/ports@freebsd.org/msg00418.html


### PR DESCRIPTION
## Summary

Runtime dep declares `gnu.org/gcc/libstdcxx: 14` but build dep is `gnu.org/gcc: '*'`, which resolves to 16.1.0 in CI. mysqld then compiles against gcc 16's libstdc++ headers — the resulting binary references `GLIBCXX_3.4.35` symver entries. At install-test time the runtime libstdc++.so.6 (gcc 14) doesn't expose 3.4.35 (introduced in gcc 16), and `mysqld --no-defaults --help` dies with
> version `GLIBCXX_3.4.35' not found (required by mysqld)

Pantry doesn't yet ship libstdcxx bottles for 15.x or 16.x (only ≤14.3.0). So pin the *build* gcc to `^14` instead, matching the runtime libstdcxx.

## Structural note

nixpkgs solves this via cc-wrapper auto-propagating `stdenv.cc.cc.lib` into RUNPATH; arch via lockstep `gcc-libs` rebuild on every gcc bump. We have neither. The right pantry fix long-term is either bottling libstdcxx 16 alongside gcc 16, or auto-emitting `runtime.dependencies.gnu.org/gcc/libstdcxx` matching whichever gcc compiled the recipe. Until then, manual match.

This is the same wall my mysql URL fix (#13100) hit on the ARM check — that PR got the build past the URL stage; this one gets it past the install-time linker check. Both are needed.

## Test plan

- [ ] CI green on `*nix64` / `*nix·ARM64` / `²` / `x64`
- [ ] mysqld smoke-test (`mysqld --no-defaults --help`) succeeds in the install phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)