### PR TITLE
new(jmacd/xdelta): VCDIFF (RFC 3284) delta compression — open-vcdiff alternative

### DIFF
--- a/projects/github.com/jmacd/xdelta/package.yml
+++ b/projects/github.com/jmacd/xdelta/package.yml
@@ -1,0 +1,57 @@
+# xdelta3 — open-source VCDIFF (RFC 3284) delta compression by Joshua MacDonald.
+#
+# The most widely used VCDIFF implementation outside Google's own
+# open-vcdiff (which is archived as of 2023-08). xdelta is what
+# Chromium auto-update uses for some delta channels, what many
+# embedded firmware update pipelines run, and the canonical
+# alternative reference for the format.
+#
+# Upstream is dormant since 2020 but the project is not archived;
+# the algorithm and CLI surface are RFC-stable. C autotools build,
+# GPL-2.0+.
+#
+# This packages the modern v3 line (`xdelta3/`). The older `xdelta1/`
+# subdir is left out — that's the 1998 prototype, of historical
+# interest only.
+
+distributable:
+  url: https://github.com/jmacd/xdelta/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  # Upstream publishes git tags but ZERO GitHub Releases. Use /tags.
+  github: jmacd/xdelta/tags
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+build:
+  working-directory: xdelta3
+  dependencies:
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
+    gnu.org/libtool: '*'
+    gnu.org/make: '*'
+    freedesktop.org/pkg-config: '*'
+    linux:
+      gnu.org/gcc: '*'
+  script:
+    - autoreconf -fi
+    - ./configure --prefix={{prefix}}
+    - make --jobs {{ hw.concurrency }}
+    - make install
+
+provides:
+  - bin/xdelta3
+
+test:
+  # Round-trip: source → delta → reconstructed-target; verify identity.
+  - run: |
+      printf 'the quick brown fox jumps over the lazy dog\n' > source.txt
+      printf 'the quick brown FOX jumps over the lazy DOG\n' > target.txt
+      xdelta3 -e -s source.txt target.txt delta.vcdiff
+      xdelta3 -d -s source.txt delta.vcdiff out.txt
+      diff -q target.txt out.txt

--- a/projects/github.com/jmacd/xdelta/package.yml
+++ b/projects/github.com/jmacd/xdelta/package.yml
@@ -15,29 +15,21 @@
 # interest only.
 
 distributable:
-  url: https://github.com/jmacd/xdelta/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/jmacd/xdelta/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   # Upstream publishes git tags but ZERO GitHub Releases. Use /tags.
   github: jmacd/xdelta/tags
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 build:
   working-directory: xdelta3
   dependencies:
-    gnu.org/autoconf: '*'
-    gnu.org/automake: '*'
-    gnu.org/libtool: '*'
-    gnu.org/make: '*'
-    freedesktop.org/pkg-config: '*'
+    gnu.org/autoconf: "*"
+    gnu.org/automake: "*"
+    gnu.org/libtool: "*"
     linux:
-      gnu.org/gcc: '*'
+      gnu.org/gcc: "*"
   script:
     - autoreconf -fi
     - ./configure --prefix={{prefix}}
@@ -49,9 +41,8 @@ provides:
 
 test:
   # Round-trip: source → delta → reconstructed-target; verify identity.
-  - run: |
-      printf 'the quick brown fox jumps over the lazy dog\n' > source.txt
-      printf 'the quick brown FOX jumps over the lazy DOG\n' > target.txt
-      xdelta3 -e -s source.txt target.txt delta.vcdiff
-      xdelta3 -d -s source.txt delta.vcdiff out.txt
-      diff -q target.txt out.txt
+  - printf 'the quick brown fox jumps over the lazy dog\n' > source.txt
+  - printf 'the quick brown FOX jumps over the lazy DOG\n' > target.txt
+  - xdelta3 -e -s source.txt target.txt delta.vcdiff
+  - xdelta3 -d -s source.txt delta.vcdiff out.txt
+  - diff target.txt out.txt


### PR DESCRIPTION
## Summary

Adds Joshua MacDonald's **xdelta3** — the most widely used VCDIFF (RFC 3284) implementation outside Google's now-archived open-vcdiff.

## Why now

Google's \`open-vcdiff\` was archived 2023-08-26 (see #13141 where I attempted to package it and parked due to vendored gflags submodule problems). xdelta is the credible alternative:

- Used by Chromium auto-update for some delta channels
- Used by many embedded firmware delta-update pipelines  
- 1284 stars, RFC 3284 conformant
- Upstream is dormant (last push 2020) but **not archived** — algorithm and CLI surface are RFC-stable

## Build

Standard autotools, GPL-2.0+. Builds from the modern \`xdelta3/\` subdir; \`xdelta1/\` (1998 prototype) intentionally skipped.

## Test plan

- [ ] CI boundary-check + plan
- [ ] 4 bottle builds
- [ ] Round-trip encode/decode of a small source/target pair, verifying byte-identity after decode — exercises both encoder and decoder

## Related

- #13141 (open-vcdiff packaging attempt, parked due to gflags/m4 vendored submodule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)