### PR TITLE
new(influxdata.com/telegraf-core): lean Telegraf (common plugins)

### DIFF
--- a/projects/influxdata.com/telegraf-core/package.yml
+++ b/projects/influxdata.com/telegraf-core/package.yml
@@ -1,0 +1,33 @@
+# Telegraf (core) — a lean Telegraf built with only the common
+# system / network / HTTP input plugins and the usual outputs. ~66 MB vs
+# ~268 MB for the full plugin set, and it skips the compile-memory-hungry
+# cloud-SDK input plugins (AWS/Azure/Alibaba). For everything, install
+# `influxdata.com/telegraf`.
+
+distributable:
+  url: https://github.com/influxdata/telegraf/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: influxdata/telegraf
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    CGO_ENABLED: 0
+    # Telegraf's `custom` tag compiles ONLY the listed plugins (opt-in).
+    # Curated common set; adjust to taste. Parsers/serializers must be
+    # listed explicitly too, or the build has no format support.
+    TAGS: "custom,inputs.cpu,inputs.mem,inputs.disk,inputs.diskio,inputs.net,inputs.system,inputs.swap,inputs.kernel,inputs.processes,inputs.procstat,inputs.internal,inputs.exec,inputs.file,inputs.tail,inputs.http,inputs.http_listener_v2,inputs.prometheus,inputs.net_response,inputs.ping,inputs.docker,inputs.socket_listener,inputs.syslog,outputs.influxdb_v2,outputs.prometheus_client,outputs.file,outputs.http,outputs.socket_writer,outputs.discard,outputs.health,outputs.exec,parsers.influx,parsers.json,parsers.prometheus,parsers.value,serializers.influx,serializers.json,serializers.prometheus,processors.enum,processors.regex"
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    # bare numeric version (no "v") — internal.Version is ParseInt'd.
+    - go build -trimpath -tags "$TAGS" -ldflags "-s -w -X github.com/influxdata/telegraf/internal.Version={{version}}" -o "{{prefix}}/bin/telegraf" ./cmd/telegraf
+
+test:
+  - telegraf --version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/telegraf

--- a/projects/influxdata.com/telegraf-core/package.yml
+++ b/projects/influxdata.com/telegraf-core/package.yml
@@ -19,11 +19,48 @@ build:
     # Telegraf's `custom` tag compiles ONLY the listed plugins (opt-in).
     # Curated common set; adjust to taste. Parsers/serializers must be
     # listed explicitly too, or the build has no format support.
-    TAGS: "custom,inputs.cpu,inputs.mem,inputs.disk,inputs.diskio,inputs.net,inputs.system,inputs.swap,inputs.kernel,inputs.processes,inputs.procstat,inputs.internal,inputs.exec,inputs.file,inputs.tail,inputs.http,inputs.http_listener_v2,inputs.prometheus,inputs.net_response,inputs.ping,inputs.docker,inputs.socket_listener,inputs.syslog,outputs.influxdb_v2,outputs.prometheus_client,outputs.file,outputs.http,outputs.socket_writer,outputs.discard,outputs.health,outputs.exec,parsers.influx,parsers.json,parsers.prometheus,parsers.value,serializers.influx,serializers.json,serializers.prometheus,processors.enum,processors.regex"
-  script:
-    - mkdir -p "{{prefix}}/bin"
-    # bare numeric version (no "v") — internal.Version is ParseInt'd.
-    - go build -trimpath -tags "$TAGS" -ldflags "-s -w -X github.com/influxdata/telegraf/internal.Version={{version}}" -o "{{prefix}}/bin/telegraf" ./cmd/telegraf
+    TAGS: >
+      custom,
+      inputs.cpu,
+      inputs.mem,
+      inputs.disk,
+      inputs.diskio,
+      inputs.net,
+      inputs.system,
+      inputs.swap,
+      inputs.kernel,
+      inputs.processes,
+      inputs.procstat,
+      inputs.internal,
+      inputs.exec,
+      inputs.file,
+      inputs.tail,
+      inputs.http,
+      inputs.http_listener_v2,
+      inputs.prometheus,
+      inputs.net_response,
+      inputs.ping,
+      inputs.docker,
+      inputs.socket_listener,
+      inputs.syslog,
+      outputs.influxdb_v2,
+      outputs.prometheus_client,
+      outputs.file,
+      outputs.http,
+      outputs.socket_writer,
+      outputs.discard,
+      outputs.health,
+      outputs.exec,
+      parsers.influx,
+      parsers.json,
+      parsers.prometheus,
+      parsers.value,
+      serializers.influx,
+      serializers.json,
+      serializers.prometheus,
+      processors.enum,
+      processors.regex
+  script: go build -trimpath -tags "$TAGS" -ldflags "-s -w -X github.com/influxdata/telegraf/internal.Version={{version}}" -o "{{prefix}}/bin/telegraf" ./cmd/telegraf
 
 test:
   - telegraf --version 2>&1 | tee out

--- a/projects/influxdata.com/telegraf-core/package.yml
+++ b/projects/influxdata.com/telegraf-core/package.yml
@@ -60,7 +60,7 @@ build:
       serializers.prometheus,
       processors.enum,
       processors.regex
-  script: go build -trimpath -tags "$TAGS" -ldflags "-s -w -X github.com/influxdata/telegraf/internal.Version={{version}}" -o "{{prefix}}/bin/telegraf" ./cmd/telegraf
+  script: go build -trimpath -tags "$(echo $TAGS | sed 's/, /,/g')" -ldflags "-s -w -X github.com/influxdata/telegraf/internal.Version={{version}}" -o "{{prefix}}/bin/telegraf" ./cmd/telegraf
 
 test:
   - telegraf --version 2>&1 | tee out


### PR DESCRIPTION
A lean Telegraf variant for flexibility/footprint: built with the  tag + a curated common-plugin set.

**~66 MB vs ~268 MB** for the full build (#13306), and it skips the compile-memory-hungry cloud-SDK input plugins (no OOM). For the complete plugin set, install .

Verified on linux/aarch64 (Debian + pkgx go.dev): builds in seconds, 22 input plugins,  → 1.39.0. Plugin allowlist is adjustable.