### PR TITLE
new(acpica.org): iasl ACPI compiler

### DIFF
--- a/projects/acpica.org/package.yml
+++ b/projects/acpica.org/package.yml
@@ -1,0 +1,57 @@
+# ACPICA — Intel's ACPI Component Architecture.
+#
+# We package it for one tool in particular: `iasl`, the ASL+ optimizing
+# compiler/disassembler. EDK II (tianocore.org/edk2) shells out to it to
+# turn `.asl` ACPI tables into `.aml` during firmware builds, so it is a
+# build-time dependency there rather than a user-facing package.
+#
+# Upstream tags switched from `R20YY_MM_DD` to a clean `YYYYMMDD` scheme
+# around mid-2025; we only match the latter.
+
+distributable:
+  url: git+https://github.com/acpica/acpica
+  ref: '{{version.raw}}'
+
+versions:
+  github: acpica/acpica/tags
+  match: /^\d{8}$/
+
+build:
+  dependencies:
+    github.com/westes/flex: '*'
+    gnu.org/bison: '*'
+    gnu.org/make: '*'
+    linux:
+      gnu.org/gcc: '*'
+  script:
+    - run: |
+        set -e
+        case "$(uname -s)" in
+          Darwin)
+            # ACPICA keeps function pointers in `__DATA,__const` tables
+            # that aren't 8-byte aligned. The arm64 mach-o linker's
+            # chained-fixups format requires that alignment and aborts
+            # with "pointer not aligned in '_AcpiExDumpNode'". Disabling
+            # chained fixups sidesteps it (lld emits the same advice).
+            make iasl CC=clang OPT_LDFLAGS="-Wl,-no_fixup_chains"
+            ;;
+          *)
+            # CC defaults to gcc (from gnu.org/gcc above).
+            make iasl
+            ;;
+        esac
+        mkdir -p "{{prefix}}/bin"
+        install -m 0755 generate/unix/bin/iasl "{{prefix}}/bin/iasl"
+
+provides:
+  - bin/iasl
+
+test:
+  - iasl -v
+  # Compile a trivial SSDT and confirm an .aml falls out.
+  - |
+    cat > t.asl <<'ASL'
+    DefinitionBlock ("", "SSDT", 2, "TEST", "T", 0x1) { Name (X, 0x42) }
+    ASL
+    iasl t.asl
+    test -s t.aml

--- a/projects/acpica.org/package.yml
+++ b/projects/acpica.org/package.yml
@@ -10,7 +10,7 @@
 
 distributable:
   url: git+https://github.com/acpica/acpica
-  ref: '{{version.raw}}'
+  ref: "{{version.tag}}"
 
 versions:
   github: acpica/acpica/tags
@@ -18,30 +18,18 @@ versions:
 
 build:
   dependencies:
-    github.com/westes/flex: '*'
-    gnu.org/bison: '*'
-    gnu.org/make: '*'
+    github.com/westes/flex: "*"
+    gnu.org/bison: "*"
     linux:
-      gnu.org/gcc: '*'
+      gnu.org/gcc: "*"
+  env:
+    darwin:
+      EXTRA_MAKEFLAGS:
+        - CC=clang
+        - OPT_LDFLAGS="-Wl,-no_fixup_chains"
   script:
-    - run: |
-        set -e
-        case "$(uname -s)" in
-          Darwin)
-            # ACPICA keeps function pointers in `__DATA,__const` tables
-            # that aren't 8-byte aligned. The arm64 mach-o linker's
-            # chained-fixups format requires that alignment and aborts
-            # with "pointer not aligned in '_AcpiExDumpNode'". Disabling
-            # chained fixups sidesteps it (lld emits the same advice).
-            make iasl CC=clang OPT_LDFLAGS="-Wl,-no_fixup_chains"
-            ;;
-          *)
-            # CC defaults to gcc (from gnu.org/gcc above).
-            make iasl
-            ;;
-        esac
-        mkdir -p "{{prefix}}/bin"
-        install -m 0755 generate/unix/bin/iasl "{{prefix}}/bin/iasl"
+    - make iasl $EXTRA_MAKEFLAGS
+    - install -Dm0755 generate/unix/bin/iasl "{{prefix}}/bin/iasl"
 
 provides:
   - bin/iasl
@@ -49,9 +37,9 @@ provides:
 test:
   - iasl -v
   # Compile a trivial SSDT and confirm an .aml falls out.
-  - |
-    cat > t.asl <<'ASL'
-    DefinitionBlock ("", "SSDT", 2, "TEST", "T", 0x1) { Name (X, 0x42) }
-    ASL
-    iasl t.asl
-    test -s t.aml
+  - run: cp $FIXTURE t.asl
+    fixture:
+      extname: asl
+      content: DefinitionBlock ("", "SSDT", 2, "TEST", "T", 0x1) { Name (X, 0x42) }
+  - iasl t.asl
+  - test -s t.aml


### PR DESCRIPTION
Adds `acpica.org`, packaging Intel ACPICA's **`iasl`** — the ASL+ optimizing compiler/disassembler.

### Why
EDK II (#13239) shells out to `iasl` to compile `.asl` ACPI tables into `.aml` during firmware builds (RamDiskDxe's NFIT table, etc.). `iasl` isn't currently in the pantry, so the edk2 build fails with `iasl: command not found` (exit 127). This packages it as a standalone build-time dependency.

> Prerequisite for #13239 — that PR build-depends on `acpica.org`, so this should land first.

### Notes
- Tags switched from `R20YY_MM_DD` to a clean `YYYYMMDD` scheme around mid-2025; we match only the latter.
- **darwin/arm64** links with `-Wl,-no_fixup_chains`: ACPICA keeps unaligned function pointers in `__DATA,__const` tables that the mach-o chained-fixups format rejects (`ld: pointer not aligned in '_AcpiExDumpNode'`; lld emits the same advice).

### Test plan
Built `iasl` locally on darwin/arm64 (pantry flex/bison/clang) from the resolved tag `20260408`; `iasl -v` reports the version and it compiles a trivial SSDT to `.aml`.