### PR TITLE
ci(setup): add `skip-codesign-import` lever for adhoc-only recipes

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,6 +11,16 @@ inputs:
   APPLE_IDENTITY:
     description: Apple identity to use for signing
     required: false
+  skip-codesign-import:
+    description: >
+      When 'true', skip importing the Apple Developer ID into the keychain.
+      Useful for recipes whose binaries require adhoc signing (eg. those
+      carrying com.apple.security.virtualization / .hypervisor entitlements,
+      which need either adhoc or a matching provisioning profile to be
+      accepted by macOS at runtime). Defense-in-depth on top of brewkit's
+      fix-machos.rb policy. See pkgxdev/pantry#7853.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -38,11 +48,11 @@ runs:
     # delete it if it does.
     - name: Delete keychain
       shell: sh
-      if: runner.os == 'macOS' && inputs.p12-password && inputs.p12-file-base64
+      if: runner.os == 'macOS' && inputs.p12-password && inputs.p12-file-base64 && inputs.skip-codesign-import != 'true'
       run: security delete-keychain signing_temp.keychain || true
 
     - uses: apple-actions/import-codesign-certs@v6
-      if: runner.os == 'macOS' && inputs.p12-password && inputs.p12-file-base64
+      if: runner.os == 'macOS' && inputs.p12-password && inputs.p12-file-base64 && inputs.skip-codesign-import != 'true'
       with:
         p12-file-base64: ${{ inputs.p12-file-base64 }}
         p12-password: ${{ inputs.p12-password }}

--- a/.github/workflows/pkg-platform.yml
+++ b/.github/workflows/pkg-platform.yml
@@ -40,6 +40,13 @@ on:
       invalidate-cloudfront:
         type: boolean
         default: true
+      skip-codesign-import:
+        description: >
+          Skip importing the Apple Developer ID into the keychain.
+          For recipes whose binaries need adhoc signing (virtualization /
+          hypervisor entitlements). See pkgxdev/pantry#7853.
+        type: boolean
+        default: false
     secrets:
       APPLE_CERTIFICATE_P12: { required: false }
       APPLE_CERTIFICATE_P12_PASSWORD: { required: false }
@@ -80,6 +87,7 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_P12_PASSWORD }}
           APPLE_IDENTITY: ${{ secrets.APPLE_IDENTITY }}
+          skip-codesign-import: ${{ inputs.skip-codesign-import }}
 
       - uses: pkgxdev/setup@v5
         with:

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -16,6 +16,13 @@ on:
       invalidate-cloudfront:
         type: boolean
         default: true
+      skip-codesign-import:
+        description: >
+          Skip importing the Apple Developer ID into the keychain.
+          For recipes whose binaries need adhoc signing (virtualization /
+          hypervisor entitlements). See pkgxdev/pantry#7853.
+        type: boolean
+        default: false
 
 jobs:
   plan:
@@ -54,4 +61,5 @@ jobs:
       tinyname: ${{ matrix.platform.tinyname }}
       complain: ${{ inputs.complain }}
       invalidate-cloudfront: ${{ inputs.invalidate-cloudfront }}
+      skip-codesign-import: ${{ inputs.skip-codesign-import }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to pkgxdev/brewkit#353. Adds a workflow-level lever to skip importing the Apple Developer ID into the keychain for recipes that need adhoc signing.

## Why

Some recipes ship binaries with entitlements that require either adhoc signing or a Developer ID with a matching provisioning profile — notably `com.apple.security.virtualization` and `com.apple.security.hypervisor`. brewkit#353 handles the binary side correctly: it sees these entitlements in the Mach-O and forces adhoc signing in `fix-machos.rb`, regardless of what signing identity the workflow imported.

This PR is the workflow-level complement that @jhheider raised in #7853: when we know a recipe is in this category, why import a Developer ID at all? It's wasteful and leaves the cert in the keychain longer than necessary.

## What changes

Purely additive lever. Default stays `false` → no behavior change for any current call.

```
pkg.yml (workflow_call input: skip-codesign-import)
  -> pkg-platform.yml (workflow_call input: skip-codesign-import)
    -> .github/actions/setup (composite input, gates the import step)
```

The `apple-actions/import-codesign-certs@v6` step (and the prophylactic `Delete keychain` step before it) are gated on `inputs.skip-codesign-import != 'true'`.

## What is **not** in this PR (deliberately)

Picking which recipes opt in. Two reasons:

1. **brewkit#353 already provides the correctness guarantee.** This PR is hardening, not a fix — recipes don't break if their flag isn't set, they just import a cert they don't end up using.
2. **The discussion of "which recipes / what mechanism" deserves its own thread.** Options range from a per-recipe pantry metadata field to a static allow-list in the workflow. Worth deciding once, separately.

`lima-vm.io` is the obvious first candidate (#7853) and a follow-up would add it.

## Test plan

- [x] YAML syntax validated on all three files
- [x] Default path unchanged (lever defaults `false`)
- [ ] CI passes
- [ ] Smoke test: kick a recipe build with `skip-codesign-import: true` and confirm the import step is skipped

Refs: pkgxdev/pantry#7853, pkgxdev/brewkit#353

🤖 Generated with [Claude Code](https://claude.com/claude-code)