### PR TITLE
new(crates.io/procs): procs 0.14.11

### DIFF
--- a/projects/crates.io/procs/package.yml
+++ b/projects/crates.io/procs/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/dalance/procs/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/procs
+
+versions:
+  github: dalance/procs
+  strip: /^v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  procs --version | grep {{version}}

--- a/projects/crates.io/procs/package.yml
+++ b/projects/crates.io/procs/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/dalance/procs/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/dalance/procs/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,7 +7,6 @@ provides:
 
 versions:
   github: dalance/procs
-  strip: /^v/
 
 build:
   dependencies:
@@ -15,5 +14,6 @@ build:
   script:
     cargo install --locked --path . --root {{prefix}}
 
-test: |
-  procs --version | grep {{version}}
+test:
+  - procs --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds [**procs**](https://github.com/dalance/procs), a modern replacement for `ps` written in Rust.

From-source via `cargo install --locked --path .` (single-crate repo). Provides `bin/procs`. linux + darwin, all arches; test asserts `procs --version`.