### PR TITLE
new(github.com/google-gemini/gemini-cli): gemini-cli 0.46.0

### DIFF
--- a/projects/github.com/google-gemini/gemini-cli/package.yml
+++ b/projects/github.com/google-gemini/gemini-cli/package.yml
@@ -1,0 +1,29 @@
+distributable:
+  url: https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-{{version}}.tgz
+  strip-components: 1
+
+display-name: gemini-cli
+
+versions:
+  npm: "@google/gemini-cli"
+
+dependencies:
+  nodejs.org: ^20
+
+build:
+  dependencies:
+    npmjs.com: "*"
+  script:
+    - npm i $ARGS .
+  env:
+    ARGS:
+      - --global
+      - --prefix={{prefix}}
+      - --install-links
+      - --unsafe-perm
+
+provides:
+  - bin/gemini
+
+test:
+  - gemini --version | grep {{version}}

--- a/projects/github.com/google-gemini/gemini-cli/package.yml
+++ b/projects/github.com/google-gemini/gemini-cli/package.yml
@@ -13,8 +13,7 @@ dependencies:
 build:
   dependencies:
     npmjs.com: "*"
-  script:
-    - npm i $ARGS .
+  script: npm i $ARGS .
   env:
     ARGS:
       - --global
@@ -26,4 +25,5 @@ provides:
   - bin/gemini
 
 test:
-  - gemini --version | grep {{version}}
+  - gemini --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds **Google's Gemini CLI** (`@google/gemini-cli`), a Node.js CLI for interacting with Gemini models from the terminal.

Installed from the npm registry tarball via the standard scoped-npm-global idiom, exposing `bin/gemini`; versions track npm dist-tags. Pure-JS — linux + darwin, all arches, `nodejs.org: ^20`. `gemini --version` verified offline (no auth needed).