### PR TITLE
new(crates.io/coreutils): uutils coreutils 0.9.0

### DIFF
--- a/projects/crates.io/coreutils/package.yml
+++ b/projects/crates.io/coreutils/package.yml
@@ -3,7 +3,7 @@
 # Does NOT install individual ls/cat/... bins, so it never clobbers GNU coreutils.
 
 distributable:
-  url: https://github.com/uutils/coreutils/archive/refs/tags/{{version}}.tar.gz
+  url: https://github.com/uutils/coreutils/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -22,6 +22,7 @@ build:
     - rm -f .cargo/config.toml
     - cargo install --locked --path . --root {{prefix}}
 
-test: |
-  coreutils --version | grep {{version}}
-  coreutils echo hi | grep hi
+test:
+  - coreutils --version | tee out
+  - grep {{version}} out
+  - coreutils echo hi | grep hi

--- a/projects/crates.io/coreutils/package.yml
+++ b/projects/crates.io/coreutils/package.yml
@@ -1,0 +1,27 @@
+# uutils coreutils ~ cross-platform Rust rewrite of GNU coreutils
+# Ships ONLY the multicall `coreutils` binary (e.g. `coreutils ls`, `coreutils cat`).
+# Does NOT install individual ls/cat/... bins, so it never clobbers GNU coreutils.
+
+distributable:
+  url: https://github.com/uutils/coreutils/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/coreutils
+
+versions:
+  github: uutils/coreutils
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    # upstream's .cargo/config.toml pins linker = aarch64-linux-gnu-gcc for the
+    # arm64 target, which the native arm64 builder doesn't have; drop it so cargo
+    # uses the default cc.
+    - rm -f .cargo/config.toml
+    - cargo install --locked --path . --root {{prefix}}
+
+test: |
+  coreutils --version | grep {{version}}
+  coreutils echo hi | grep hi


### PR DESCRIPTION
Adds **uutils coreutils**, the cross-platform Rust rewrite of GNU coreutils (https://github.com/uutils/coreutils).

**Design note:** `cargo install --path .` builds the **multicall** binary `coreutils` (default-run, default feature `feat_common_core`), invoked as `coreutils ls`, `coreutils cat`, …. We ship **only** `bin/coreutils` — it does **not** install individual `ls`/`cat`/… bins, so it does **not** clobber GNU coreutils. From-source, linux + darwin, all arches.