### PR TITLE
new(atuin.sh): magical shell history

### DIFF
--- a/projects/atuin.sh/package.yml
+++ b/projects/atuin.sh/package.yml
@@ -13,9 +13,7 @@ build:
   dependencies:
     rust-lang.org: "*"
     rust-lang.org/cargo: "*"
-  script:
-    - cargo build --release --locked --bin atuin
-    - install -Dm0755 target/release/atuin "{{prefix}}/bin/atuin"
+  script: cargo install --locked --path crates/atuin --root {{prefix}}
 
 test:
   - atuin --version 2>&1 | tee out

--- a/projects/atuin.sh/package.yml
+++ b/projects/atuin.sh/package.yml
@@ -1,0 +1,25 @@
+# Atuin — magical shell history: a SQLite-backed, fuzzy-searchable,
+# optionally end-to-end-encrypted-syncable replacement for your shell's
+# history, with rich context (exit code, cwd, duration, host).
+
+distributable:
+  url: https://github.com/atuinsh/atuin/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: atuinsh/atuin
+
+build:
+  dependencies:
+    rust-lang.org: "*"
+    rust-lang.org/cargo: "*"
+  script:
+    - cargo build --release --locked --bin atuin
+    - install -Dm0755 target/release/atuin "{{prefix}}/bin/atuin"
+
+test:
+  - atuin --version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/atuin


### PR DESCRIPTION
Adds [Atuin](https://atuin.sh) — SQLite-backed, fuzzy-searchable, syncable shell history.

Rust. Verified on linux/aarch64 (Debian + pkgx rust-lang.org): builds clean,  → 18.16.1.