### PR TITLE
new(usage.jdx.dev): usage 3.5.0

### DIFF
--- a/projects/usage.jdx.dev/package.yml
+++ b/projects/usage.jdx.dev/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/jdx/usage/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/jdx/usage/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,11 +7,6 @@ provides:
 
 versions:
   github: jdx/usage
-  strip: /^v/
-
-platforms:
-  - linux
-  - darwin
 
 build:
   dependencies:
@@ -19,5 +14,5 @@ build:
   script: cargo install --locked --path cli --root {{prefix}}
 
 test:
-  script:
-    - usage --version | grep {{version}}
+    - usage --version | tee out
+    - grep {{version}} out

--- a/projects/usage.jdx.dev/package.yml
+++ b/projects/usage.jdx.dev/package.yml
@@ -1,0 +1,23 @@
+distributable:
+  url: https://github.com/jdx/usage/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/usage
+
+versions:
+  github: jdx/usage
+  strip: /^v/
+
+platforms:
+  - linux
+  - darwin
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script: cargo install --locked --path cli --root {{prefix}}
+
+test:
+  script:
+    - usage --version | grep {{version}}


### PR DESCRIPTION
Adds [**usage**](https://usage.jdx.dev) by jdx — a CLI spec tool for defining/parsing usage-spec CLIs (companion to mise).

From-source via `cargo install --locked --path cli --root {{prefix}}`. The `usage` binary is produced by the workspace member `cli/` (crate `usage-cli`, which declares `[[bin]] name = "usage"`), not the root or the `usage-lib` crate. linux + darwin, all arches.