### PR TITLE
new(citus): horizontally-scalable PostgreSQL extension

### DIFF
--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -44,20 +44,34 @@ build:
       # that gcc rejects. Use the same clang to stay compatible.
       llvm.org: '*'
   script:
-    # PGXS uses pg_config to determine install dirs. Override `prefix`
-    # at install time so extension files land in pantry's bottle, not
-    # in the Postgres dependency's tree.
+    # On darwin, `pg_config --cflags` returns a stale -isysroot pointing
+    # at the macOS SDK PG was bottled against (e.g. MacOSX15.2.sdk), but
+    # the darwin runners only have the current Xcode SDK installed.
+    # Build a wrapper pg_config that rewrites the bad path to the current
+    # SDK, and point Citus's configure at it via PG_CONFIG. The wrapper
+    # is a no-op pass-through on linux.
+    - |
+      SDK_REWRITE=""
+      if [ "$(uname)" = "Darwin" ]; then
+        SDK=$(xcrun --sdk macosx --show-sdk-path)
+        SDK_REWRITE="| sed -E 's|/Applications/Xcode[^[:space:]]*/SDKs/MacOSX[0-9.]+\\.sdk|$SDK|g'"
+      fi
+      mkdir -p "$PWD/pgconfig-shim"
+      cat > "$PWD/pgconfig-shim/pg_config" <<EOF
+      #!/bin/sh
+      "{{deps.postgresql.org.prefix}}/bin/pg_config" "\$@" $SDK_REWRITE
+      EOF
+      chmod +x "$PWD/pgconfig-shim/pg_config"
+    # PGXS uses pg_config to determine install dirs. Override `prefix` at
+    # install time so extension files land in pantry's bottle, not in the
+    # Postgres dependency's tree.
     - ./configure $ARGS
-    # PGXS appends PG_CFLAGS *after* PG's own CFLAGS, so the fresh
-    # -isysroot wins over the stale one baked into pg_config on darwin
-    # (clang resolves multiple -isysroot left-to-right; last wins).
-    # Variable is empty (and harmless) on linux.
-    - make --jobs {{ hw.concurrency }} PG_CFLAGS="$PG_CFLAGS_EXTRA"
-    - make install-all prefix={{prefix}} PG_CFLAGS="$PG_CFLAGS_EXTRA"
+    - make --jobs {{ hw.concurrency }}
+    - make install-all prefix={{prefix}}
   env:
     CC: clang
     ARGS:
-      - PG_CONFIG={{deps.postgresql.org.prefix}}/bin/pg_config
+      - PG_CONFIG=$PWD/pgconfig-shim/pg_config
       - --prefix={{prefix}}
       - --with-libcurl
       - --with-lz4
@@ -65,15 +79,8 @@ build:
     darwin:
       # Brewkit's hermetic CPATH masks the Xcode SDK, so Xcode clang's
       # #include_next chain can't reach <stdio.h>, <inttypes.h>, etc.
-      # Point the toolchain at the active SDK explicitly. The PG bottle
-      # was also built with macOS SDK 15.2 and bakes that path into
-      # `pg_config --cflags` as `-isysroot .../MacOSX15.2.sdk`, but the
-      # darwin runners only carry a newer SDK now. Append a fresh
-      # -isysroot via PG_CFLAGS so clang sees both and uses the last
-      # one (clang's documented behaviour) — pointing at the SDK that
-      # actually exists.
+      # Point the toolchain at the active SDK explicitly.
       SDKROOT: $(xcrun --sdk macosx --show-sdk-path)
-      PG_CFLAGS_EXTRA: -isysroot $(xcrun --sdk macosx --show-sdk-path)
 
 # Citus ships no executables — it's a Postgres extension loaded inside
 # the server process. Bottle contents:

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -14,35 +14,27 @@
 # PostgreSQL compatibility (Citus 14.x): PG 16, 17, 18.
 
 distributable:
-  url: https://github.com/citusdata/citus/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/citusdata/citus/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: citusdata/citus
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 dependencies:
-  postgresql.org: '>=16<19'
-  curl.se: '*'           # anonymous statistics collection
-  lz4.org: '*'           # column compression
-  facebook.com/zstd: '*' # column compression
-  openssl.org: '*'       # transitively via libpq / PG
+  postgresql.org: ">=16<19"
+  curl.se: "*" # anonymous statistics collection
+  lz4.org: "*" # column compression
+  facebook.com/zstd: "*" # column compression
+  openssl.org: "*" # transitively via libpq / PG
 
 build:
   dependencies:
-    gnu.org/make: '*'
-    freedesktop.org/pkg-config: '*'
     linux:
       # PostgreSQL bottle was built with clang, and Citus extensions
       # inherit CFLAGS via `pg_config --cflags` — those carry
       # clang-specific warnings (e.g. -Werror=unguarded-availability-new)
       # that gcc rejects. Use the same clang to stay compatible.
-      llvm.org: '*'
+      llvm.org: "*"
   script:
     # PGXS uses pg_config to determine install dirs. Override `prefix` at
     # install time so extension files land in pantry's bottle, not in the
@@ -57,31 +49,25 @@ build:
     # (PGXS's `override CPPFLAGS := -I. -I$(srcdir) $(CPPFLAGS)` then
     # prepends its own bits, preserving our SDK fix). Linux gets the
     # unmodified value, so the rewrite is a no-op there.
-    - |
-      PG_CONFIG="{{deps.postgresql.org.prefix}}/bin/pg_config"
-      CPPFLAGS_PG=$("$PG_CONFIG" --cppflags)
-      LDFLAGS_PG=$("$PG_CONFIG" --ldflags)
-      if [ "$(uname)" = "Darwin" ]; then
-        SDK=$(xcrun --sdk macosx --show-sdk-path)
-        REWRITE="s|/Applications/Xcode[^[:space:]]*/SDKs/MacOSX[0-9.]+\\.sdk|$SDK|g"
-        CPPFLAGS_PG=$(printf '%s' "$CPPFLAGS_PG" | sed -E "$REWRITE")
-        LDFLAGS_PG=$(printf '%s' "$LDFLAGS_PG" | sed -E "$REWRITE")
-      fi
-      make --jobs {{ hw.concurrency }} CPPFLAGS="$CPPFLAGS_PG" LDFLAGS="$LDFLAGS_PG"
-      make install-all prefix={{prefix}} CPPFLAGS="$CPPFLAGS_PG" LDFLAGS="$LDFLAGS_PG"
+    - make --jobs {{ hw.concurrency }} CPPFLAGS="$CPPFLAGS_PG" LDFLAGS="$LDFLAGS_PG"
+    - make install-all prefix={{prefix}} CPPFLAGS="$CPPFLAGS_PG" LDFLAGS="$LDFLAGS_PG"
   env:
     CC: clang
     ARGS:
-      - PG_CONFIG={{deps.postgresql.org.prefix}}/bin/pg_config
       - --prefix={{prefix}}
       - --with-libcurl
       - --with-lz4
       - --with-zstd
+    linux:
+      CPPFLAGS_PG: $(pg_config --cppflags)
+      LDFLAGS_PG: $(pg_config --ldflags)
     darwin:
       # Brewkit's hermetic CPATH masks the Xcode SDK, so Xcode clang's
       # #include_next chain can't reach <stdio.h>, <inttypes.h>, etc.
       # Point the toolchain at the active SDK explicitly.
       SDKROOT: $(xcrun --sdk macosx --show-sdk-path)
+      CPPFLAGS_PG: $(pg_config --cppflags | sed -E "s#/Applications/Xcode[^[:space:]]*/SDKs/MacOSX[0-9.]+\\.sdk#$(xcrun --sdk macosx --show-sdk-path)#g")
+      LDFLAGS_PG: $(pg_config --ldflags | sed -E "s#/Applications/Xcode[^[:space:]]*/SDKs/MacOSX[0-9.]+\\.sdk#$(xcrun --sdk macosx --show-sdk-path)#g")
 
 # Citus ships no executables — it's a Postgres extension loaded inside
 # the server process. Bottle contents:
@@ -92,9 +78,14 @@ build:
 # (cf. zlib.net, which is also library-only).
 
 test:
+  env:
+    linux:
+      LIB: citus.so
+    darwin:
+      LIB: citus.dylib
   script:
     # PGXS installs the loadable module as citus.so on linux,
     # citus.dylib on darwin, both under lib/postgresql when the
     # prefix lacks "postgres"/"pgsql" tokens (PGXS convention).
-    - test -f "{{prefix}}/lib/postgresql/citus.so" -o -f "{{prefix}}/lib/postgresql/citus.dylib"
+    - test -f "{{prefix}}/lib/postgresql/$LIB"
     - test -f "{{prefix}}/share/postgresql/extension/citus.control"

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -60,12 +60,15 @@ build:
     - |
       PG_CONFIG="{{deps.postgresql.org.prefix}}/bin/pg_config"
       CPPFLAGS_PG=$("$PG_CONFIG" --cppflags)
+      LDFLAGS_PG=$("$PG_CONFIG" --ldflags)
       if [ "$(uname)" = "Darwin" ]; then
         SDK=$(xcrun --sdk macosx --show-sdk-path)
-        CPPFLAGS_PG=$(printf '%s' "$CPPFLAGS_PG" | sed -E "s|/Applications/Xcode[^[:space:]]*/SDKs/MacOSX[0-9.]+\.sdk|$SDK|g")
+        REWRITE="s|/Applications/Xcode[^[:space:]]*/SDKs/MacOSX[0-9.]+\\.sdk|$SDK|g"
+        CPPFLAGS_PG=$(printf '%s' "$CPPFLAGS_PG" | sed -E "$REWRITE")
+        LDFLAGS_PG=$(printf '%s' "$LDFLAGS_PG" | sed -E "$REWRITE")
       fi
-      make --jobs {{ hw.concurrency }} CPPFLAGS="$CPPFLAGS_PG"
-      make install-all prefix={{prefix}} CPPFLAGS="$CPPFLAGS_PG"
+      make --jobs {{ hw.concurrency }} CPPFLAGS="$CPPFLAGS_PG" LDFLAGS="$LDFLAGS_PG"
+      make install-all prefix={{prefix}} CPPFLAGS="$CPPFLAGS_PG" LDFLAGS="$LDFLAGS_PG"
   env:
     CC: clang
     ARGS:

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -48,11 +48,12 @@ build:
     # at install time so extension files land in pantry's bottle, not
     # in the Postgres dependency's tree.
     - ./configure $ARGS
-    # PG_CPPFLAGS is appended by PGXS after PG's own CPPFLAGS, so the
-    # fresh -isysroot wins over the stale one baked into pg_config on
-    # darwin. Empty (and harmless) on linux.
-    - make --jobs {{ hw.concurrency }} PG_CPPFLAGS="$PG_CPPFLAGS_EXTRA"
-    - make install-all prefix={{prefix}} PG_CPPFLAGS="$PG_CPPFLAGS_EXTRA"
+    # PGXS appends PG_CFLAGS *after* PG's own CFLAGS, so the fresh
+    # -isysroot wins over the stale one baked into pg_config on darwin
+    # (clang resolves multiple -isysroot left-to-right; last wins).
+    # Variable is empty (and harmless) on linux.
+    - make --jobs {{ hw.concurrency }} PG_CFLAGS="$PG_CFLAGS_EXTRA"
+    - make install-all prefix={{prefix}} PG_CFLAGS="$PG_CFLAGS_EXTRA"
   env:
     CC: clang
     ARGS:
@@ -68,11 +69,11 @@ build:
       # was also built with macOS SDK 15.2 and bakes that path into
       # `pg_config --cflags` as `-isysroot .../MacOSX15.2.sdk`, but the
       # darwin runners only carry a newer SDK now. Append a fresh
-      # -isysroot via PG_CPPFLAGS so clang sees both and uses the last
+      # -isysroot via PG_CFLAGS so clang sees both and uses the last
       # one (clang's documented behaviour) — pointing at the SDK that
       # actually exists.
       SDKROOT: $(xcrun --sdk macosx --show-sdk-path)
-      PG_CPPFLAGS_EXTRA: -isysroot $(xcrun --sdk macosx --show-sdk-path)
+      PG_CFLAGS_EXTRA: -isysroot $(xcrun --sdk macosx --show-sdk-path)
 
 # Citus ships no executables — it's a Postgres extension loaded inside
 # the server process. Bottle contents:

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -93,7 +93,8 @@ build:
 
 test:
   script:
-    # Shared object lands in lib/postgresql when prefix lacks
-    # "postgres"/"pgsql" tokens (PGXS convention).
-    - test -f "{{prefix}}/lib/postgresql/citus.so" || test -f "{{prefix}}/lib/citus.so"
-    - test -f "{{prefix}}/share/postgresql/extension/citus.control" || test -f "{{prefix}}/share/extension/citus.control"
+    # PGXS installs the loadable module as citus.so on linux,
+    # citus.dylib on darwin, both under lib/postgresql when the
+    # prefix lacks "postgres"/"pgsql" tokens (PGXS convention).
+    - ls "{{prefix}}/lib/postgresql/citus.so" "{{prefix}}/lib/postgresql/citus.dylib" 2>/dev/null | grep -q .
+    - test -f "{{prefix}}/share/postgresql/extension/citus.control"

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -96,5 +96,5 @@ test:
     # PGXS installs the loadable module as citus.so on linux,
     # citus.dylib on darwin, both under lib/postgresql when the
     # prefix lacks "postgres"/"pgsql" tokens (PGXS convention).
-    - ls "{{prefix}}/lib/postgresql/citus.so" "{{prefix}}/lib/postgresql/citus.dylib" 2>/dev/null | grep -q .
+    - test -f "{{prefix}}/lib/postgresql/citus.so" -o -f "{{prefix}}/lib/postgresql/citus.dylib"
     - test -f "{{prefix}}/share/postgresql/extension/citus.control"

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -1,0 +1,70 @@
+# Citus — horizontally-scalable PostgreSQL extension.
+#
+# Citus extends Postgres into a distributed SQL database by sharding
+# tables across worker nodes. It's a drop-in extension: same Postgres,
+# same SQL, just transparently parallelised across a cluster. Common
+# alternative to CockroachDB / Yugabyte for users who want to stay on
+# vanilla Postgres semantics.
+#
+# Build: PGXS-based extension. Installs no CLI tools — the artefacts
+# are a shared library (citus.so) plus extension control/SQL files,
+# loaded inside Postgres via `CREATE EXTENSION citus` after adding it
+# to shared_preload_libraries.
+#
+# PostgreSQL compatibility (Citus 14.x): PG 16, 17, 18.
+
+distributable:
+  url: https://github.com/citusdata/citus/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: citusdata/citus
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+dependencies:
+  postgresql.org: '>=16<19'
+  curl.se: '*'           # anonymous statistics collection
+  lz4.org: '*'           # column compression
+  facebook.com/zstd: '*' # column compression
+  openssl.org: '*'       # transitively via libpq / PG
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+    freedesktop.org/pkg-config: '*'
+    linux:
+      gnu.org/gcc: '*'
+  script:
+    # PGXS uses pg_config to determine install dirs. Override `prefix`
+    # at install time so extension files land in pantry's bottle, not
+    # in the Postgres dependency's tree.
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install-all prefix={{prefix}}
+  env:
+    ARGS:
+      - PG_CONFIG={{deps.postgresql.org.prefix}}/bin/pg_config
+      - --prefix={{prefix}}
+      - --with-libcurl
+      - --with-lz4
+      - --with-zstd
+
+# Citus ships no executables — it's a Postgres extension loaded inside
+# the server process. Bottle contents:
+#   {{prefix}}/lib/postgresql/citus.so
+#   {{prefix}}/share/postgresql/extension/citus.control
+#   {{prefix}}/share/postgresql/extension/citus--*.sql
+# `provides:` validates bin/sbin paths, so omit the key entirely
+# (cf. zlib.net, which is also library-only).
+
+test:
+  script:
+    # Shared object lands in lib/postgresql when prefix lacks
+    # "postgres"/"pgsql" tokens (PGXS convention).
+    - test -f "{{prefix}}/lib/postgresql/citus.so" || test -f "{{prefix}}/lib/citus.so"
+    - test -f "{{prefix}}/share/postgresql/extension/citus.control" || test -f "{{prefix}}/share/extension/citus.control"

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -43,11 +43,17 @@ build:
     # PGXS uses pg_config to determine install dirs. Override `prefix`
     # at install time so extension files land in pantry's bottle, not
     # in the Postgres dependency's tree.
+    #
+    # Citus's configure inherits CC from `pg_config --cc`, which on the
+    # pantry postgresql.org bottle reports `clang`. The pantry linux
+    # toolchain ships gcc, not clang, so we pin CC=cc (gcc on linux,
+    # clang on darwin) to keep the build hermetic.
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}
     - make install-all prefix={{prefix}}
   env:
     ARGS:
+      - CC=cc
       - PG_CONFIG={{deps.postgresql.org.prefix}}/bin/pg_config
       - --prefix={{prefix}}
       - --with-libcurl

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -48,15 +48,11 @@ build:
     # at install time so extension files land in pantry's bottle, not
     # in the Postgres dependency's tree.
     - ./configure $ARGS
-    # The PostgreSQL bottle was built with macOS SDK 15.2, so
-    # `pg_config --cflags` injects `-isysroot .../MacOSX15.2.sdk`.
-    # Pantry's darwin runners ship a newer SDK only, so that path no
-    # longer exists and the compile dies looking for stdio.h / math.h.
-    # Strip the stale isysroot from Makefile.global; SDKROOT (set
-    # below) then drives the toolchain to the current SDK.
-    - test ! -f Makefile.global || sed -i.bak -E 's|-isysroot[[:space:]]+/Applications/Xcode[^[:space:]]*||g' Makefile.global
-    - make --jobs {{ hw.concurrency }}
-    - make install-all prefix={{prefix}}
+    # PG_CPPFLAGS is appended by PGXS after PG's own CPPFLAGS, so the
+    # fresh -isysroot wins over the stale one baked into pg_config on
+    # darwin. Empty (and harmless) on linux.
+    - make --jobs {{ hw.concurrency }} PG_CPPFLAGS="$PG_CPPFLAGS_EXTRA"
+    - make install-all prefix={{prefix}} PG_CPPFLAGS="$PG_CPPFLAGS_EXTRA"
   env:
     CC: clang
     ARGS:
@@ -68,8 +64,15 @@ build:
     darwin:
       # Brewkit's hermetic CPATH masks the Xcode SDK, so Xcode clang's
       # #include_next chain can't reach <stdio.h>, <inttypes.h>, etc.
-      # Point the toolchain at the active SDK explicitly.
+      # Point the toolchain at the active SDK explicitly. The PG bottle
+      # was also built with macOS SDK 15.2 and bakes that path into
+      # `pg_config --cflags` as `-isysroot .../MacOSX15.2.sdk`, but the
+      # darwin runners only carry a newer SDK now. Append a fresh
+      # -isysroot via PG_CPPFLAGS so clang sees both and uses the last
+      # one (clang's documented behaviour) — pointing at the SDK that
+      # actually exists.
       SDKROOT: $(xcrun --sdk macosx --show-sdk-path)
+      PG_CPPFLAGS_EXTRA: -isysroot $(xcrun --sdk macosx --show-sdk-path)
 
 # Citus ships no executables — it's a Postgres extension loaded inside
 # the server process. Bottle contents:

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -44,34 +44,32 @@ build:
       # that gcc rejects. Use the same clang to stay compatible.
       llvm.org: '*'
   script:
-    # On darwin, `pg_config --cflags` returns a stale -isysroot pointing
-    # at the macOS SDK PG was bottled against (e.g. MacOSX15.2.sdk), but
-    # the darwin runners only have the current Xcode SDK installed.
-    # Build a wrapper pg_config that rewrites the bad path to the current
-    # SDK, and point Citus's configure at it via PG_CONFIG. The wrapper
-    # is a no-op pass-through on linux.
-    - |
-      SDK_REWRITE=""
-      if [ "$(uname)" = "Darwin" ]; then
-        SDK=$(xcrun --sdk macosx --show-sdk-path)
-        SDK_REWRITE="| sed -E 's|/Applications/Xcode[^[:space:]]*/SDKs/MacOSX[0-9.]+\\.sdk|$SDK|g'"
-      fi
-      mkdir -p "$PWD/pgconfig-shim"
-      cat > "$PWD/pgconfig-shim/pg_config" <<EOF
-      #!/bin/sh
-      "{{deps.postgresql.org.prefix}}/bin/pg_config" "\$@" $SDK_REWRITE
-      EOF
-      chmod +x "$PWD/pgconfig-shim/pg_config"
     # PGXS uses pg_config to determine install dirs. Override `prefix` at
     # install time so extension files land in pantry's bottle, not in the
     # Postgres dependency's tree.
     - ./configure $ARGS
-    - make --jobs {{ hw.concurrency }}
-    - make install-all prefix={{prefix}}
+    # On darwin, PG's installed Makefile.global hard-codes -isysroot
+    # /Applications/Xcode.app/.../SDKs/MacOSX15.2.sdk (the SDK PG was
+    # bottled with). That SDK isn't present on current runners, so
+    # stdio.h / inttypes.h disappear. Build a sanitised CPPFLAGS string
+    # by re-reading pg_config --cppflags and rewriting the path, then
+    # pass it on the make command line so it overrides PG's value
+    # (PGXS's `override CPPFLAGS := -I. -I$(srcdir) $(CPPFLAGS)` then
+    # prepends its own bits, preserving our SDK fix). Linux gets the
+    # unmodified value, so the rewrite is a no-op there.
+    - |
+      PG_CONFIG="{{deps.postgresql.org.prefix}}/bin/pg_config"
+      CPPFLAGS_PG=$("$PG_CONFIG" --cppflags)
+      if [ "$(uname)" = "Darwin" ]; then
+        SDK=$(xcrun --sdk macosx --show-sdk-path)
+        CPPFLAGS_PG=$(printf '%s' "$CPPFLAGS_PG" | sed -E "s|/Applications/Xcode[^[:space:]]*/SDKs/MacOSX[0-9.]+\.sdk|$SDK|g")
+      fi
+      make --jobs {{ hw.concurrency }} CPPFLAGS="$CPPFLAGS_PG"
+      make install-all prefix={{prefix}} CPPFLAGS="$CPPFLAGS_PG"
   env:
     CC: clang
     ARGS:
-      - PG_CONFIG=$PWD/pgconfig-shim/pg_config
+      - PG_CONFIG={{deps.postgresql.org.prefix}}/bin/pg_config
       - --prefix={{prefix}}
       - --with-libcurl
       - --with-lz4

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -48,6 +48,13 @@ build:
     # at install time so extension files land in pantry's bottle, not
     # in the Postgres dependency's tree.
     - ./configure $ARGS
+    # The PostgreSQL bottle was built with macOS SDK 15.2, so
+    # `pg_config --cflags` injects `-isysroot .../MacOSX15.2.sdk`.
+    # Pantry's darwin runners ship a newer SDK only, so that path no
+    # longer exists and the compile dies looking for stdio.h / math.h.
+    # Strip the stale isysroot from Makefile.global; SDKROOT (set
+    # below) then drives the toolchain to the current SDK.
+    - test ! -f Makefile.global || sed -i.bak -E 's|-isysroot[[:space:]]+/Applications/Xcode[^[:space:]]*||g' Makefile.global
     - make --jobs {{ hw.concurrency }}
     - make install-all prefix={{prefix}}
   env:

--- a/projects/github.com/citusdata/citus/package.yml
+++ b/projects/github.com/citusdata/citus/package.yml
@@ -38,27 +38,31 @@ build:
     gnu.org/make: '*'
     freedesktop.org/pkg-config: '*'
     linux:
-      gnu.org/gcc: '*'
+      # PostgreSQL bottle was built with clang, and Citus extensions
+      # inherit CFLAGS via `pg_config --cflags` — those carry
+      # clang-specific warnings (e.g. -Werror=unguarded-availability-new)
+      # that gcc rejects. Use the same clang to stay compatible.
+      llvm.org: '*'
   script:
     # PGXS uses pg_config to determine install dirs. Override `prefix`
     # at install time so extension files land in pantry's bottle, not
     # in the Postgres dependency's tree.
-    #
-    # Citus's configure inherits CC from `pg_config --cc`, which on the
-    # pantry postgresql.org bottle reports `clang`. The pantry linux
-    # toolchain ships gcc, not clang, so we pin CC=cc (gcc on linux,
-    # clang on darwin) to keep the build hermetic.
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}
     - make install-all prefix={{prefix}}
   env:
+    CC: clang
     ARGS:
-      - CC=cc
       - PG_CONFIG={{deps.postgresql.org.prefix}}/bin/pg_config
       - --prefix={{prefix}}
       - --with-libcurl
       - --with-lz4
       - --with-zstd
+    darwin:
+      # Brewkit's hermetic CPATH masks the Xcode SDK, so Xcode clang's
+      # #include_next chain can't reach <stdio.h>, <inttypes.h>, etc.
+      # Point the toolchain at the active SDK explicitly.
+      SDKROOT: $(xcrun --sdk macosx --show-sdk-path)
 
 # Citus ships no executables — it's a Postgres extension loaded inside
 # the server process. Bottle contents:


### PR DESCRIPTION
## Summary

Adds Citus — the PostgreSQL extension that shards tables across worker nodes to provide horizontal scaling while keeping vanilla Postgres semantics. Common alternative to CockroachDB / Yugabyte for teams who want distributed Postgres without leaving Postgres itself.

- Source build (PGXS) from upstream tarballs at `github.com/citusdata/citus`.
- Citus 14.x supports PostgreSQL 16, 17, 18 (configure enforces this), so `postgresql.org` is pinned `>=16<19`.
- Compression deps (`lz4.org`, `facebook.com/zstd`) and `curl.se` (anonymous stats) are wired explicitly to match upstream's default feature set.
- `make install-all prefix={{prefix}}` redirects PGXS-derived install dirs into pantry's bottle prefix so extension artefacts (`citus.so`, control + SQL files) don't leak into the `postgresql.org` dependency tree.
- No `provides:` — Citus ships no CLI; artefacts are loaded inside Postgres via `CREATE EXTENSION citus` after adding to `shared_preload_libraries`.

## Test plan

- [ ] CI build passes on linux/x86-64
- [ ] CI build passes on linux/aarch64
- [ ] CI build passes on darwin/x86-64
- [ ] CI build passes on darwin/aarch64
- [ ] `citus.so` present under `lib/postgresql/`
- [ ] `citus.control` present under `share/postgresql/extension/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)