### PR TITLE
new(ziglang.org/zls): Zig Language Server (source build)

### DIFF
--- a/projects/ziglang.org/zls/package.yml
+++ b/projects/ziglang.org/zls/package.yml
@@ -1,0 +1,49 @@
+# zls — Zig Language Server
+#
+# Built from source via `zig build install` using pantry's existing
+# `ziglang.org` bottle as a build dependency. (The parent `ziglang.org`
+# recipe vendors prebuilt zig binaries as a chicken-and-egg exception;
+# downstream Zig tooling like zls is built from source.)
+#
+# Version pin: zls master tracks unreleased zig master. We ignore the
+# 0.16.x line because zls 0.16 requires zig 0.16, which upstream has
+# not released yet (pantry's ziglang.org bottle is 0.15.2). Re-evaluate
+# when zig 0.16 ships.
+
+distributable:
+  url: https://github.com/zigtools/zls/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: zigtools/zls
+  ignore:
+    - /^0\.16/  # requires unreleased zig 0.16
+
+platforms:
+  - darwin
+  - linux/x86-64
+  - linux/aarch64
+
+build:
+  dependencies:
+    ziglang.org: '~0.15.1'  # zls 0.15.x minimum_zig_version
+  # zig produces statically-linked binaries; skip the patchelf step
+  # (same rationale as the ziglang.org parent recipe).
+  skip: fix-patchelf
+  script:
+    # Keep zig's caches inside the build tree so the build is hermetic
+    # and we don't touch $HOME. zig's package manager will fetch
+    # zls's declared dependencies (known-folders, diffz, lsp-kit)
+    # over the network during `zig build`.
+    - run: |
+        zig build install \
+          --prefix "{{prefix}}" \
+          -Doptimize=ReleaseSafe \
+          --global-cache-dir "$PWD/.zig-global-cache" \
+          --cache-dir "$PWD/.zig-build-cache"
+
+provides:
+  - bin/zls
+
+test:
+  - zls --version | grep -F '{{version}}'

--- a/projects/ziglang.org/zls/package.yml
+++ b/projects/ziglang.org/zls/package.yml
@@ -17,33 +17,29 @@ distributable:
 versions:
   github: zigtools/zls
   ignore:
-    - /^0\.16/  # requires unreleased zig 0.16
-
-platforms:
-  - darwin
-  - linux/x86-64
-  - linux/aarch64
+    - /^0\.16/ # requires unreleased zig 0.16
 
 build:
   dependencies:
-    ziglang.org: '~0.15.1'  # zls 0.15.x minimum_zig_version
+    ziglang.org: "~0.15.1" # zls 0.15.x minimum_zig_version
   # zig produces statically-linked binaries; skip the patchelf step
   # (same rationale as the ziglang.org parent recipe).
   skip: fix-patchelf
-  script:
-    # Keep zig's caches inside the build tree so the build is hermetic
-    # and we don't touch $HOME. zig's package manager will fetch
-    # zls's declared dependencies (known-folders, diffz, lsp-kit)
-    # over the network during `zig build`.
-    - run: |
-        zig build install \
-          --prefix "{{prefix}}" \
-          -Doptimize=ReleaseSafe \
-          --global-cache-dir "$PWD/.zig-global-cache" \
-          --cache-dir "$PWD/.zig-build-cache"
+  # Keep zig's caches inside the build tree so the build is hermetic
+  # and we don't touch $HOME. zig's package manager will fetch
+  # zls's declared dependencies (known-folders, diffz, lsp-kit)
+  # over the network during `zig build`.
+  script: zig build install $BUILD_OPTS
+  env:
+    BUILD_OPTS:
+      - --prefix "{{prefix}}"
+      - -Doptimize=ReleaseSafe
+      - --global-cache-dir "$PWD/.zig-global-cache"
+      - --cache-dir "$PWD/.zig-build-cache"
 
 provides:
   - bin/zls
 
 test:
-  - zls --version | grep -F '{{version}}'
+  - zls --version | tee out
+  - grep -F '{{version}}' out


### PR DESCRIPTION
## Summary

Adds the **Zig Language Server** as `projects/ziglang.org/zls/package.yml`, a sub-package under the existing `ziglang.org` recipe.

- **From-source build** via `zig build install -Doptimize=ReleaseSafe`. The parent `ziglang.org` bottle vendors prebuilt zig as a chicken-and-egg exception; downstream Zig tooling like zls is compiled here from source against that bottle.
- **Build dep**: `ziglang.org: '~0.15.1'` — zls 0.15.1's `minimum_zig_version` is 0.15.1, and pantry's current ziglang.org bottle is 0.15.2 (satisfies `~0.15.1`).
- **Dependency fetching**: zig's package manager fetches the three declared tarball deps (`known-folders`, `diffz`, `lsp-kit`) during `zig build`. The lazy `tracy` dep is not pulled because tracy is not enabled. Caches are kept inside the build tree (`--global-cache-dir`/`--cache-dir`) so the build doesn't touch `$HOME`.
- **`skip: fix-patchelf`** — zig produces statically-linked binaries; matches the parent ziglang.org recipe's pattern.
- **Version pin**: `versions.ignore: - /^0\.16/`. zls 0.16.0 exists but requires zig 0.16, which upstream has not released yet. The pin should be removed once `ziglang.org` ships a 0.16 bottle.

This is the standard cross-distro approach — see Arch's [`zls` PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/zls) which also drives `zig build install -Doptimize=ReleaseSafe` against a system zig.

## Test plan

- [ ] CI builds on linux/x86-64
- [ ] CI builds on linux/aarch64
- [ ] CI builds on darwin/aarch64
- [ ] CI builds on darwin/x86-64
- [ ] `zls --version` prints `0.15.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)