### PR TITLE
new(github.com/rhysd/actionlint): actionlint 1.7.12

### DIFF
--- a/projects/github.com/rhysd/actionlint/package.yml
+++ b/projects/github.com/rhysd/actionlint/package.yml
@@ -1,16 +1,9 @@
 distributable:
-  url: https://github.com/rhysd/actionlint/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/rhysd/actionlint/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: rhysd/actionlint/tags
-  strip: /^v/
-
-platforms:
-  - darwin/aarch64
-  - darwin/x86-64
-  - linux/aarch64
-  - linux/x86-64
 
 provides:
   - bin/actionlint
@@ -18,16 +11,17 @@ provides:
 build:
   dependencies:
     go.dev: '*'
-  script: |
-    go build -trimpath -ldflags="$LDFLAGS" -o {{prefix}}/bin/actionlint ./cmd/actionlint
+  script: go build -trimpath -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/actionlint ./cmd/actionlint
   env:
     CGO_ENABLED: 0
-    LDFLAGS:
+    GO_LDFLAGS:
       - -s
       - -w
       - -X github.com/rhysd/actionlint.version={{version}}
     linux:
-      LDFLAGS:
+      GO_LDFLAGS:
         - -buildmode=pie
 
-test: test "$(actionlint -version | head -1)" = "{{version}}"
+test:
+  - actionlint -version | tee out
+  - test "$(head -1 out)" = "{{version}}"

--- a/projects/github.com/rhysd/actionlint/package.yml
+++ b/projects/github.com/rhysd/actionlint/package.yml
@@ -1,0 +1,33 @@
+distributable:
+  url: https://github.com/rhysd/actionlint/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: rhysd/actionlint/tags
+  strip: /^v/
+
+platforms:
+  - darwin/aarch64
+  - darwin/x86-64
+  - linux/aarch64
+  - linux/x86-64
+
+provides:
+  - bin/actionlint
+
+build:
+  dependencies:
+    go.dev: '*'
+  script: |
+    go build -trimpath -ldflags="$LDFLAGS" -o {{prefix}}/bin/actionlint ./cmd/actionlint
+  env:
+    CGO_ENABLED: 0
+    LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/rhysd/actionlint.version={{version}}
+    linux:
+      LDFLAGS:
+        - -buildmode=pie
+
+test: test "$(actionlint -version | head -1)" = "{{version}}"


### PR DESCRIPTION
actionlint is a static checker for GitHub Actions workflow files.

Built **from source** from the upstream tagged tarball with the `go.dev` toolchain — a single static binary via `go build -trimpath -ldflags "-s -w -X github.com/rhysd/actionlint.version={{version}}" ./cmd/actionlint`, `CGO_ENABLED=0` (`-buildmode=pie` on linux). darwin + linux, aarch64 + x86-64.

Test asserts the injected version: `actionlint -version | head -1` equals the package version.