### PR TITLE
new(crates.io/findutils): uutils findutils 0.9.0

### DIFF
--- a/projects/crates.io/findutils/package.yml
+++ b/projects/crates.io/findutils/package.yml
@@ -1,0 +1,26 @@
+distributable:
+  url: https://github.com/uutils/findutils/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/find
+  - bin/locate
+  - bin/updatedb
+  - bin/xargs
+
+versions:
+  github: uutils/findutils
+
+platforms:
+  - linux
+  - darwin
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  test "$({{prefix}}/bin/find --version | head -n1 | grep -o '{{version}}')" = "{{version}}"
+  test "$({{prefix}}/bin/xargs --version | head -n1 | grep -o '{{version}}')" = "{{version}}"

--- a/projects/crates.io/findutils/package.yml
+++ b/projects/crates.io/findutils/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/uutils/findutils/archive/refs/tags/{{version}}.tar.gz
+  url: https://github.com/uutils/findutils/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -11,16 +11,15 @@ provides:
 versions:
   github: uutils/findutils
 
-platforms:
-  - linux
-  - darwin
-
 build:
   dependencies:
     rust-lang.org/cargo: '*'
   script:
     cargo install --locked --path . --root {{prefix}}
 
-test: |
-  test "$({{prefix}}/bin/find --version | head -n1 | grep -o '{{version}}')" = "{{version}}"
-  test "$({{prefix}}/bin/xargs --version | head -n1 | grep -o '{{version}}')" = "{{version}}"
+test:
+  - test "$(command -v find)" = "{{prefix}}/bin/find"
+  - find --version | tee out
+  - test "$(head -n1 out | grep -o '{{version}}')" = "{{version}}"
+  - xargs --version | tee out
+  - test "$(head -n1 out | grep -o '{{version}}')" = "{{version}}"


### PR DESCRIPTION
Adds a from-source recipe for [**uutils findutils**](https://github.com/uutils/findutils) — the Rust rewrite of GNU findutils.

Installs four individual binaries (`find`, `locate`, `updatedb`, `xargs`) — verified from `Cargo.toml` `[[bin]]` entries; there is no multicall `findutils` binary (unlike uutils coreutils). The `testing-commandline` test fixture is also built but intentionally not listed in `provides`. `find`/`xargs` shadow the system tools by design (pantry lets the user select). Test invokes the prefix-installed bins explicitly.