### PR TITLE
new(kured): Kubernetes node reboot daemon

### DIFF
--- a/projects/github.com/kubereboot/kured/package.yml
+++ b/projects/github.com/kubereboot/kured/package.yml
@@ -5,24 +5,17 @@ distributable:
 versions:
   github: kubereboot/kured
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 build:
   dependencies:
-    go.dev: '*'
-  script:
-    - go build $GO_ARGS -ldflags="$LD_FLAGS" ./cmd/kured
+    go.dev: "*"
+  script: go build $GO_ARGS -ldflags="$GO_LDFLAGS" ./cmd/kured
   env:
     CGO_ENABLED: 0
-    LD_FLAGS:
+    GO_LDFLAGS:
       - -s -w
       - -X main.version={{version}}
     linux:
-      LD_FLAGS:
+      GO_LDFLAGS:
         - -buildmode=pie
     GO_ARGS:
       - -trimpath
@@ -32,4 +25,5 @@ provides:
   - bin/kured
 
 test:
-  - kured --help 2>&1 | grep -i kured
+  - kured --help 2>&1 | tee out
+  - grep -i kured out

--- a/projects/github.com/kubereboot/kured/package.yml
+++ b/projects/github.com/kubereboot/kured/package.yml
@@ -1,0 +1,35 @@
+distributable:
+  url: https://github.com/kubereboot/kured/archive/{{version.raw}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: kubereboot/kured
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  dependencies:
+    go.dev: '*'
+  script:
+    - go build $GO_ARGS -ldflags="$LD_FLAGS" ./cmd/kured
+  env:
+    CGO_ENABLED: 0
+    LD_FLAGS:
+      - -s -w
+      - -X main.version={{version}}
+    linux:
+      LD_FLAGS:
+        - -buildmode=pie
+    GO_ARGS:
+      - -trimpath
+      - -o={{prefix}}/bin/kured
+
+provides:
+  - bin/kured
+
+test:
+  - kured --help 2>&1 | grep -i kured


### PR DESCRIPTION
## Summary

- New recipe for [kured](https://github.com/kubereboot/kured) (KUbernetes REboot Daemon) — a daemonset that performs safe, automatic node reboots when the need is indicated by the underlying OS (e.g. presence of `/var/run/reboot-required`).
- Trivial Go single-binary build via `go build ./cmd/kured`; uses `{{version.raw}}` since upstream tags have no `v` prefix.
- Platforms: linux/{x86-64,aarch64} + darwin/{x86-64,aarch64}.
- Built with `-trimpath`, `-s -w`, `-X main.version={{version}}`, and `-buildmode=pie` on linux (mirroring upstream `.goreleaser.yml` defaults).

## Test plan

- [x] `bk build github.com/kubereboot/kured` succeeds on darwin/aarch64 (version 1.22.0)
- [x] `bk test github.com/kubereboot/kured` passes (`kured --help` lists usage flags)
- [ ] CI builds linux/{x86-64,aarch64} + darwin/x86-64