### PR TITLE
fix(tcl.tk/tcl): SF file-feed versions, skip rc-only (#12187)

### DIFF
--- a/projects/tcl.tk/tcl/package.yml
+++ b/projects/tcl.tk/tcl/package.yml
@@ -1,13 +1,18 @@
 distributable:
-  url: https://prdownloads.sourceforge.net/tcl/tcl{{ version }}-src.tar.gz
+  url: https://downloads.sourceforge.net/project/tcl/Tcl/{{ version }}/tcl{{ version }}-src.tar.gz
   strip-components: 1
 
 versions:
-  url: https://sourceforge.net/projects/tcl/files/Tcl/
-  match: /files\/Tcl\/\d+\.\d+\.\d+\//
+  # Match release tarballs from the SourceForge file feed (enumerates all
+  # versions). The previous dir listing matched version dirs, but the latest
+  # dir (9.0.4/) holds only a release candidate (tcl9.0.4rc0-src.tar.gz), so it
+  # resolved to 9.0.4 whose final -src tarball 404s. Matching the final tarball
+  # name skips rc-only releases.
+  url: https://sourceforge.net/projects/tcl/rss?path=/Tcl
+  match: /tcl\d+\.\d+\.\d+-src\.tar\.gz/
   strip:
-    - /files\/Tcl\//
-    - /\//
+    - /^tcl/
+    - /-src\.tar\.gz/
 
 build:
   working-directory: unix


### PR DESCRIPTION
Replaces #13333 (closed: the official download page only shows the latest version).

Fixes #12187. The `versions` source now reads the SourceForge **file feed** (`rss?path=/Tcl`) and matches **final** `-src` tarball names. This enumerates all versions (8.6.x, 9.0.x …) — addressing the "only latest" objection — while skipping rc-only releases: the old dir listing resolved `9.0.4` (its dir holds only `tcl9.0.4rc0-src.tar.gz`), so `tcl9.0.4-src.tar.gz` 404d. Now resolves to `9.0.3` (latest final).

Same SourceForge-RSS idiom already used by `gphoto.org/libgphoto2`, `sourceforge.net/e2fsprogs`. Also moves the distributable off the dead `prdownloads.sourceforge.net` mirror.
