### PR TITLE
new(harbor-cli): CLI client for Harbor container registry

### DIFF
--- a/projects/github.com/goharbor/harbor-cli/package.yml
+++ b/projects/github.com/goharbor/harbor-cli/package.yml
@@ -1,39 +1,32 @@
 distributable:
-  url: https://github.com/goharbor/harbor-cli/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/goharbor/harbor-cli/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: goharbor/harbor-cli
-
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
 
 provides:
   - bin/harbor
 
 build:
   dependencies:
-    go.dev: '*'
-  script: |
-    go mod download
-    mkdir -p "{{ prefix }}"/bin
-    go build -v -trimpath -ldflags="$LDFLAGS" -o "{{ prefix }}"/bin/harbor ./cmd/harbor
+    go.dev: "*"
+  script:
+    - go mod download
+    - go build -v -trimpath -ldflags="$GO_LDFLAGS" -o "{{ prefix }}"/bin/harbor ./cmd/harbor
   env:
     GOPROXY: https://proxy.golang.org,direct
     GOSUMDB: sum.golang.org
     GO111MODULE: on
     CGO_ENABLED: 0
-    LDFLAGS:
+    GO_LDFLAGS:
       - -s
       - -w
-      - -X github.com/goharbor/harbor-cli/cmd/harbor/internal/version.Version=v{{version}}
+      - -X github.com/goharbor/harbor-cli/cmd/harbor/internal/version.Version={{version.tag}}
     linux:
-      LDFLAGS:
+      GO_LDFLAGS:
         - -buildmode=pie
 
 test:
-  script:
-    - harbor version | grep -F "v{{version}}"
+  - harbor version | tee out
+  - grep -F "v{{version}}" out

--- a/projects/github.com/goharbor/harbor-cli/package.yml
+++ b/projects/github.com/goharbor/harbor-cli/package.yml
@@ -1,0 +1,39 @@
+distributable:
+  url: https://github.com/goharbor/harbor-cli/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: goharbor/harbor-cli
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+provides:
+  - bin/harbor
+
+build:
+  dependencies:
+    go.dev: '*'
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o "{{ prefix }}"/bin/harbor ./cmd/harbor
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/goharbor/harbor-cli/cmd/harbor/internal/version.Version=v{{version}}
+    linux:
+      LDFLAGS:
+        - -buildmode=pie
+
+test:
+  script:
+    - harbor version | grep -F "v{{version}}"


### PR DESCRIPTION
## Summary
- Adds `harbor-cli`, the official command-line client for the [Harbor](https://goharbor.io) cloud native container registry.
- Single-binary Go build from `./cmd/harbor`; version injected via `github.com/goharbor/harbor-cli/cmd/harbor/internal/version.Version` (matches upstream `.goreleaser.yaml`).
- Platforms: linux/{x86-64,aarch64}, darwin/{x86-64,aarch64}.
- Provides `bin/harbor`.

Upstream: https://github.com/goharbor/harbor-cli (latest release v0.0.22).

Note: this packages only the CLI. The Harbor server itself is not packaged (out of scope for pantry; see related discussion).

## Test plan
- [ ] CI builds for all four target platforms.
- [ ] `harbor version` prints the injected `vX.Y.Z` (test step greps for `v{{version}}`).