### PR TITLE
new(github.com/amacneil/dbmate): database migration tool

### DIFF
--- a/projects/github.com/amacneil/dbmate/package.yml
+++ b/projects/github.com/amacneil/dbmate/package.yml
@@ -1,0 +1,24 @@
+# dbmate — a lightweight, framework-agnostic database migration tool (PostgreSQL, MySQL, SQLite, ClickHouse) driven by plain SQL files.
+
+distributable:
+  url: https://github.com/amacneil/dbmate/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: amacneil/dbmate
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/dbmate" .
+
+test:
+  - dbmate --version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/dbmate

--- a/projects/github.com/amacneil/dbmate/package.yml
+++ b/projects/github.com/amacneil/dbmate/package.yml
@@ -12,9 +12,7 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0
-  script:
-    - mkdir -p "{{prefix}}/bin"
-    - go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/dbmate" .
+  script: go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/dbmate" .
 
 test:
   - dbmate --version 2>&1 | tee out


### PR DESCRIPTION
Adds [dbmate](https://github.com/amacneil/dbmate) — a lightweight, framework-agnostic DB migration tool (PostgreSQL/MySQL/SQLite/ClickHouse) driven by plain SQL.

Pure-Go, `CGO_ENABLED=0`. Verified on linux/aarch64: `dbmate --version` → `2.33.0`.