### PR TITLE
new(github.com/derailed/popeye): Kubernetes cluster sanitizer

### DIFF
--- a/projects/github.com/derailed/popeye/package.yml
+++ b/projects/github.com/derailed/popeye/package.yml
@@ -12,9 +12,7 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0
-  script:
-    - mkdir -p "{{prefix}}/bin"
-    - go build -trimpath -ldflags "-s -w -X github.com/derailed/popeye/cmd.version={{version.tag}}" -o "{{prefix}}/bin/popeye" .
+  script: go build -trimpath -ldflags "-s -w -X github.com/derailed/popeye/cmd.version={{version.tag}}" -o "{{prefix}}/bin/popeye" .
 
 test:
   - popeye version 2>&1 | tee out

--- a/projects/github.com/derailed/popeye/package.yml
+++ b/projects/github.com/derailed/popeye/package.yml
@@ -1,0 +1,24 @@
+# Popeye — a Kubernetes cluster sanitizer: scans live clusters (and manifests) for misconfigurations, grouped by resource.
+
+distributable:
+  url: https://github.com/derailed/popeye/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: derailed/popeye
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - go build -trimpath -ldflags "-s -w -X github.com/derailed/popeye/cmd.version={{version.tag}}" -o "{{prefix}}/bin/popeye" .
+
+test:
+  - popeye version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/popeye


### PR DESCRIPTION
Adds [Popeye](https://github.com/derailed/popeye) — a Kubernetes cluster sanitizer that scans live clusters (and manifests) for misconfigurations.

Pure-Go, `CGO_ENABLED=0`. Verified on linux/aarch64 (Debian + pkgx `go.dev`): builds clean, `popeye version` → `v0.22.1`.