### PR TITLE
new(litestream.io): streaming replication for SQLite

### DIFF
--- a/projects/litestream.io/package.yml
+++ b/projects/litestream.io/package.yml
@@ -1,0 +1,26 @@
+# Litestream — streaming replication for SQLite. Continuously ships the
+# WAL to S3-compatible object storage (and other backends) for
+# point-in-time recovery, with near-zero overhead on the live database.
+
+distributable:
+  url: https://github.com/benbjohnson/litestream/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: benbjohnson/litestream
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0   # pure-Go (modernc.org/sqlite), no cgo sqlite
+  script:
+    - mkdir -p {{prefix}}/bin
+    - go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o {{prefix}}/bin/litestream ./cmd/litestream
+
+test:
+  - litestream version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/litestream

--- a/projects/litestream.io/package.yml
+++ b/projects/litestream.io/package.yml
@@ -14,9 +14,7 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0   # pure-Go (modernc.org/sqlite), no cgo sqlite
-  script:
-    - mkdir -p {{prefix}}/bin
-    - go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o {{prefix}}/bin/litestream ./cmd/litestream
+  script: go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o {{prefix}}/bin/litestream ./cmd/litestream
 
 test:
   - litestream version 2>&1 | tee out


### PR DESCRIPTION
## What
Adds `litestream.io` — [Litestream](https://litestream.io), streaming replication for SQLite: continuously ships the WAL to S3-compatible object storage (and other backends) for point-in-time recovery, with near-zero overhead on the live DB.

## Notes
- Pure-Go (`modernc.org/sqlite`, `CGO_ENABLED=0`); single `litestream` binary.
- Release tag embedded via `-X main.Version`, asserted by the test (`litestream version`).

## Test plan
- [x] Verified on **linux/aarch64** (Debian + pkgx `go.dev`): builds clean, `litestream version` reports `v0.5.12`.