### PR TITLE
new(clickhouse.com): column-oriented OLAP database (vendored)

### DIFF
--- a/projects/clickhouse.com/package.yml
+++ b/projects/clickhouse.com/package.yml
@@ -1,0 +1,54 @@
+# ClickHouse — fast, open-source, column-oriented OLAP database. Vendors
+# upstream's official static Linux builds and macOS binaries (a
+# from-source build is a multi-hour C++ compile). One `clickhouse`
+# multi-tool binary: `clickhouse local|client|server|keeper`.
+
+distributable: ~
+
+versions:
+  github: ClickHouse/ClickHouse/tags
+  match: /^v\d+\.\d+\.\d+\.\d+-stable$/
+  strip:
+    - /^v/
+    - /-stable$/
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+warnings:
+  - vendored
+
+build:
+  dependencies:
+    curl.se: "*"
+    gnu.org/tar: "*"
+  env:
+    linux/x86-64:
+      ASSET: clickhouse-common-static-{{version}}-amd64.tgz
+    linux/aarch64:
+      ASSET: clickhouse-common-static-{{version}}-arm64.tgz
+    darwin/x86-64:
+      ASSET: clickhouse-macos
+    darwin/aarch64:
+      ASSET: clickhouse-macos-aarch64
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - |
+      URL="https://github.com/ClickHouse/ClickHouse/releases/download/{{version.tag}}/$ASSET"
+      # Linux ships a static tarball (binary under usr/bin); macOS ships
+      # the raw binary directly.
+      case "$ASSET" in
+        *.tgz) curl -Lf "$URL" | tar xzOf - "clickhouse-common-static-{{version}}/usr/bin/clickhouse" > "{{prefix}}/bin/clickhouse" ;;
+        *)     curl -Lf "$URL" -o "{{prefix}}/bin/clickhouse" ;;
+      esac
+      chmod +x "{{prefix}}/bin/clickhouse"
+
+test:
+  - clickhouse --version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/clickhouse

--- a/projects/clickhouse.com/package.yml
+++ b/projects/clickhouse.com/package.yml
@@ -12,12 +12,6 @@ versions:
     - /^v/
     - /-stable$/
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
 warnings:
   - vendored
 
@@ -35,16 +29,14 @@ build:
     darwin/aarch64:
       ASSET: clickhouse-macos-aarch64
   script:
-    - mkdir -p "{{prefix}}/bin"
-    - |
-      URL="https://github.com/ClickHouse/ClickHouse/releases/download/{{version.tag}}/$ASSET"
+    - URL="https://github.com/ClickHouse/ClickHouse/releases/download/{{version.tag}}/$ASSET"
       # Linux ships a static tarball (binary under usr/bin); macOS ships
       # the raw binary directly.
-      case "$ASSET" in
-        *.tgz) curl -Lf "$URL" | tar xzOf - "clickhouse-common-static-{{version}}/usr/bin/clickhouse" > "{{prefix}}/bin/clickhouse" ;;
-        *)     curl -Lf "$URL" -o "{{prefix}}/bin/clickhouse" ;;
-      esac
-      chmod +x "{{prefix}}/bin/clickhouse"
+    - run: curl -Lf "$URL" | tar xzOf - "clickhouse-common-static-{{version}}/usr/bin/clickhouse" > clickhouse
+      if: linux
+    - run: curl -Lf "$URL" -o clickhouse
+      if: darwin
+    - install -Dm755 clickhouse {{prefix}}/bin/clickhouse
 
 test:
   - clickhouse --version 2>&1 | tee out


### PR DESCRIPTION
Adds [ClickHouse](https://clickhouse.com) — fast column-oriented OLAP database.

## Why vendored
A from-source ClickHouse build is a **multi-hour C++ compile** (LLVM/clang toolchain, huge translation units, very high RAM/disk) — impractical on standard CI runners. Vendoring upstream's official static Linux builds + macOS binaries gives a working `clickhouse` multi-tool binary now, on all 4 platforms.

Verified on linux/aarch64 (Debian): extracts the 677 MB static binary, `clickhouse --version` → 26.4.4.38.

## Path to a from-source recipe
ClickHouse builds with CMake + Ninja against a specific clang. A from-source recipe would need:
1. `build.dependencies: { cmake.org, ninja-build.org, llvm.org (pinned major), … }`.
2. A configure step disabling the bundled-everything default to fit runner resources, and almost certainly a **much larger CI timeout** (hours) — the main blocker.

Given the build cost and that upstream ships reproducible official binaries, vendored is the pragmatic choice here.