### PR TITLE
new(atuin.sh): atuin 18.16.1

### DIFF
--- a/projects/atuin.sh/package.yml
+++ b/projects/atuin.sh/package.yml
@@ -1,0 +1,25 @@
+distributable:
+  url: https://github.com/atuinsh/atuin/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: atuinsh/atuin
+  strip: /^v/
+
+build:
+  dependencies:
+    rust-lang.org: '*'
+    rust-lang.org/cargo: '*'
+  script:
+    - cargo install $CARGO_ARGS --path crates/atuin
+  env:
+    CARGO_ARGS:
+      - --locked
+      - --root="{{prefix}}"
+
+provides:
+  - bin/atuin
+
+test:
+  - atuin --version | grep {{version}}
+  - atuin -h


### PR DESCRIPTION
Adds **atuin** — a syncing, searchable Ctrl-R shell-history replacement.

Built **from source** via `cargo install --locked --path crates/atuin` (the workspace's binary crate), installing `bin/atuin`. atuin uses edition 2024 and pins a recent `rust-version`, so it needs a current Rust toolchain (`rust-lang.org: '*'` resolves to the newest pantry rust).