### PR TITLE
new(mycli.net): MySQL/MariaDB CLI (autocompletion + highlighting)

### DIFF
--- a/projects/mycli.net/package.yml
+++ b/projects/mycli.net/package.yml
@@ -1,0 +1,30 @@
+# mycli — a MySQL/MariaDB CLI with auto-completion and syntax highlighting.
+
+distributable:
+  url: https://github.com/dbcli/mycli/archive/refs/tags/v{{ version }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: dbcli/mycli/tags
+  strip: /^v/
+
+dependencies:
+  pkgx.sh: ">=1"
+
+build:
+  dependencies:
+    python.org: ~3.11
+  env:
+    # GitHub archives carry no .git, so setuptools-scm can't infer the
+    # version — hand it the tag.
+    SETUPTOOLS_SCM_PRETEND_VERSION: "{{version}}"
+  script:
+    - bkpyvenv stage {{prefix}} {{version}}
+    - ${{prefix}}/venv/bin/pip install .
+    - bkpyvenv seal {{prefix}} mycli
+
+provides:
+  - bin/mycli
+
+test:
+  - mycli --version | grep {{version}}

--- a/projects/mycli.net/package.yml
+++ b/projects/mycli.net/package.yml
@@ -1,12 +1,11 @@
 # mycli — a MySQL/MariaDB CLI with auto-completion and syntax highlighting.
 
 distributable:
-  url: https://github.com/dbcli/mycli/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/dbcli/mycli/archive/refs/tags/{{ version.tag }}.tar.gz
   strip-components: 1
 
 versions:
   github: dbcli/mycli/tags
-  strip: /^v/
 
 dependencies:
   pkgx.sh: ">=1"
@@ -27,4 +26,5 @@ provides:
   - bin/mycli
 
 test:
-  - mycli --version | grep {{version}}
+  - mycli --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds [mycli](https://mycli.net) — a MySQL/MariaDB command-line client with auto-completion and syntax highlighting.

Python (`bkpyvenv`). Verified on linux/aarch64 (Debian + pkgx): builds, `mycli --version` → 1.74.0.

`SETUPTOOLS_SCM_PRETEND_VERSION` set because GitHub archives lack the .git setuptools-scm needs.