### PR TITLE
new(openfga): fine-grained authorization (Google Zanzibar-inspired)

### DIFF
--- a/projects/github.com/openfga/openfga/package.yml
+++ b/projects/github.com/openfga/openfga/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/openfga/openfga/archive/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: openfga/openfga
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    go.dev: ^1.25
+  script:
+    - go build $GO_ARGS -ldflags="$LD_FLAGS" ./cmd/openfga
+  env:
+    LD_FLAGS:
+      - -s -w
+      - -X github.com/openfga/openfga/internal/build.Version={{version}}
+      - -X github.com/openfga/openfga/internal/build.Commit=pkgx
+      - -X github.com/openfga/openfga/internal/build.Date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+    linux:
+      LD_FLAGS:
+        - -buildmode=pie
+    GO_ARGS:
+      - -trimpath
+      - -o={{prefix}}/bin/openfga
+
+provides:
+  - bin/openfga
+
+test:
+  - openfga version 2>&1 | grep {{version}}

--- a/projects/github.com/openfga/openfga/package.yml
+++ b/projects/github.com/openfga/openfga/package.yml
@@ -1,29 +1,22 @@
 distributable:
-  url: https://github.com/openfga/openfga/archive/v{{version}}.tar.gz
+  url: https://github.com/openfga/openfga/archive/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: openfga/openfga
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 build:
   dependencies:
     go.dev: ^1.25
-  script:
-    - go build $GO_ARGS -ldflags="$LD_FLAGS" ./cmd/openfga
+  script: go build $GO_ARGS -ldflags="$GO_LDFLAGS" ./cmd/openfga
   env:
-    LD_FLAGS:
+    GO_LDFLAGS:
       - -s -w
       - -X github.com/openfga/openfga/internal/build.Version={{version}}
       - -X github.com/openfga/openfga/internal/build.Commit=pkgx
       - -X github.com/openfga/openfga/internal/build.Date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     linux:
-      LD_FLAGS:
+      GO_LDFLAGS:
         - -buildmode=pie
     GO_ARGS:
       - -trimpath
@@ -33,4 +26,5 @@ provides:
   - bin/openfga
 
 test:
-  - openfga version 2>&1 | grep {{version}}
+  - openfga version 2>&1 | tee out
+  - grep {{version}} out


### PR DESCRIPTION
## Summary
- Add `openfga` recipe (CNCF sandbox project) providing a Zanzibar-inspired fine-grained authorization engine.
- Standard Go single-binary build for linux/{x86-64,aarch64} and darwin/{x86-64,aarch64}.
- ldflags injected for `internal/build.{Version,Commit,Date}` (matches homebrew-core).

## Test plan
- [x] `pkgx openfga version` returns the recipe version
- [ ] CI green on all four platforms

Upstream: https://github.com/openfga/openfga