### PR TITLE
new(x.org/font-util): X.Org font-util (autotools, prereq for xserver)

### DIFF
--- a/projects/x.org/font-util/package.yml
+++ b/projects/x.org/font-util/package.yml
@@ -1,0 +1,51 @@
+# X.Org font-util — small helper for X11 font packages.
+#
+# Provides:
+#   - bdftruncate, ucs2any (BDF font format converter shell scripts)
+#   - fontutil.pc (pkg-config exporting `fontrootdir` etc., consumed
+#     by `xserver`'s meson.build to compute the default FontPath)
+#   - util/fontutil.m4 (autotools macros used by sibling x.org/font-*
+#     packages — none in pantry yet, but expected)
+#
+# NOT the source of `mkfontscale`/`mkfontdir` — those live in the
+# separate upstream `mkfontscale` package (not yet in pantry).
+#
+# Same role as arch's `xorg-font-util`, debian's `xfonts-utils`,
+# nixpkgs `xorg.fontutil`. Tiny — autotools-based, two shell scripts
+# + pkgconfig + m4 macros.
+
+distributable:
+  url: https://www.x.org/releases/individual/font/font-util-{{version}}.tar.xz
+  strip-components: 1
+
+versions:
+  url: https://www.x.org/releases/individual/font/
+  match: /font-util-\d+\.\d+\.\d+\.tar\.xz/
+  strip:
+    - /^font-util-/
+    - /\.tar\.xz$/
+
+display-name: X.Org font-util
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+    freedesktop.org/pkg-config: '*'
+    x.org/util-macros: '*'
+  script:
+    - ./configure --prefix={{prefix}}
+    - make --jobs {{ hw.concurrency }}
+    - make install
+
+provides:
+  - bin/bdftruncate
+  - bin/ucs2any
+
+test:
+  # Accept either $libdir/pkgconfig (autotools default) or
+  # $datarootdir/pkgconfig (some distros relocate); font-util's own
+  # `make install` writes to lib/pkgconfig on most builds.
+  - test -f "{{prefix}}/lib/pkgconfig/fontutil.pc" -o -f "{{prefix}}/share/pkgconfig/fontutil.pc"
+  - test -f "{{prefix}}/share/util-macros/fontutil.m4" -o -f "{{prefix}}/share/aclocal/fontutil.m4"
+  # Smoke-test the BDF scripts at least load:
+  - bdftruncate --help 2>&1 | head -1 || ucs2any --help 2>&1 | head -1 || true

--- a/projects/x.org/font-util/package.yml
+++ b/projects/x.org/font-util/package.yml
@@ -29,9 +29,7 @@ display-name: X.Org font-util
 
 build:
   dependencies:
-    gnu.org/make: '*'
-    freedesktop.org/pkg-config: '*'
-    x.org/util-macros: '*'
+    x.org/util-macros: "*"
   script:
     - ./configure --prefix={{prefix}}
     - make --jobs {{ hw.concurrency }}
@@ -42,10 +40,13 @@ provides:
   - bin/ucs2any
 
 test:
-  # Accept either $libdir/pkgconfig (autotools default) or
-  # $datarootdir/pkgconfig (some distros relocate); font-util's own
-  # `make install` writes to lib/pkgconfig on most builds.
-  - test -f "{{prefix}}/lib/pkgconfig/fontutil.pc" -o -f "{{prefix}}/share/pkgconfig/fontutil.pc"
-  - test -f "{{prefix}}/share/util-macros/fontutil.m4" -o -f "{{prefix}}/share/aclocal/fontutil.m4"
-  # Smoke-test the BDF scripts at least load:
-  - bdftruncate --help 2>&1 | head -1 || ucs2any --help 2>&1 | head -1 || true
+  dependencies:
+    freedesktop.org/pkg-config: "*"
+  script:
+    # Accept either $libdir/pkgconfig (autotools default) or
+    # $datarootdir/pkgconfig (some distros relocate); font-util's own
+    # `make install` writes to lib/pkgconfig on most builds.
+    - pkg-config --cflags --libs fontutil
+    # Smoke-test the BDF scripts at least load:
+    - test "$(bdftruncate --version)" = "font-util {{version}}"
+    - test "$(ucs2any --version)" = "font-util {{version}}"


### PR DESCRIPTION
## Summary

Tiny new recipe for X.Org's `font-util` — provides:
- `fontutil.pc` pkg-config file (consumed by `xserver`'s `meson.build` for the default FontPath computation)
- `fontutil.m4` autotools macros (used by sibling `x.org/font-*` packages — none in pantry yet, expected)
- `bdftruncate` + `ucs2any` BDF-format converter shell scripts

Same role as arch's `xorg-font-util`, debian's `xfonts-utils`, nixpkgs' `xorg.fontutil`.

## Extracted from #13103

#13103 added both `x.org/xserver` and `x.org/font-util` in one PR. xserver depends on font-util, but pantry's CI resolver can't satisfy a same-PR sibling dep — xserver's resolve step 404s on `dist.pkgx.dev/x.org/font-util/linux/x86-64/versions.txt` because the bottle hasn't been published. font-util needs to merge + bottle first; once it does, #13103 (which keeps the xserver recipe + the same font-util content) will resolve correctly on the next CI iteration.

CI on the combined #13103 already validated this recipe builds green on `linux/x86-64` + `linux/aarch64`.

## Test plan

- [x] Combined-PR CI green for this recipe (verified on #13103)
- [ ] Standalone PR re-validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)