### PR TITLE
fix(tcl.tk/tcl): resolve final releases, not rc-only dirs (#12187)

### DIFF
--- a/projects/tcl.tk/tcl/package.yml
+++ b/projects/tcl.tk/tcl/package.yml
@@ -1,13 +1,16 @@
 distributable:
-  url: https://prdownloads.sourceforge.net/tcl/tcl{{ version }}-src.tar.gz
+  url: https://downloads.sourceforge.net/project/tcl/Tcl/{{ version }}/tcl{{ version }}-src.tar.gz
   strip-components: 1
 
 versions:
-  url: https://sourceforge.net/projects/tcl/files/Tcl/
-  match: /files\/Tcl\/\d+\.\d+\.\d+\//
+  # Scrape the official download page, which lists final releases only. The
+  # SourceForge dir listing also exposes rc-only dirs (e.g. 9.0.4/ holds just
+  # tcl9.0.4rc0-src.tar.gz), so it resolved to 9.0.4 whose -src tarball 404s.
+  url: https://www.tcl-lang.org/software/tcltk/download.html
+  match: /tcl\d+\.\d+\.\d+-src\.tar\.gz/
   strip:
-    - /files\/Tcl\//
-    - /\//
+    - /^tcl/
+    - /-src\.tar\.gz/
 
 build:
   working-directory: unix


### PR DESCRIPTION
Fixes #12187 — `tcl.tk/tcl=9.0.4` build failure (`404: .../tcl9.0.4-src.tar.gz`).

**Root cause:** the `versions` source scraped the SourceForge directory listing (`/projects/tcl/files/Tcl/`), which exposes dirs for release-candidate-only versions — `9.0.4/` currently contains only `tcl9.0.4rc0-src.tar.gz`, no final `tcl9.0.4-src.tar.gz`. So it resolved to `9.0.4` and the distributable 404d. (The `prdownloads.sourceforge.net` mirror in the distributable URL is also dead.)

**Fix:** resolve versions from the official download page (final releases only — currently `9.0.3`) and fetch via the live `downloads.sourceforge.net/project/...` scheme — i.e. the same working config the sibling `tcl-lang.org` recipe already uses.
