### PR TITLE
new(github.com/johnkerl/miller): mlr — awk/sed/cut for CSV/JSON

### DIFF
--- a/projects/github.com/johnkerl/miller/package.yml
+++ b/projects/github.com/johnkerl/miller/package.yml
@@ -1,0 +1,24 @@
+# Miller (mlr) — like awk/sed/cut/join/sort for CSV, TSV, JSON and other structured data.
+
+distributable:
+  url: https://github.com/johnkerl/miller/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: johnkerl/miller
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - go build -trimpath -ldflags "-s -w" -o "{{prefix}}/bin/mlr" ./cmd/mlr
+
+test:
+  - mlr version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/mlr

--- a/projects/github.com/johnkerl/miller/package.yml
+++ b/projects/github.com/johnkerl/miller/package.yml
@@ -12,9 +12,7 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0
-  script:
-    - mkdir -p "{{prefix}}/bin"
-    - go build -trimpath -ldflags "-s -w" -o "{{prefix}}/bin/mlr" ./cmd/mlr
+  script: go build -trimpath -ldflags "-s -w" -o "{{prefix}}/bin/mlr" ./cmd/mlr
 
 test:
   - mlr version 2>&1 | tee out


### PR DESCRIPTION
Adds [Miller](https://miller.readthedocs.io) (`mlr`) — like awk/sed/cut/join/sort for CSV, TSV, JSON & other structured data.

Pure-Go, `CGO_ENABLED=0`. Verified on linux/aarch64: builds clean, `mlr version` → `6.18.1`.