### PR TITLE
new(dapr.io): Distributed Application Runtime CLI (CNCF graduated)

### DIFF
--- a/projects/dapr.io/package.yml
+++ b/projects/dapr.io/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/dapr/cli/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/dapr/cli/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
@@ -10,7 +10,7 @@ provides:
 
 build:
   dependencies:
-    go.dev: '*'
+    go.dev: "*"
   script:
     - go mod download
     - go build -v -trimpath -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/dapr .
@@ -22,7 +22,7 @@ build:
       - -X main.version={{version}}
       - -X main.apiVersion=1.0
       - -X github.com/dapr/cli/pkg/standalone.gitcommit=pkgx
-      - -X github.com/dapr/cli/pkg/standalone.gitversion=v{{version}}
+      - -X github.com/dapr/cli/pkg/standalone.gitversion={{version.tag}}
     linux:
       # or segmentation fault
       # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
@@ -31,4 +31,5 @@ build:
 
 test:
   - dapr help
-  - 'test "$(dapr version | head -n1)" = "CLI version: {{version}} "'
+  - dapr version | tee out
+  - 'test "$(head -n1 out)" = "CLI version: {{version}} "'

--- a/projects/dapr.io/package.yml
+++ b/projects/dapr.io/package.yml
@@ -1,0 +1,34 @@
+distributable:
+  url: https://github.com/dapr/cli/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: dapr/cli
+
+provides:
+  - bin/dapr
+
+build:
+  dependencies:
+    go.dev: '*'
+  script:
+    - go mod download
+    - go build -v -trimpath -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/dapr .
+  env:
+    CGO_ENABLED: 0
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+      - -X main.apiVersion=1.0
+      - -X github.com/dapr/cli/pkg/standalone.gitcommit=pkgx
+      - -X github.com/dapr/cli/pkg/standalone.gitversion=v{{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      GO_LDFLAGS:
+        - -buildmode=pie
+
+test:
+  - dapr help
+  - 'test "$(dapr version | head -n1)" = "CLI version: {{version}} "'


### PR DESCRIPTION
## Summary
- Adds `projects/dapr.io/package.yml` — source build of the `dapr` CLI from [`dapr/cli`](https://github.com/dapr/cli)
- Dapr is a CNCF graduated project. This recipe ships the user-facing CLI; the `daprd` runtime (typically run as a K8s sidecar / multi-binary) is intentionally out of scope and can land as a follow-up
- Single Go binary, `main.go` at repo root → `go build .`. ldflags wired the same way upstream Makefile does (`main.version`, `main.apiVersion`, `pkg/standalone.gitcommit/gitversion`)
- Local source build verified against `v1.17.1` (Go 1.26): `dapr version` reports `CLI version: 1.17.1`

## Test plan
- [x] Local `go build` of v1.17.1 on darwin/arm64 with the recipe's exact ldflags
- [x] `dapr help` exit 0; `dapr version | head -n1` matches `CLI version: <ver>` (trailing space, matches upstream `fmt.Printf`)
- [ ] CI green on darwin + linux