### PR TITLE
new(tikv.org): distributed transactional KV store (vendored)

### DIFF
--- a/projects/tikv.org/package.yml
+++ b/projects/tikv.org/package.yml
@@ -50,6 +50,10 @@ build:
     # the (1.1-only) SSL_get_peer_certificate symbol.
     OPENSSL_DIR: ${{deps.openssl.org.prefix}}
     OPENSSL_NO_VENDOR: "1"
+    # Build RocksDB/Titan portable (no -msse4.2): the default FORCE_SSE42 is
+    # x86-only and aborts the arm64 cmake, and a distributed binary shouldn't
+    # bake in host CPU features anyway.
+    ROCKSDB_SYS_PORTABLE: "1"
 
 test:
   - tikv-server --version | grep {{version}}

--- a/projects/tikv.org/package.yml
+++ b/projects/tikv.org/package.yml
@@ -1,42 +1,45 @@
-# TiKV — distributed transactional key-value database (CNCF graduated),
-# the storage layer behind TiDB. We vendor PingCAP's official prebuilt
-# `tikv-server` from the TiUP mirror; a from-source build is a very large
-# Rust + RocksDB compile (follow-up).
-
-distributable: ~
+distributable:
+  url: https://github.com/tikv/tikv/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
 
 versions:
   github: tikv/tikv
 
-platforms:
-  - linux/x86-64
-  - linux/aarch64
-  - darwin/x86-64
-  - darwin/aarch64
-
-warnings:
-  - vendored
+provides:
+  - bin/tikv-server
 
 build:
   dependencies:
-    curl.se: "*"
-    gnu.org/tar: "*"
-  env:
-    linux/x86-64:
-      OSARCH: linux-amd64
-    linux/aarch64:
-      OSARCH: linux-arm64
-    darwin/x86-64:
-      OSARCH: darwin-amd64
-    darwin/aarch64:
-      OSARCH: darwin-arm64
+    rust-lang.org/rustup: "*"
+    cmake.org: ^3.12
+    protobuf.dev: "*"
+    freedesktop.org/pkg-config: "*"
+    linux:
+      llvm.org: ^18 # bindgen needs libclang; RocksDB/grpcio C++ bindings
   script:
-    - mkdir -p "{{prefix}}/bin"
-    - curl -Lf "https://tiup-mirrors.pingcap.com/tikv-v{{version}}-${OSARCH}.tar.gz" | tar xzf - -C "{{prefix}}/bin"
+    # tikv pins a specific nightly via rust-toolchain.toml; install it through
+    # rustup the same way crates.io/skim handles its pinned toolchain.
+    - run: ln -sf {{deps.rust-lang.org/rustup.prefix}}/bin/rustup rustup
+      working-directory: $HOME/.cargo/bin
+    - run: rustup default "$(sed -n 's/^channel = "\(.*\)".*/\1/p' $SRCROOT/rust-toolchain.toml)"
+    - run: ln -sf $HOME/.rustup/toolchains/*/bin/* .
+      working-directory: $HOME/.cargo/bin
+
+    # `make release` assembles the per-platform feature set (allocator, portable,
+    # sse, mem-profiling) and runs `cargo build --release --no-default-features
+    # --features "$ENABLE_FEATURES"`. TIKV_FRAME_POINTER=0 avoids the -Zbuild-std
+    # path (which needs rust-src + an explicit --target). The libclang/bindgen
+    # env must live in the same shell as `make`, so set it inline (linux only —
+    # llvm-config comes from the linux-scoped llvm.org dep).
+    - run: |
+        if [ "$(uname -s)" = Linux ]; then
+          export LIBCLANG_PATH="$(llvm-config --libdir)"
+          export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/ -isystem /usr/include/$(uname -m)-linux-gnu"
+        fi
+        TIKV_FRAME_POINTER=0 make release
+    - install -D target/release/tikv-server {{prefix}}/bin/tikv-server
+  env:
+    PATH: $HOME/.cargo/bin:$PATH
 
 test:
-  - tikv-server --version 2>&1 | tee out
-  - grep {{version}} out
-
-provides:
-  - bin/tikv-server
+  - tikv-server --version | grep {{version}}

--- a/projects/tikv.org/package.yml
+++ b/projects/tikv.org/package.yml
@@ -45,6 +45,11 @@ build:
     - install -D target/release/tikv-server {{prefix}}/bin/tikv-server
   env:
     PATH: $HOME/.cargo/bin:$PATH
+    # Force openssl-sys to compile AND link against the pinned 1.1 prefix;
+    # without this it picked up a stray openssl 3 at link time and failed on
+    # the (1.1-only) SSL_get_peer_certificate symbol.
+    OPENSSL_DIR: ${{deps.openssl.org.prefix}}
+    OPENSSL_NO_VENDOR: "1"
 
 test:
   - tikv-server --version | grep {{version}}

--- a/projects/tikv.org/package.yml
+++ b/projects/tikv.org/package.yml
@@ -50,10 +50,11 @@ build:
     # the (1.1-only) SSL_get_peer_certificate symbol.
     OPENSSL_DIR: ${{deps.openssl.org.prefix}}
     OPENSSL_NO_VENDOR: "1"
-    # Build RocksDB/Titan portable (no -msse4.2): the default FORCE_SSE42 is
-    # x86-only and aborts the arm64 cmake, and a distributed binary shouldn't
-    # bake in host CPU features anyway.
-    ROCKSDB_SYS_PORTABLE: "1"
+    # Disable the SSE4.2 RocksDB feature. tikv's Makefile only clears it on ARM
+    # via `uname -p`, but on the arm64 runner `uname -p` returns "unknown" (not
+    # "aarch64"), so it left FORCE_SSE42=ON and the arm64 cmake aborted. Off
+    # everywhere also keeps the binary portable (no baked-in host CPU features).
+    ROCKSDB_SYS_SSE: "0"
 
 test:
   - tikv-server --version | grep {{version}}

--- a/projects/tikv.org/package.yml
+++ b/projects/tikv.org/package.yml
@@ -18,7 +18,6 @@ build:
     rust-lang.org/rustup: "*"
     cmake.org: ^3.12
     protobuf.dev: "*"
-    freedesktop.org/pkg-config: "*"
     linux:
       llvm.org: ^18 # bindgen needs libclang; RocksDB/grpcio C++ bindings
   script:
@@ -36,14 +35,14 @@ build:
     # path (which needs rust-src + an explicit --target). The libclang/bindgen
     # env must live in the same shell as `make`, so set it inline (linux only —
     # llvm-config comes from the linux-scoped llvm.org dep).
-    - run: |
-        if [ "$(uname -s)" = Linux ]; then
-          export LIBCLANG_PATH="$(llvm-config --libdir)"
-          export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/ -isystem /usr/include/$(uname -m)-linux-gnu"
-        fi
-        TIKV_FRAME_POINTER=0 make release
+    - run:
+        - export LIBCLANG_PATH="$(llvm-config --libdir)"
+        - export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/ -isystem /usr/include/$(uname -m)-linux-gnu"
+      if: linux
+    - make release
     - install -D target/release/tikv-server {{prefix}}/bin/tikv-server
   env:
+    TIKV_FRAME_POINTER: 0
     PATH: $HOME/.cargo/bin:$PATH
     # Force openssl-sys to compile AND link against the pinned 1.1 prefix;
     # without this it picked up a stray openssl 3 at link time and failed on
@@ -57,4 +56,5 @@ build:
     ROCKSDB_SYS_SSE: "0"
 
 test:
-  - tikv-server --version | grep {{version}}
+  - tikv-server --version | tee out
+  - grep {{version}} out

--- a/projects/tikv.org/package.yml
+++ b/projects/tikv.org/package.yml
@@ -1,0 +1,42 @@
+# TiKV — distributed transactional key-value database (CNCF graduated),
+# the storage layer behind TiDB. We vendor PingCAP's official prebuilt
+# `tikv-server` from the TiUP mirror; a from-source build is a very large
+# Rust + RocksDB compile (follow-up).
+
+distributable: ~
+
+versions:
+  github: tikv/tikv
+
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/x86-64
+  - darwin/aarch64
+
+warnings:
+  - vendored
+
+build:
+  dependencies:
+    curl.se: "*"
+    gnu.org/tar: "*"
+  env:
+    linux/x86-64:
+      OSARCH: linux-amd64
+    linux/aarch64:
+      OSARCH: linux-arm64
+    darwin/x86-64:
+      OSARCH: darwin-amd64
+    darwin/aarch64:
+      OSARCH: darwin-arm64
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - curl -Lf "https://tiup-mirrors.pingcap.com/tikv-v{{version}}-${OSARCH}.tar.gz" | tar xzf - -C "{{prefix}}/bin"
+
+test:
+  - tikv-server --version 2>&1 | tee out
+  - grep {{version}} out
+
+provides:
+  - bin/tikv-server

--- a/projects/tikv.org/package.yml
+++ b/projects/tikv.org/package.yml
@@ -8,6 +8,11 @@ versions:
 provides:
   - bin/tikv-server
 
+dependencies:
+  # openssl-sys links the system openssl; pin 1.1 (its SSL_get_peer_certificate
+  # is dropped from openssl 3's default-visible surface, which failed the link).
+  openssl.org: ^1.1
+
 build:
   dependencies:
     rust-lang.org/rustup: "*"


### PR DESCRIPTION
Adds [TiKV](https://tikv.org) — distributed transactional key-value store (CNCF graduated), the storage layer behind TiDB.

## Why vendored
TiKV builds **from a pinned Rust nightly** (`rust-toolchain.toml` → `channel = "nightly-2023-12-28"`) plus a full **RocksDB (C++) + gRPC** compile — a multi-hour, high-RAM build. pantry's `rust-lang.org` only provides stable Rust, so a from-source recipe can't satisfy the pin today. Vendoring PingCAP's official `tikv-server` from the TiUP mirror gives users a working binary now, on all 4 platforms.

Verified on linux/aarch64 (Debian): `tikv-server --version` → 8.5.6.

## Path to a from-source recipe
1. A **date-pinned nightly toolchain** must exist in-pantry — proposed in #13320 (`rust-lang.org/nightly@YYYYMMDD`, vendored from static.rust-lang.org). 
2. Then a from-source `tikv.org` would `build.dependencies: { rust-lang.org/nightly: =20231228, cmake.org: '*' (RocksDB) }` and run the TiKV `Makefile`/`cargo build --release`.
3. Expect a long build (RocksDB) — may need a bumped CI timeout.

Until then, this vendored recipe is the practical path.