### PR TITLE
new(crates.io/b3sum): b3sum 1.8.5

### DIFF
--- a/projects/crates.io/b3sum/package.yml
+++ b/projects/crates.io/b3sum/package.yml
@@ -1,0 +1,23 @@
+distributable:
+  url: https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/b3sum
+
+versions:
+  github: BLAKE3-team/BLAKE3
+
+platforms:
+  - linux
+  - darwin
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path b3sum --root {{prefix}}
+
+test: |
+  b3sum --version | grep {{version}}
+  test "$(printf '' | b3sum --no-names)" = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"

--- a/projects/crates.io/b3sum/package.yml
+++ b/projects/crates.io/b3sum/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/{{version}}.tar.gz
+  url: https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -8,16 +8,13 @@ provides:
 versions:
   github: BLAKE3-team/BLAKE3
 
-platforms:
-  - linux
-  - darwin
-
 build:
   dependencies:
     rust-lang.org/cargo: '*'
   script:
     cargo install --locked --path b3sum --root {{prefix}}
 
-test: |
-  b3sum --version | grep {{version}}
-  test "$(printf '' | b3sum --no-names)" = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+test:
+  - b3sum --version | tee out
+  - grep {{version}} out
+  - test "$(printf '' | b3sum --no-names)" = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"


### PR DESCRIPTION
Adds a from-source recipe for **b3sum**, the BLAKE3 cryptographic hash CLI.

Upstream https://github.com/BLAKE3-team/BLAKE3 (Rust); the CLI crate is at `b3sum/`. Built via `cargo install --locked --path b3sum`, modeled on `crates.io/zoxide`. Tags are bare `X.Y.Z` (no `v`). The test asserts `--version` and that the empty-input hash equals the canonical BLAKE3 spec vector `af1349b9…3262` (deterministic, no network).