### PR TITLE
new(github.com/bitnami-labs/sealed-secrets): kubeseal CLI

### DIFF
--- a/projects/github.com/bitnami-labs/sealed-secrets/package.yml
+++ b/projects/github.com/bitnami-labs/sealed-secrets/package.yml
@@ -1,0 +1,24 @@
+# Sealed Secrets — kubeseal CLI. Encrypts K8s Secrets into SealedSecrets safe to commit; the in-cluster controller decrypts them.
+
+distributable:
+  url: https://github.com/bitnami-labs/sealed-secrets/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: bitnami-labs/sealed-secrets
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - go build -trimpath -ldflags "-s -w -X main.VERSION={{version.tag}}" -o "{{prefix}}/bin/kubeseal" ./cmd/kubeseal
+
+test:
+  - kubeseal --version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/kubeseal

--- a/projects/github.com/bitnami-labs/sealed-secrets/package.yml
+++ b/projects/github.com/bitnami-labs/sealed-secrets/package.yml
@@ -12,9 +12,7 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0
-  script:
-    - mkdir -p "{{prefix}}/bin"
-    - go build -trimpath -ldflags "-s -w -X main.VERSION={{version.tag}}" -o "{{prefix}}/bin/kubeseal" ./cmd/kubeseal
+  script: go build -trimpath -ldflags "-s -w -X main.VERSION={{version.tag}}" -o "{{prefix}}/bin/kubeseal" ./cmd/kubeseal
 
 test:
   - kubeseal --version 2>&1 | tee out


### PR DESCRIPTION
Adds the `kubeseal` client from [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) — encrypts K8s Secrets into SealedSecrets safe to commit.

Pure-Go, `CGO_ENABLED=0`. Verified on linux/aarch64: `kubeseal --version` → `v0.37.0`.