### PR TITLE
new(x.org/xext): libXext 1.3.7

### DIFF
--- a/projects/x.org/xext/package.yml
+++ b/projects/x.org/xext/package.yml
@@ -1,0 +1,35 @@
+distributable:
+  url: https://www.x.org/archive/individual/lib/libXext-{{version}}.tar.xz
+  strip-components: 1
+
+versions:
+  url: https://xorg.freedesktop.org/archive/individual/lib/
+  match: /libXext-\d+\.\d+(\.\d+)?\.tar\.xz/
+  strip:
+    - /libXext-/
+    - /.tar.xz/
+
+dependencies:
+  x.org/x11: '*'
+  x.org/protocol: '*'
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make --jobs {{ hw.concurrency }} install
+
+  env:
+    ARGS:
+      - --prefix="{{prefix}}"
+      - --disable-dependency-tracking
+      - --disable-silent-rules
+      - --sysconfdir={{pkgx.prefix}}/x.org/etc
+      - --localstatedir={{pkgx.prefix}}/x.org/var
+
+test:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+  script: pkg-config --modversion xext | grep {{version}}


### PR DESCRIPTION
Adds **libXext**, the X11 common extensions library — the one remaining gap in pantry's otherwise-complete X.org client stack.

From-source via the standard X.org autotools flow, mirroring the sibling x.org libraries (libXfixes / libXrender / libXrandr). Depends only on libX11 (`x.org/x11`) and xorgproto (`x.org/protocol`).

(Surfaced while packaging PyQt5 #13064: the manylinux Qt wheel dlopens libXext among the rest of the x.org stack.)