### PR TITLE
new(tcl-lang.org/tk/v8): Tk 8.6 GUI toolkit

### DIFF
--- a/projects/tcl-lang.org/tk/v8/package.yml
+++ b/projects/tcl-lang.org/tk/v8/package.yml
@@ -1,0 +1,63 @@
+# Tk 8.6 — legacy GUI toolkit.
+#
+# Companion to tcl-lang.org/v8. Tk 9.0 has a broken `minizip` target
+# in its Makefile that fails build; 8.6.x stays buildable. Required
+# by git-gui, python-tk@3.9, and other legacy Tcl GUIs.
+
+distributable:
+  url: https://downloads.sourceforge.net/project/tcl/Tcl/{{version}}/tk{{version}}-src.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://www.tcl-lang.org/software/tcltk/download.html
+  match: /tk8\.6\.\d+-src\.tar\.gz/
+  strip:
+    - /^tk/
+    - /-src\.tar\.gz/
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+dependencies:
+  tcl-lang.org/v8: '*'
+  freedesktop.org/pkg-config: '*'
+  linux:
+    x.org/x11: '*'
+    x.org/exts: '*'
+    freetype.org: '*'
+
+build:
+  working-directory: unix
+  darwin:
+    working-directory: macosx
+
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+    - run: |
+        cd "{{prefix}}/bin"
+        [ ! -e wish ] && ln -sf "wish{{version.major}}.{{version.minor}}" wish || true
+
+  env:
+    CPPFLAGS: -I{{deps.tcl-lang.org/v8.prefix}}/include
+    ARGS:
+      - --prefix={{prefix}}
+      - --exec-prefix={{prefix}}
+      - --with-tcl={{deps.tcl-lang.org/v8.prefix}}/lib
+      - --enable-shared
+      - --enable-threads
+      - --enable-64bit
+    darwin:
+      ARGS:
+        - --enable-aqua
+
+test:
+  - test -f "{{prefix}}/lib/libtk{{version.major}}.{{version.minor}}.dylib" -o -f "{{prefix}}/lib/libtk{{version.major}}.{{version.minor}}.so"
+
+provides:
+  - bin/wish
+  - bin/wish{{version.major}}.{{version.minor}}


### PR DESCRIPTION
Split from #13081. Tk 8.6 GUI toolkit; companion to `tcl-lang.org/v8`.

**Depends on `tcl-lang.org/v8` (#13081) — merge that first** so Tcl's bottle is published (otherwise the build 404s resolving it; that co-dependency is why the combined PR's Tk checks were red).