### PR TITLE
new(x.org/xserver): X.Org X server

### DIFF
--- a/projects/x.org/xserver/package.yml
+++ b/projects/x.org/xserver/package.yml
@@ -89,7 +89,9 @@ build:
     # vm86), xres / xinerama / xv / dpms (standard X extensions),
     # pciaccess+drm (modern DDX needs DRM/KMS to find outputs).
     - meson setup .. $MESON_ARGS
-    - ninja --jobs {{ hw.concurrency }}
+    # ninja takes -j (short form only); `--jobs` is unrecognized and makes
+    # ninja print its usage and exit non-zero.
+    - ninja -j {{ hw.concurrency }}
     - ninja install
 
   env:

--- a/projects/x.org/xserver/package.yml
+++ b/projects/x.org/xserver/package.yml
@@ -85,9 +85,15 @@ build:
     # - xselinux=false : SELinux integration, Linux-distro-specific.
     # - docs=false / devel-docs=false : avoid pulling xmlto+xsltproc.
     #
-    # Enabled: xorg=true (the headline binary), int10=stub (no x86emu
-    # vm86), xres / xinerama / xv / dpms (standard X extensions),
-    # pciaccess+drm (modern DDX needs DRM/KMS to find outputs).
+    # Enabled: xorg=true (the headline binary), int10=x86emu (the portable
+    # software real-mode emulator, works on both x86-64 and aarch64),
+    # xres / xinerama / xv / dpms (standard X extensions), pciaccess+drm
+    # (modern DDX needs DRM/KMS to find outputs).
+    #
+    # NB: int10=stub is not usable here — on x86-64 meson still compiles
+    # xf86int10.c (which defines xf86InitInt10) alongside stub.c (which
+    # redefines it), and lld rejects the duplicate symbol. x86emu links
+    # cleanly and is the config every distro ships for cross-arch VBIOS.
     - meson setup .. $MESON_ARGS
     # ninja takes -j (short form only); `--jobs` is unrecognized and makes
     # ninja print its usage and exit non-zero.
@@ -118,7 +124,7 @@ build:
       - -Ddevel-docs=false
       - -Dxkb_dir={{prefix}}/share/X11/xkb
       - -Dxkb_output_dir={{prefix}}/var/lib/xkb
-      - -Dint10=stub
+      - -Dint10=x86emu
       - -Ddri1=false                  # legacy DRI1, no consumers
       - -Ddri2=true
       - -Ddri3=true

--- a/projects/x.org/xserver/package.yml
+++ b/projects/x.org/xserver/package.yml
@@ -1,0 +1,136 @@
+# X.Org X server — the reference X11 display server.
+#
+# Provides `Xorg`, the main DDX (Device Dependent X) binary that
+# drives the local display via the kernel's DRM/KMS stack on Linux.
+# Companion to `x.org/x11` (libX11), `x.org/protocol` (xorgproto),
+# and the rest of `x.org/*` libraries already in the pantry.
+#
+# Supersedes the abandoned WIP at pkgxdev/pantry#7474 (autotools-era,
+# Debian-multiarch path hardcoded) — modern xserver (>= 21.1.x) is
+# meson-built and the upstream autotools path is gone.
+#
+# Linux-only. macOS uses XQuartz which is a separate distribution;
+# Windows uses Xwin via Cygwin (also out of scope here). Matches
+# arch's `arch=('x86_64')` shape — they don't ship Xorg for darwin
+# either.
+
+distributable:
+  url: https://www.x.org/archive/individual/xserver/xorg-server-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://www.x.org/archive/individual/xserver/
+  match: /xorg-server-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /^xorg-server-/
+    - /\.tar\.gz$/
+
+display-name: Xorg server
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+
+dependencies:
+  pixman.org: '*'
+  xkbcommon.org: '*'
+  github.com/anholt/libepoxy: '*'
+  dri.freedesktop.org: '*'             # libdrm
+  sourceforge.net/libtirpc: '*'        # secure-rpc (XDM authentication)
+  x.org/protocol: '*'                  # xorgproto
+  x.org/x11: '*'
+  x.org/xkbfile: '*'
+  x.org/libxfont2: '*'                 # builtin server font rasterizer
+  x.org/pciaccess: '*'
+  x.org/xau: '*'
+  x.org/xdmcp: '*'
+  x.org/xshmfence: '*'
+  x.org/xtrans: '*'
+  x.org/libcvt: '*'                    # CRTC mode computation
+  x.org/exts: '*'                      # xext / xorgxext
+
+build:
+  dependencies:
+    mesonbuild.com: '*'
+    ninja-build.org: '*'
+    freedesktop.org/pkg-config: '*'
+    python.org: '>=3.9'                # meson requires python 3.7+; pin slightly higher
+    x.org/util-macros: '*'
+    x.org/font-util: '*'               # provides fontutil.pc for FontPath computation
+
+  # Out-of-source meson build under ./build, matching arch / nixpkgs
+  # convention. brewkit drops the working-directory into the source
+  # tree, so `..` is the source root from inside `build/`.
+  working-directory: build
+
+  script:
+    # Note on disabled features (vs. arch's PKGBUILD which enables):
+    #
+    # - glamor=false   : requires libGL / mesa, not yet in pantry. Xorg
+    #                    still works as an unaccelerated 2D server; GL
+    #                    rendering is fallback (software). Re-enable
+    #                    once mesa3d.org's recipe is ready.
+    # - xephyr=false   : separate nested-X test server, needs full
+    #                    set of xcb-util-* libs. Out of scope.
+    # - xnest=false    : same.
+    # - xvfb=false     : separate headless server, can be split into
+    #                    a sibling sub-package later.
+    # - libunwind=false: optional crash-dump symbolizer, no recipe.
+    # - udev=false     : systemd-libs not in pantry runtime closure
+    #                    yet. Xorg loads device config via legacy
+    #                    paths instead.
+    # - systemd_logind=false : same reason.
+    # - suid_wrapper=false : not needed when not running as
+    #                    /usr/lib/Xorg + setuid root.
+    # - xselinux=false : SELinux integration, Linux-distro-specific.
+    # - docs=false / devel-docs=false : avoid pulling xmlto+xsltproc.
+    #
+    # Enabled: xorg=true (the headline binary), int10=stub (no x86emu
+    # vm86), xres / xinerama / xv / dpms (standard X extensions),
+    # pciaccess+drm (modern DDX needs DRM/KMS to find outputs).
+    - meson setup .. $MESON_ARGS
+    - ninja --jobs {{ hw.concurrency }}
+    - ninja install
+
+  env:
+    MESON_ARGS:
+      - --prefix={{prefix}}
+      - --buildtype=release
+      - -Dxorg=true
+      - -Dxephyr=false
+      - -Dxnest=false
+      - -Dxvfb=false
+      - -Dxwin=false
+      - -Dxquartz=false
+      - -Dglamor=false
+      - -Dudev=false
+      - -Dudev_kms=false
+      - -Dsystemd_logind=false
+      - -Dlibunwind=false
+      - -Dxselinux=false
+      - -Dsuid_wrapper=false
+      - -Ddtrace=false
+      - -Dlinux_apm=false
+      - -Dlinux_acpi=false
+      - -Ddocs=false
+      - -Ddevel-docs=false
+      - -Dxkb_dir={{prefix}}/share/X11/xkb
+      - -Dxkb_output_dir={{prefix}}/var/lib/xkb
+      - -Dint10=stub
+      - -Ddri1=false                  # legacy DRI1, no consumers
+      - -Ddri2=true
+      - -Ddri3=true
+      - -Dxf86-input-inputtest=false  # test driver, not user-facing
+
+provides:
+  - bin/Xorg
+
+test:
+  # Xorg uses single-dash flags from the legacy X11 CLI tradition.
+  # `-version` prints to stderr and exits non-zero on older builds,
+  # so be lenient about the exit code; succeed if the X.Org Foundation
+  # banner appears.
+  - run: |
+      out=$(Xorg -version 2>&1 || true)
+      echo "$out" | head -10
+      echo "$out" | grep -qi "x.org x server"


### PR DESCRIPTION
Split from #13103. The X.Org X server (Xorg, meson build).

**Depends on `x.org/font-util` (#13103) — merge that first** so font-util's bottle is published (otherwise the build 404s resolving it).