### PR TITLE
new(github.com/smallstep/cli): step — zero-trust crypto CLI

### DIFF
--- a/projects/github.com/smallstep/cli/package.yml
+++ b/projects/github.com/smallstep/cli/package.yml
@@ -1,0 +1,24 @@
+# step — Smallstep's CLI for zero-trust crypto: X.509 + SSH certificates, ACME, JWT/JWK/JWS/JWE, OAuth/OIDC. Pairs with step-ca.
+
+distributable:
+  url: https://github.com/smallstep/cli/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: smallstep/cli
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/step" ./cmd/step
+
+test:
+  - step version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/step

--- a/projects/github.com/smallstep/cli/package.yml
+++ b/projects/github.com/smallstep/cli/package.yml
@@ -12,9 +12,7 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0
-  script:
-    - mkdir -p "{{prefix}}/bin"
-    - go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/step" ./cmd/step
+  script: go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/step" ./cmd/step
 
 test:
   - step version 2>&1 | tee out


### PR DESCRIPTION
Adds [`step`](https://smallstep.com/cli) — Smallstep's CLI for X.509 + SSH certs, ACME, JWT/JWK/JWS/JWE, OAuth/OIDC. Pairs with step-ca.

Pure-Go, `CGO_ENABLED=0`. Verified on linux/aarch64: `step version` → `v0.30.6`.