### PR TITLE
new(opencost): Kubernetes cost monitoring (CNCF sandbox)

### DIFF
--- a/projects/opencost.io/package.yml
+++ b/projects/opencost.io/package.yml
@@ -5,16 +5,12 @@ distributable:
 versions:
   github: opencost/opencost
 
-platforms:
-  - darwin
-  - linux
-
 provides:
   - bin/opencost
 
 build:
   dependencies:
-    go.dev: '*'
+    go.dev: "*"
   script:
     - go mod download
     - go build -trimpath -ldflags="$GO_LDFLAGS" -o '{{prefix}}/bin/opencost' ./cmd/costmodel
@@ -31,5 +27,4 @@ build:
         - -buildmode=pie
 
 test:
-  script:
-    - opencost --help
+  - opencost --help

--- a/projects/opencost.io/package.yml
+++ b/projects/opencost.io/package.yml
@@ -1,0 +1,35 @@
+distributable:
+  url: https://github.com/opencost/opencost/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: opencost/opencost
+
+platforms:
+  - darwin
+  - linux
+
+provides:
+  - bin/opencost
+
+build:
+  dependencies:
+    go.dev: '*'
+  script:
+    - go mod download
+    - go build -trimpath -ldflags="$GO_LDFLAGS" -o '{{prefix}}/bin/opencost' ./cmd/costmodel
+  env:
+    CGO_ENABLED: 0
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - -X github.com/opencost/opencost/core/pkg/version.Version=v{{version}}
+      - -X github.com/opencost/opencost/core/pkg/version.GitCommit=pkgx
+    linux:
+      GO_LDFLAGS:
+        - -buildmode=pie
+
+test:
+  script:
+    - opencost --help


### PR DESCRIPTION
## Summary
- Adds `opencost.io` recipe for [OpenCost](https://github.com/opencost/opencost), the CNCF sandbox tool for real-time Kubernetes cost monitoring and allocation.
- Standard Go single-binary build from upstream `./cmd/costmodel` package (no other `cmd/` subdirs exist).
- Linker flags match upstream `Makefile` exactly (`-X github.com/opencost/opencost/core/pkg/version.Version=...`, `GitCommit=...`).
- Built and verified locally on darwin/arm64 with go 1.26.2; binary runs `--help` cleanly (cobra "Cost-Model metric exporter and data aggregator").

## Test plan
- [x] Local `bk build opencost.io` succeeds (darwin)
- [x] Binary `opencost --help` prints cobra usage
- [ ] CI build on linux
- [ ] CI build on darwin