### PR TITLE
new(net-snmp.org): net-snmp 5.9.5

### DIFF
--- a/projects/net-snmp.org/package.yml
+++ b/projects/net-snmp.org/package.yml
@@ -16,7 +16,6 @@ dependencies:
 
 build:
   dependencies:
-    freedesktop.org/pkg-config: '*'
     darwinsys.com/file: '*' # libtool needs the `file` program at configure time
   script:
     - ./configure $ARGS
@@ -55,6 +54,8 @@ test:
   # NB: the net-snmp 5.9.5 source mis-stamps its version as 5.9.4 (upstream
   # AC_INIT was never bumped past 5.9.4), so the tools report "5.9.4" and we
   # can't assert {{version}}. Verify instead that the built tools run and link.
-  script: |
-    snmptranslate -V 2>&1 | grep -i "net-snmp version"
-    net-snmp-config --cflags | grep -- -I
+  script:
+    - snmptranslate -V 2>&1 | tee out
+    - grep -i "net-snmp version" out
+    - net-snmp-config --cflags | tee out
+    - grep -- -I out

--- a/projects/net-snmp.org/package.yml
+++ b/projects/net-snmp.org/package.yml
@@ -1,0 +1,60 @@
+distributable:
+  url: https://downloads.sourceforge.net/project/net-snmp/net-snmp/{{version}}/net-snmp-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  # GitHub tags are polluted with .preN/.rcN/4-component tags that the semver
+  # parser can't read; scrape the SourceForge release dirs for clean X.Y.Z.
+  url: https://sourceforge.net/projects/net-snmp/files/net-snmp/
+  match: _/projects/net-snmp/files/net-snmp/\d+\.\d+\.\d+/_
+  strip:
+    - _^/projects/net-snmp/files/net-snmp/_
+    - _/$_
+
+dependencies:
+  openssl.org: ^1.1
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+    darwinsys.com/file: '*' # libtool needs the `file` program at configure time
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - --prefix={{prefix}}
+      - --with-defaults
+      - --with-openssl={{deps.openssl.org.prefix}}
+      - --with-default-snmp-version=3
+      - --disable-embedded-perl
+      - --without-perl-modules
+      - --disable-dependency-tracking
+    darwin:
+      # net-snmp hard-codes -Werror=declaration-after-statement, which its own
+      # pre-C99 darwin MIB code (swinst_darwin.c) violates. A general -Wno-error
+      # doesn't undo a specific -Werror=foo in clang, so target it precisely.
+      CFLAGS: $CFLAGS -Wno-implicit-function-declaration -Wno-error=declaration-after-statement
+      # the darwin host-resource MIB modules (hr_disk, swinst_darwin) call
+      # CoreFoundation / IOKit / DiskArbitration / LaunchServices; configure
+      # doesn't auto-link them in this sandbox, so do it explicitly.
+      LDFLAGS: $LDFLAGS -framework CoreFoundation -framework IOKit -framework DiskArbitration -framework CoreServices
+
+provides:
+  - bin/snmpget
+  - bin/snmpgetnext
+  - bin/snmpwalk
+  - bin/snmptranslate
+  - bin/snmpset
+  - bin/snmpd
+  - bin/snmptrap
+  - bin/net-snmp-config
+
+test:
+  # NB: the net-snmp 5.9.5 source mis-stamps its version as 5.9.4 (upstream
+  # AC_INIT was never bumped past 5.9.4), so the tools report "5.9.4" and we
+  # can't assert {{version}}. Verify instead that the built tools run and link.
+  script: |
+    snmptranslate -V 2>&1 | grep -i "net-snmp version"
+    net-snmp-config --cflags | grep -- -I


### PR DESCRIPTION
Adds the **Net-SNMP** suite (SNMP v1/v2c/v3) from source: snmpget/snmpwalk/snmptranslate/snmpset/snmpd plus net-snmp-config and the netsnmp libraries.

Built from the canonical SourceForge release tarball via autotools, linked against `openssl.org` for SNMPv3 crypto.

Notes:
- `--with-defaults` makes the otherwise-**interactive** configure run non-interactively; embedded-perl and perl modules are disabled to keep the build self-contained.
- libtool needs the `file` program at configure time → `darwinsys.com/file` build dep.
- Versions are scraped from the SourceForge release dirs (the GitHub tags are polluted with `.preN`/`.rcN`/4-component tags the semver parser can't read).
- **Upstream quirk:** the 5.9.5 source mis-stamps its version as `5.9.4` (`AC_INIT([Net-SNMP],[5.9.4],…)` was never bumped), so the tools report `5.9.4`. The test therefore verifies the tools run/link rather than asserting the marketing version.
