### PR TITLE
new(github.com/smallstep/certificates): step-ca — online CA

### DIFF
--- a/projects/github.com/smallstep/certificates/package.yml
+++ b/projects/github.com/smallstep/certificates/package.yml
@@ -1,0 +1,24 @@
+# step-ca — Smallstep's online certificate authority: private ACME, X.509 + SSH CA, policy + provisioners. Pairs with the step CLI.
+
+distributable:
+  url: https://github.com/smallstep/certificates/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: smallstep/certificates
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/step-ca" ./cmd/step-ca
+
+test:
+  - step-ca version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/step-ca

--- a/projects/github.com/smallstep/certificates/package.yml
+++ b/projects/github.com/smallstep/certificates/package.yml
@@ -12,9 +12,7 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0
-  script:
-    - mkdir -p "{{prefix}}/bin"
-    - go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/step-ca" ./cmd/step-ca
+  script: go build -trimpath -ldflags "-s -w -X main.Version={{version.tag}}" -o "{{prefix}}/bin/step-ca" ./cmd/step-ca
 
 test:
   - step-ca version 2>&1 | tee out


### PR DESCRIPTION
Adds [`step-ca`](https://smallstep.com/docs/step-ca) — Smallstep's online certificate authority: private ACME, X.509 + SSH CA, policy + provisioners.

Pure-Go, `CGO_ENABLED=0`. Verified on linux/aarch64: `step-ca version` → `v0.30.2`.