### PR TITLE
new(influxdata.com/telegraf): plugin-driven metrics agent

### DIFF
--- a/projects/influxdata.com/telegraf/package.yml
+++ b/projects/influxdata.com/telegraf/package.yml
@@ -1,0 +1,29 @@
+# Telegraf — InfluxData's plugin-driven server agent for collecting,
+# processing, aggregating and writing metrics and events. Builds the
+# full plugin set (a large build — the cloud-SDK input plugins are
+# memory-hungry to compile).
+
+distributable:
+  url: https://github.com/influxdata/telegraf/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: influxdata/telegraf
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    # internal.Version is ParseInt'd per dotted field, so pass the bare
+    # numeric version (no leading "v") or `telegraf --version` panics.
+    - go build -trimpath -ldflags "-s -w -X github.com/influxdata/telegraf/internal.Version={{version}}" -o "{{prefix}}/bin/telegraf" ./cmd/telegraf
+
+test:
+  - telegraf --version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/telegraf

--- a/projects/influxdata.com/telegraf/package.yml
+++ b/projects/influxdata.com/telegraf/package.yml
@@ -15,11 +15,7 @@ build:
     go.dev: "*"
   env:
     CGO_ENABLED: 0
-  script:
-    - mkdir -p "{{prefix}}/bin"
-    # internal.Version is ParseInt'd per dotted field, so pass the bare
-    # numeric version (no leading "v") or `telegraf --version` panics.
-    - go build -trimpath -ldflags "-s -w -X github.com/influxdata/telegraf/internal.Version={{version}}" -o "{{prefix}}/bin/telegraf" ./cmd/telegraf
+  script: go build -trimpath -ldflags "-s -w -X github.com/influxdata/telegraf/internal.Version={{version}}" -o "{{prefix}}/bin/telegraf" ./cmd/telegraf
 
 test:
   - telegraf --version 2>&1 | tee out


### PR DESCRIPTION
Adds [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) — InfluxData plugin-driven metrics/events agent.

Pure-Go, full plugin set. Verified on linux/aarch64 (Debian + pkgx, with swap — the cloud-SDK plugins are compile-memory-hungry):  → 1.39.0.

Note: large build;  must be the bare numeric version (no leading v) or --version panics on ParseInt.