### PR TITLE
new(patroni): PostgreSQL HA template (Zalando)

### DIFF
--- a/projects/github.com/zalando/patroni/package.yml
+++ b/projects/github.com/zalando/patroni/package.yml
@@ -26,12 +26,19 @@ build:
     - bkpyvenv seal {{prefix}} patroni patronictl
 
 test:
-  # `patroni --version` and `patronictl --version` were inconclusive
-  # in CI — the bkpyvenv-sealed shims may not yet have the version
-  # baked in at test time, or output format diverges. `--help`
-  # always exercises argv parsing and confirms the binary loads.
-  - patroni --help 2>&1 | grep -iq patroni
-  - patronictl --help 2>&1 | grep -iq patronictl
+  # patroni's main CLI expects a positional config-file argument
+  # and exits non-zero without it — `--help` flag may or may not
+  # be honored before that check. Verify the bkpyvenv-sealed shims
+  # exist and are executable instead; the pip install step itself
+  # exercises the package import path during venv build, which is
+  # the real correctness gate.
+  - test -x "{{prefix}}/bin/patroni"
+  - test -x "{{prefix}}/bin/patronictl"
+  # patronictl is the orchestration sub-tool with proper argparse;
+  # capture output to avoid SIGPIPE if it short-circuits.
+  - run: |
+      out=$(patronictl --help 2>&1 || true)
+      echo "$out" | grep -iq patroni
 
 provides:
   - bin/patroni

--- a/projects/github.com/zalando/patroni/package.yml
+++ b/projects/github.com/zalando/patroni/package.yml
@@ -11,11 +11,12 @@ versions:
 
 dependencies:
   pkgx.sh: ">=1"
-  postgresql.org: '*'    # patroni invokes pg_ctl, pg_rewind, pg_basebackup, pg_controldata
+  postgresql.org: "*" # patroni invokes pg_ctl, pg_rewind, pg_basebackup, pg_controldata
   # DCS backends — users pick one (etcd is the most common default):
   # etcd.io: '*'
   # consul.io: '*'
   # zookeeper.apache.org: '*'
+  psycopg.org/psycopg2: "*" # patroni's Python code depends on psycopg2
 
 build:
   dependencies:
@@ -26,19 +27,8 @@ build:
     - bkpyvenv seal {{prefix}} patroni patronictl
 
 test:
-  # patroni's main CLI expects a positional config-file argument
-  # and exits non-zero without it — `--help` flag may or may not
-  # be honored before that check. Verify the bkpyvenv-sealed shims
-  # exist and are executable instead; the pip install step itself
-  # exercises the package import path during venv build, which is
-  # the real correctness gate.
-  - test -x "{{prefix}}/bin/patroni"
-  - test -x "{{prefix}}/bin/patronictl"
-  # patronictl is the orchestration sub-tool with proper argparse;
-  # capture output to avoid SIGPIPE if it short-circuits.
-  - run: |
-      out=$(patronictl --help 2>&1 || true)
-      echo "$out" | grep -iq patroni
+  - test "$(patroni --version)" = "patroni {{version}}"
+  - test "$(patronictl version)" = "patronictl version {{version}}"
 
 provides:
   - bin/patroni

--- a/projects/github.com/zalando/patroni/package.yml
+++ b/projects/github.com/zalando/patroni/package.yml
@@ -26,8 +26,12 @@ build:
     - bkpyvenv seal {{prefix}} patroni patronictl
 
 test:
-  - patroni --version 2>&1 | grep {{version}}
-  - patronictl --version 2>&1 | grep {{version}}
+  # `patroni --version` and `patronictl --version` were inconclusive
+  # in CI — the bkpyvenv-sealed shims may not yet have the version
+  # baked in at test time, or output format diverges. `--help`
+  # always exercises argv parsing and confirms the binary loads.
+  - patroni --help 2>&1 | grep -iq patroni
+  - patronictl --help 2>&1 | grep -iq patronictl
 
 provides:
   - bin/patroni

--- a/projects/github.com/zalando/patroni/package.yml
+++ b/projects/github.com/zalando/patroni/package.yml
@@ -1,0 +1,34 @@
+distributable:
+  # NB: the project moved from zalando/patroni to patroni/patroni (community fork).
+  # GitHub redirects the old path, but we pin the canonical one.
+  url: https://github.com/patroni/patroni/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: patroni/patroni
+  ignore:
+    - /-(rc|alpha|beta)\d/
+
+dependencies:
+  pkgx.sh: ">=1"
+  postgresql.org: '*'    # patroni invokes pg_ctl, pg_rewind, pg_basebackup, pg_controldata
+  # DCS backends — users pick one (etcd is the most common default):
+  # etcd.io: '*'
+  # consul.io: '*'
+  # zookeeper.apache.org: '*'
+
+build:
+  dependencies:
+    python.org: ^3.9
+  script:
+    - bkpyvenv stage {{prefix}} {{version}}
+    - ${{prefix}}/venv/bin/pip install .
+    - bkpyvenv seal {{prefix}} patroni patronictl
+
+test:
+  - patroni --version 2>&1 | grep {{version}}
+  - patronictl --version 2>&1 | grep {{version}}
+
+provides:
+  - bin/patroni
+  - bin/patronictl


### PR DESCRIPTION
## Summary

- Add a new pantry recipe for [Patroni](https://github.com/patroni/patroni), the de-facto orchestrator for PostgreSQL high-availability with etcd / Consul / ZooKeeper as the DCS backend.
- Pure-Python install staged into a sealed venv via `bkpyvenv stage` / `bkpyvenv seal`, exposing `patroni` and `patronictl`.
- Pinned `python.org: ^3.9` (matches patroni's classifiers / current build matrix). `postgresql.org: '*'` is declared at runtime because patroni shells out to `pg_ctl`, `pg_rewind`, `pg_basebackup`, `pg_controldata`.

## Notes

- The project moved from `zalando/patroni` to `patroni/patroni` (community-maintained fork). GitHub still redirects the old path, but the recipe pins the canonical `patroni/patroni` URL and version source.
- DCS dependencies (etcd / Consul / ZooKeeper) are intentionally left commented out — users choose one, and patroni installs the Python client libraries (`python-etcd`, `kazoo`, `py-consul`) via pip.

## Test plan

- [ ] `pkgx +patroni patroni --version` matches the pinned version.
- [ ] `patronictl --version` matches.
- [ ] CI green on Linux + macOS.