### PR TITLE
new(go.dev/dev-simd): Go toolchain from the dev.simd branch (SIMD intrinsics)

### DIFF
--- a/projects/go.dev/dev-simd/README.md
+++ b/projects/go.dev/dev-simd/README.md
@@ -1,0 +1,84 @@
+# Go — `dev.simd` SIMD toolchain
+
+A build of the Go toolchain from upstream Go's experimental **`dev.simd`** branch
+(targeting Go 1.27), which adds the **`simd/archsimd`** package: portable SIMD
+*intrinsics* you write in plain Go — no cgo, no hand-written assembly. The
+compiler lowers them to real vector instructions on:
+
+- **amd64** — AVX2 / AVX-512
+- **arm64** — NEON
+
+## Why this package
+
+`simd/archsimd` is not in a released Go yet. amd64 support shipped in Go 1.26
+behind `GOEXPERIMENT=simd`; **arm64 (NEON) only exists on the `dev.simd` branch**
+and is slated for Go 1.27. This package lets you **build and benchmark SIMD Go
+code today**, on both amd64 and Apple-Silicon/arm64, before 1.27 is released —
+reproducibly, from a pinned commit.
+
+It is a **pinned snapshot of a moving dev branch**, so it is intentionally
+experimental and version-pinned (see *Versioning*). For released Go, use
+[`go.dev`](https://pkgx.dev/pkgs/go.dev/).
+
+## Usage
+
+This package deliberately does **not** claim the `go` / `gofmt` commands (so it
+never shadows the canonical `go.dev`). Use it explicitly with `+`:
+
+```sh
+# which toolchain is it?
+pkgx +go.dev/dev-simd -- go version          # go version go1.27 ...
+
+# build / run SIMD code (set the experiment flag)
+GOEXPERIMENT=simd pkgx +go.dev/dev-simd -- go build ./...
+GOEXPERIMENT=simd pkgx +go.dev/dev-simd -- go test ./...
+```
+
+A minimal program that uses the intrinsics:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"simd/archsimd"
+)
+
+func main() {
+	// 4-wide u32 vector add (NEON on arm64, SSE/AVX on amd64)
+	a := archsimd.LoadUint32x4([]uint32{1, 2, 3, 4})
+	b := archsimd.LoadUint32x4([]uint32{10, 20, 30, 40})
+	var out [4]uint32
+	a.Add(b).Store(out[:])
+	fmt.Println(out) // [11 22 33 44]
+}
+```
+
+```sh
+GOEXPERIMENT=simd pkgx +go.dev/dev-simd -- go run .
+```
+
+The `simd/archsimd` package only compiles under `GOEXPERIMENT=simd`; without the
+flag your code uses its normal (scalar) path.
+
+## Versioning
+
+`dev.simd` has no release tags, so each version is a **pinned commit**, named by
+that commit's date in CalVer `YYYY.M.D.HH.MM.SS`:
+
+```sh
+pkgx +go.dev/dev-simd@2026.6.1.17.4.35 -- go version   # a specific snapshot
+```
+
+Newer commits get higher (later-dated) versions, so the latest snapshot is the
+default. The exact upstream commit for each version is recorded in the recipe.
+
+## Caveats
+
+- **Experimental.** `simd/archsimd` is outside the Go 1 compatibility promise;
+  its API can change. This is a dev-branch snapshot, not a Go release.
+- **`GOEXPERIMENT=simd` is required** to compile code that imports
+  `simd/archsimd`.
+- For production, prefer released [`go.dev`](https://pkgx.dev/pkgs/go.dev/) —
+  amd64 SIMD lands in Go 1.26, arm64 SIMD in Go 1.27.

--- a/projects/go.dev/dev-simd/package.yml
+++ b/projects/go.dev/dev-simd/package.yml
@@ -38,9 +38,6 @@ build:
   working-directory: src
   # will only segfault if updated with patchelf
   skip: fix-patchelf
-  env:
-    v2026.6.1.17.4.35: 0e5948dc597c831b0c235cc0b3d34fa7587ddd47
-    go2026.6.1.17.4.35: go1.27
   script:
     # Map this version -> the dev.simd commit it pins, and fetch that exact
     # source. GitHub mirrors go.googlesource.com/go; the archive needs the full
@@ -49,7 +46,7 @@ build:
         # No .git in the archive and dev.simd has no VERSION file, so cmd/dist
         # can't derive a version; synthesize one (functional toolchain; the
         # pinned commit above is the real identity of the snapshot).
-    - test -f VERSION || echo "$go{{version}}" > VERSION
+    - run: test -f VERSION || echo "$go{{version}}" > VERSION
       working-directory: $SRCROOT
 
     - ./make.bash
@@ -64,6 +61,8 @@ build:
         - if test -f VERSION; then cp VERSION "{{prefix}}"; fi
       working-directory: $SRCROOT
   env:
+    v2026.6.1.17.4.35: 0e5948dc597c831b0c235cc0b3d34fa7587ddd47
+    go2026.6.1.17.4.35: go1.27
     # `make.bash` complains about unset GOCACHE and HOME otherwise
     GOCACHE: "$SRCROOT/.gocache"
     GOROOT_FINAL: ${{ prefix }}

--- a/projects/go.dev/dev-simd/package.yml
+++ b/projects/go.dev/dev-simd/package.yml
@@ -38,32 +38,30 @@ build:
   working-directory: src
   # will only segfault if updated with patchelf
   skip: fix-patchelf
+  env:
+    v2026.6.1.17.4.35: 0e5948dc597c831b0c235cc0b3d34fa7587ddd47
+    go2026.6.1.17.4.35: go1.27
   script:
     # Map this version -> the dev.simd commit it pins, and fetch that exact
     # source. GitHub mirrors go.googlesource.com/go; the archive needs the full
     # 40-char SHA.
-    - run: |
-        case "{{version.raw}}" in
-          2026.6.1.17.4.35) SHA=0e5948dc597c831b0c235cc0b3d34fa7587ddd47 ;;
-          *) echo "no commit mapping for version {{version.raw}}" >&2; exit 1 ;;
-        esac
-        curl -Lf "https://github.com/golang/go/archive/${SHA}.tar.gz" | tar xz --strip-components=1
+    - run: curl -Lf "https://github.com/golang/go/archive/${v{{version}}}.tar.gz" | tar xz --strip-components=1
         # No .git in the archive and dev.simd has no VERSION file, so cmd/dist
         # can't derive a version; synthesize one (functional toolchain; the
         # pinned commit above is the real identity of the snapshot).
-        test -f VERSION || echo "go1.27" > VERSION
+    - test -f VERSION || echo "$go{{version}}" > VERSION
       working-directory: $SRCROOT
 
     - ./make.bash
 
     # cleanup + install the GOROOT
     - rm -f *.{bash,bat,rc} Make.dist
-    - run: find . -mindepth 1 -delete
+    - run: find . -mindepth 1 -exec rm -r {} \;
       working-directory: ${{ prefix }}
-    - run: |
-        cp -a api bin doc lib misc pkg src test "{{prefix}}"
-        if test -f go.env; then cp go.env "{{prefix}}"; fi
-        if test -f VERSION; then cp VERSION "{{prefix}}"; fi
+    - run:
+        - cp -a api bin doc lib misc pkg src test "{{prefix}}"
+        - if test -f go.env; then cp go.env "{{prefix}}"; fi
+        - if test -f VERSION; then cp VERSION "{{prefix}}"; fi
       working-directory: $SRCROOT
   env:
     # `make.bash` complains about unset GOCACHE and HOME otherwise
@@ -74,12 +72,12 @@ build:
 test:
   env:
     GOEXPERIMENT: simd  # the whole point of this package
-  script: |
-    mv $FIXTURE $FIXTURE.go
+  script:
+    - mv $FIXTURE $FIXTURE.go
     # 1) the toolchain works
-    test "Hello World" = "$(go run $FIXTURE.go)"
+    - test "Hello World" = "$(go run $FIXTURE.go)"
     # 2) the experimental SIMD package is present and builds under the flag
-    go build -o /dev/null $FIXTURE.go
+    - go build -o /dev/null $FIXTURE.go
   fixture: |
     package main
 

--- a/projects/go.dev/dev-simd/package.yml
+++ b/projects/go.dev/dev-simd/package.yml
@@ -47,11 +47,12 @@ build:
     # Map this version -> the dev.simd commit it pins, and fetch that exact
     # source. GitHub mirrors go.googlesource.com/go; the archive needs the full
     # 40-char SHA.
-    - run: curl -Lf "https://github.com/golang/go/archive/${SHA}.tar.gz" | tar xz --strip-components=1
+    - run:
+        - curl -Lf "https://github.com/golang/go/archive/${SHA}.tar.gz" | tar xz --strip-components=1
         # No .git in the archive and dev.simd has no VERSION file, so cmd/dist
         # can't derive a version; synthesize one (functional toolchain; the
         # pinned commit above is the real identity of the snapshot).
-    - run: test -f VERSION || echo "$GOVER" > VERSION
+        - test -f VERSION || echo "$GOVER" > VERSION
       working-directory: $SRCROOT
 
     - ./make.bash

--- a/projects/go.dev/dev-simd/package.yml
+++ b/projects/go.dev/dev-simd/package.yml
@@ -39,14 +39,19 @@ build:
   # will only segfault if updated with patchelf
   skip: fix-patchelf
   script:
+    # version specific data
+    - run:
+      - export SHA=0e5948dc597c831b0c235cc0b3d34fa7587ddd47
+      - export GOVER=go1.27
+      if: 2026.6.1.17.4.35
     # Map this version -> the dev.simd commit it pins, and fetch that exact
     # source. GitHub mirrors go.googlesource.com/go; the archive needs the full
     # 40-char SHA.
-    - run: curl -Lf "https://github.com/golang/go/archive/${v{{version}}}.tar.gz" | tar xz --strip-components=1
+    - run: curl -Lf "https://github.com/golang/go/archive/${SHA}.tar.gz" | tar xz --strip-components=1
         # No .git in the archive and dev.simd has no VERSION file, so cmd/dist
         # can't derive a version; synthesize one (functional toolchain; the
         # pinned commit above is the real identity of the snapshot).
-    - run: test -f VERSION || echo "$go{{version}}" > VERSION
+    - run: test -f VERSION || echo "$GOVER" > VERSION
       working-directory: $SRCROOT
 
     - ./make.bash
@@ -61,8 +66,6 @@ build:
         - if test -f VERSION; then cp VERSION "{{prefix}}"; fi
       working-directory: $SRCROOT
   env:
-    v2026.6.1.17.4.35: 0e5948dc597c831b0c235cc0b3d34fa7587ddd47
-    go2026.6.1.17.4.35: go1.27
     # `make.bash` complains about unset GOCACHE and HOME otherwise
     GOCACHE: "$SRCROOT/.gocache"
     GOROOT_FINAL: ${{ prefix }}

--- a/projects/go.dev/dev-simd/package.yml
+++ b/projects/go.dev/dev-simd/package.yml
@@ -1,0 +1,97 @@
+# Go toolchain built from the experimental `dev.simd` branch (targeting Go 1.27),
+# which adds the `simd/archsimd` SIMD intrinsics for amd64 (AVX2/AVX-512) AND
+# arm64 (NEON). Lets you build cgo-free, assembly-free SIMD code with
+# `GOEXPERIMENT=simd` before Go 1.27 is released.
+#
+# `dev.simd` is a moving branch with no tags, so each packaged version is a
+# PINNED COMMIT. The version is the commit's committer date as CalVer
+# (YYYY.M.D.HH.MM.SS) — meaningful, monotonic, and parseable (no SemVer
+# pre-release, which brewkit can't parse). The build fetches that exact commit.
+#
+# To add another snapshot: append its CalVer to `versions:` and a matching
+# `<calver>) SHA=<full-40-char-sha> ;;` arm to the case in build.script.
+display-name: Go (dev.simd SIMD intrinsics)
+
+distributable: ~  # no single archive; each version fetches its pinned commit
+
+versions:
+  - 2026.6.1.17.4.35  # go.googlesource.com/go dev.simd @ 0e5948dc (2026-06-01)
+
+# Deliberately NO `provides:` and NO `interprets:`. This package ships bin/go and
+# bin/gofmt just like go.dev, so claiming them here would make the bare `pkgx go`
+# / `.go` interpreter ambiguous between the two. pkgx has no `conflicts:` field;
+# the idiomatic mutual exclusion is to let the canonical `go.dev` own those
+# command/interpreter names and use this experimental toolchain only explicitly:
+#
+#     pkgx +go.dev/dev-simd -- go build ...      # opt-in; never shadows go.dev
+#
+# (`+pkg` puts this package's bin/ on PATH regardless of `provides`.)
+
+dependencies:
+  openssl.org: 1  # for ca-certificates
+
+build:
+  dependencies:
+    curl.se: '*'   # fetch the pinned commit archive
+    gnu.org/m4: 1
+    go.dev: '*'    # bootstrap toolchain
+  working-directory: src
+  # will only segfault if updated with patchelf
+  skip: fix-patchelf
+  script:
+    # Map this version -> the dev.simd commit it pins, and fetch that exact
+    # source. GitHub mirrors go.googlesource.com/go; the archive needs the full
+    # 40-char SHA.
+    - run: |
+        case "{{version.raw}}" in
+          2026.6.1.17.4.35) SHA=0e5948dc597c831b0c235cc0b3d34fa7587ddd47 ;;
+          *) echo "no commit mapping for version {{version.raw}}" >&2; exit 1 ;;
+        esac
+        curl -Lf "https://github.com/golang/go/archive/${SHA}.tar.gz" | tar xz --strip-components=1
+        # No .git in the archive and dev.simd has no VERSION file, so cmd/dist
+        # can't derive a version; synthesize one (functional toolchain; the
+        # pinned commit above is the real identity of the snapshot).
+        test -f VERSION || echo "go1.27" > VERSION
+      working-directory: $SRCROOT
+
+    - ./make.bash
+
+    # cleanup + install the GOROOT
+    - rm -f *.{bash,bat,rc} Make.dist
+    - run: find . -mindepth 1 -delete
+      working-directory: ${{ prefix }}
+    - run: |
+        cp -a api bin doc lib misc pkg src test "{{prefix}}"
+        if test -f go.env; then cp go.env "{{prefix}}"; fi
+        if test -f VERSION; then cp VERSION "{{prefix}}"; fi
+      working-directory: $SRCROOT
+  env:
+    # `make.bash` complains about unset GOCACHE and HOME otherwise
+    GOCACHE: "$SRCROOT/.gocache"
+    GOROOT_FINAL: ${{ prefix }}
+    GOROOT_BOOTSTRAP: ${{ deps.go.dev.prefix }}
+
+test:
+  env:
+    GOEXPERIMENT: simd  # the whole point of this package
+  script: |
+    mv $FIXTURE $FIXTURE.go
+    # 1) the toolchain works
+    test "Hello World" = "$(go run $FIXTURE.go)"
+    # 2) the experimental SIMD package is present and builds under the flag
+    go build -o /dev/null $FIXTURE.go
+  fixture: |
+    package main
+
+    import (
+        "fmt"
+
+        "simd/archsimd"
+    )
+
+    func main() {
+        // Compiles only when the simd intrinsics package exists (GOEXPERIMENT=simd).
+        // AVX2() is defined on every GOARCH (false off amd64), so this is portable.
+        _ = archsimd.X86.AVX2()
+        fmt.Println("Hello World")
+    }


### PR DESCRIPTION
## What

Adds `go.dev/dev-simd`: the Go toolchain built from upstream Go's experimental **`dev.simd`** branch (targeting Go 1.27), which provides the **`simd/archsimd`** package — portable SIMD intrinsics written in plain Go (no cgo, no hand-written assembly) that the compiler lowers to AVX2/AVX-512 on amd64 and **NEON on arm64**.

## Why

`simd/archsimd` isn't in a released Go yet: amd64 shipped in Go 1.26 behind `GOEXPERIMENT=simd`, but **arm64 (NEON) only exists on `dev.simd`** (slated for 1.27). This package lets people build/benchmark SIMD Go today on both amd64 and Apple-Silicon/arm64, reproducibly from a pinned commit, before 1.27 lands.

## How it's structured

- **Sub-package of `go.dev`** (alongside `go.dev/govulncheck`, `go.dev/testscript`).
- **Pinned-commit snapshots** of a tagless branch, versioned by the commit's committer date as CalVer (`YYYY.M.D.HH.MM.SS`). `distributable: ~` + a `version → SHA` case in `build.script` fetches the exact commit. First version `2026.6.1.17.4.35` = commit `0e5948dc`. (The archive has no `.git`/`VERSION`, so a `VERSION` is synthesized for `cmd/dist`.)
- **No `provides:` / `interprets:`** on purpose: it ships `bin/go` like `go.dev`, so it must not claim the bare `go`/`gofmt` commands or the `.go` interpreter. Used explicitly: `pkgx +go.dev/dev-simd -- go …`.
- README renders on pkgx.dev (rationale, usage, versioning, caveats).

## Verified

`bk build` and `bk audit` pass. The built toolchain reports `go1.27`, and `GOEXPERIMENT=simd go run` of a `simd/archsimd` program works — including NEON `Uint32x4` on `darwin/arm64`.

## Note for maintainers

This packages a **snapshot of a moving pre-release dev branch**, not a tagged Go release — flagging that explicitly so you can decide whether it fits the pantry's scope. It is experimental (the `simd` package is outside the Go 1 compatibility promise) and opt-in (no command shadowing). Happy to adjust naming/structure, restrict platforms, or close if it's out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)