### PR TITLE
new(victoriametrics.com): Prometheus-compatible TSDB + vm* tools

### DIFF
--- a/projects/victoriametrics.com/package.yml
+++ b/projects/victoriametrics.com/package.yml
@@ -1,0 +1,44 @@
+# VictoriaMetrics — fast, cost-effective, scalable monitoring &
+# time-series database. Drop-in Prometheus-compatible TSDB (remote-write
+# + PromQL/MetricsQL) plus the vm* tool suite (vmagent scraper, vmalert
+# rules, vmauth proxy, vmbackup/vmrestore, vmctl migrator).
+
+distributable:
+  url: https://github.com/VictoriaMetrics/VictoriaMetrics/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: VictoriaMetrics/VictoriaMetrics
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+  script:
+    # All binaries live under ./app/<name>. Pure-Go, CGO-free. Embed the
+    # release tag into each via lib/buildinfo.Version (mirrors upstream's
+    # Makefile GO_BUILDINFO `-X` so `--version` reports it).
+    - mkdir -p {{prefix}}/bin
+    - |
+      for app in victoria-metrics vmagent vmalert vmalert-tool vmauth vmbackup vmrestore vmctl; do
+        go build -trimpath \
+          -ldflags "-s -w -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=$app-{{version.tag}}" \
+          -o "{{prefix}}/bin/$app" "./app/$app"
+      done
+
+test:
+  - victoria-metrics --version 2>&1 | tee out
+  - grep {{version}} out
+  - vmagent --version 2>&1 | grep {{version}}
+  - vmctl --version 2>&1 | grep {{version}}
+
+provides:
+  - bin/victoria-metrics
+  - bin/vmagent
+  - bin/vmalert
+  - bin/vmalert-tool
+  - bin/vmauth
+  - bin/vmbackup
+  - bin/vmrestore
+  - bin/vmctl

--- a/projects/victoriametrics.com/package.yml
+++ b/projects/victoriametrics.com/package.yml
@@ -15,23 +15,31 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version={{version.tag}}
+    BINS:
+      - victoria-metrics
+      - vmagent
+      - vmalert
+      - vmalert-tool
+      - vmauth
+      - vmbackup
+      - vmrestore
+      - vmctl
   script:
-    # All binaries live under ./app/<name>. Pure-Go, CGO-free. Embed the
-    # release tag into each via lib/buildinfo.Version (mirrors upstream's
-    # Makefile GO_BUILDINFO `-X` so `--version` reports it).
-    - mkdir -p {{prefix}}/bin
-    - |
-      for app in victoria-metrics vmagent vmalert vmalert-tool vmauth vmbackup vmrestore vmctl; do
-        go build -trimpath \
-          -ldflags "-s -w -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=$app-{{version.tag}}" \
-          -o "{{prefix}}/bin/$app" "./app/$app"
-      done
+    - for app in $BINS; do
+    - go build -trimpath -ldflags "$GO_LDFLAGS" -o "{{prefix}}/bin/$app" "./app/$app"
+    - done
 
 test:
   - victoria-metrics --version 2>&1 | tee out
   - grep {{version}} out
-  - vmagent --version 2>&1 | grep {{version}}
-  - vmctl --version 2>&1 | grep {{version}}
+  - vmagent --version 2>&1 | tee out
+  - grep {{version}} out
+  - vmctl --version 2>&1 | tee out
+  - grep {{version}} out
 
 provides:
   - bin/victoria-metrics


### PR DESCRIPTION
## What
Adds `victoriametrics.com` — [VictoriaMetrics](https://victoriametrics.com), a fast, cost-effective, scalable Prometheus-compatible time-series database & monitoring solution.

Builds the full single-node suite from source: `victoria-metrics`, `vmagent`, `vmalert`, `vmalert-tool`, `vmauth`, `vmbackup`, `vmrestore`, `vmctl`.

## Notes
- Pure-Go, `CGO_ENABLED=0`. All binaries live under `./app/<name>`.
- Release tag embedded via `lib/buildinfo.Version` (mirrors upstream's Makefile `GO_BUILDINFO -X`), so `--version` reports it — which the test asserts.

## Test plan
- [x] `victoria-metrics --version` / `vmagent` / `vmctl` report the tag
- Verified locally on **linux/aarch64** (Debian + pkgx `go.dev`): all 8 binaries build clean and report `v1.145.0`.