### PR TITLE
new(nvitop.io): interactive NVIDIA-GPU process viewer (closes #6879)

### DIFF
--- a/projects/nvitop.io/package.yml
+++ b/projects/nvitop.io/package.yml
@@ -1,0 +1,39 @@
+# nvitop — interactive NVIDIA-GPU process viewer.
+#
+# Curses-style top-like UI over the NVIDIA Management Library
+# (NVML). Pure-Python (no compiled bits); installs cleanly into a
+# python venv. ~7k stars upstream, frequently asked for —
+# closes pkgxdev/pantry#6879.
+#
+# Linux + darwin both supported by the package itself. nvitop will
+# print "No NVIDIA driver detected" on hosts without GPUs, which
+# is the expected behaviour; we don't try to gate on driver presence.
+
+distributable:
+  url: https://github.com/XuehaiPan/nvitop/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: XuehaiPan/nvitop
+
+dependencies:
+  python.org: '>=3.8'
+
+build:
+  dependencies:
+    python.org: '>=3.8'
+  script:
+    - bkpyvenv stage {{prefix}} {{version}}
+    - ${{prefix}}/venv/bin/pip install .
+    - bkpyvenv seal {{prefix}} nvitop
+
+provides:
+  - bin/nvitop
+
+test:
+  # `nvitop --version` works without an NVIDIA driver present — it
+  # short-circuits before touching libnvidia-ml. `--help` is the
+  # same way. The CI sandbox has no GPU, so the interactive UI can't
+  # actually be tested here.
+  - nvitop --version 2>&1 | head -1
+  - nvitop --version 2>&1 | grep -i "{{version}}"

--- a/projects/nvitop.io/package.yml
+++ b/projects/nvitop.io/package.yml
@@ -10,7 +10,7 @@
 # is the expected behaviour; we don't try to gate on driver presence.
 
 distributable:
-  url: https://github.com/XuehaiPan/nvitop/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/XuehaiPan/nvitop/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
@@ -20,12 +20,9 @@ dependencies:
   python.org: '>=3.8'
 
 build:
-  dependencies:
-    python.org: '>=3.8'
-  script:
-    - bkpyvenv stage {{prefix}} {{version}}
-    - ${{prefix}}/venv/bin/pip install .
-    - bkpyvenv seal {{prefix}} nvitop
+  - bkpyvenv stage {{prefix}} {{version}}
+  - ${{prefix}}/venv/bin/pip install .
+  - bkpyvenv seal {{prefix}} nvitop
 
 provides:
   - bin/nvitop
@@ -35,5 +32,5 @@ test:
   # short-circuits before touching libnvidia-ml. `--help` is the
   # same way. The CI sandbox has no GPU, so the interactive UI can't
   # actually be tested here.
-  - nvitop --version 2>&1 | head -1
-  - nvitop --version 2>&1 | grep -i "{{version}}"
+  - nvitop --version
+  - nvitop --version 2>&1 | grep "{{version}}"


### PR DESCRIPTION
## Summary

Closes #6879. New recipe for [nvitop](https://github.com/XuehaiPan/nvitop) — curses-style top-like UI over NVIDIA's NVML. Pure-Python, ~7k stars, Apache-2.0.

Uses brewkit's `bkpyvenv stage/seal` pattern (same shape as streamlink / ipython / s3tools / hatch). Produces a self-contained venv with `bin/nvitop`.

On hosts without an NVIDIA driver the binary still prints \`--version\` and exits cleanly, so CI testing works fine on GPU-less runners.

## Test plan

- [x] `nvitop --version` prints the upstream version string (CI-checkable)
- [ ] CI green on `*nix64` / `*nix·ARM64` / `²` / `x64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)