### PR TITLE
new(librsync.github.io): rdiff + librsync (rsync remote-delta algorithm)

### DIFF
--- a/projects/librsync.github.io/package.yml
+++ b/projects/librsync.github.io/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/librsync/librsync/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/librsync/librsync/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 # Library that implements the rsync remote-delta algorithm (signature / delta /
@@ -7,8 +7,6 @@ distributable:
 
 versions:
   github: librsync/librsync/tags
-  strip:
-    - /^v/
 
 dependencies:
   rpm.org/popt: ^1
@@ -33,15 +31,14 @@ provides:
   - bin/rdiff
 
 test:
-  env:
-    RDIFF: "{{prefix}}/bin/rdiff"
   script:
-    - $RDIFF -V | grep -F {{version}}
+    - rdiff -V | tee out
+    - grep -F {{version}} out
     # round-trip: signature -> delta -> patch
     - head -c 65536 /dev/urandom > basis.bin
     - cp basis.bin new.bin
     - printf 'edit' >> new.bin
-    - $RDIFF signature basis.bin basis.sig
-    - $RDIFF delta basis.sig new.bin new.delta
-    - $RDIFF patch basis.bin new.delta out.bin
+    - rdiff signature basis.bin basis.sig
+    - rdiff delta basis.sig new.bin new.delta
+    - rdiff patch basis.bin new.delta out.bin
     - cmp new.bin out.bin

--- a/projects/librsync.github.io/package.yml
+++ b/projects/librsync.github.io/package.yml
@@ -1,0 +1,47 @@
+distributable:
+  url: https://github.com/librsync/librsync/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+# Library that implements the rsync remote-delta algorithm (signature / delta /
+# patch). Ships the `rdiff` CLI used as the reference for librsync interop.
+
+versions:
+  github: librsync/librsync/tags
+  strip:
+    - /^v/
+
+dependencies:
+  rpm.org/popt: ^1
+
+build:
+  dependencies:
+    cmake.org: ^3
+    ninja-build.org: ^1
+  script:
+    - cmake -S . -B build $ARGS
+    - cmake --build build --parallel {{ hw.concurrency }}
+    - cmake --install build
+  env:
+    ARGS:
+      - -GNinja
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+      - -DBUILD_RDIFF=ON
+      - -DENABLE_TESTS=OFF
+
+provides:
+  - bin/rdiff
+
+test:
+  env:
+    RDIFF: "{{prefix}}/bin/rdiff"
+  script:
+    - $RDIFF -V | grep -F {{version}}
+    # round-trip: signature -> delta -> patch
+    - head -c 65536 /dev/urandom > basis.bin
+    - cp basis.bin new.bin
+    - printf 'edit' >> new.bin
+    - $RDIFF signature basis.bin basis.sig
+    - $RDIFF delta basis.sig new.bin new.delta
+    - $RDIFF patch basis.bin new.delta out.bin
+    - cmp new.bin out.bin


### PR DESCRIPTION
Adds [librsync](https://librsync.github.io/), the LGPL-2.1+ library that implements the rsync rolling-checksum delta algorithm (signature / delta / patch). Ships the \`rdiff\` reference CLI, which is the canonical interop target for any rsync-style delta tooling.

CMake build; runtime dep \`rpm.org/popt\` for CLI option parsing.

Built and tested locally (darwin/aarch64); the test round-trips a 64 KiB random basis through \`rdiff signature\` → \`rdiff delta\` → \`rdiff patch\` and \`cmp\`s the result.

Refs: [librsync/librsync](https://github.com/librsync/librsync) @ v2.3.4, homebrew/librsync.