### PR TITLE
new(asdf-vm.com): asdf 0.19.0

### DIFF
--- a/projects/asdf-vm.com/package.yml
+++ b/projects/asdf-vm.com/package.yml
@@ -1,10 +1,9 @@
 distributable:
-  url: https://github.com/asdf-vm/asdf/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/asdf-vm/asdf/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: asdf-vm/asdf
-  strip: /^v/
 
 provides:
   - bin/asdf
@@ -12,23 +11,24 @@ provides:
 build:
   dependencies:
     go.dev: ^1.24
-  script:
-    - go build $ARGS -ldflags="$LDFLAGS" ./cmd/asdf
+  script: go build $ARGS -ldflags="$GO_LDFLAGS" ./cmd/asdf
   env:
     CGO_ENABLED: 0
     ARGS:
       - -trimpath
       - -o={{prefix}}/bin/asdf
-    LDFLAGS:
+    GO_LDFLAGS:
       - -s
       - -w
       - -X main.version={{version}}
     linux:
-      LDFLAGS:
+      GO_LDFLAGS:
         - -buildmode=pie
 
 test:
   # `asdf version` (and --version) print "<version> (revision <ref>)";
   # build from a tarball has no .git so the revision resolves to "unknown".
-  - asdf version | grep {{version}}
-  - asdf --version | grep {{version}}
+  - asdf version | tee out
+  - grep {{version}} out
+  - asdf --version | tee out
+  - grep {{version}} out

--- a/projects/asdf-vm.com/package.yml
+++ b/projects/asdf-vm.com/package.yml
@@ -1,0 +1,34 @@
+distributable:
+  url: https://github.com/asdf-vm/asdf/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: asdf-vm/asdf
+  strip: /^v/
+
+provides:
+  - bin/asdf
+
+build:
+  dependencies:
+    go.dev: ^1.24
+  script:
+    - go build $ARGS -ldflags="$LDFLAGS" ./cmd/asdf
+  env:
+    CGO_ENABLED: 0
+    ARGS:
+      - -trimpath
+      - -o={{prefix}}/bin/asdf
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+    linux:
+      LDFLAGS:
+        - -buildmode=pie
+
+test:
+  # `asdf version` (and --version) print "<version> (revision <ref>)";
+  # build from a tarball has no .git so the revision resolves to "unknown".
+  - asdf version | grep {{version}}
+  - asdf --version | grep {{version}}


### PR DESCRIPTION
Adds a from-source recipe for **asdf**, the extendable runtime version manager (Ruby/Node/Erlang/…).

As of the v0.16 rewrite asdf is a single **Go** binary built from `./cmd/asdf` (previously a bash script), so this builds with `go.dev` and installs `bin/asdf`. Version injected via `-X main.version`; `asdf version` prints `<version> (revision …)` so the test uses a substring match.