### PR TITLE
new(crates.io/gping): gping 1.20.2

### DIFF
--- a/projects/crates.io/gping/package.yml
+++ b/projects/crates.io/gping/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/orf/gping/archive/refs/tags/gping-v{{version}}.tar.gz
+  url: https://github.com/orf/gping/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -12,8 +12,8 @@ versions:
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path gping --root {{prefix}}
+  script: cargo install --locked --path gping --root {{prefix}}
 
-test: |
-  gping --version | grep {{version}}
+test:
+  - gping --version | tee out
+  - grep {{version}} out

--- a/projects/crates.io/gping/package.yml
+++ b/projects/crates.io/gping/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/orf/gping/archive/refs/tags/gping-v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/gping
+
+versions:
+  github: orf/gping/tags
+  strip: /^gping-v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path gping --root {{prefix}}
+
+test: |
+  gping --version | grep {{version}}


### PR DESCRIPTION
Adds **gping** — ping with a live terminal graph (https://github.com/orf/gping). Cargo workspace; the binary crate is the `gping/` member, so `--path gping`. Upstream tags are prefixed `gping-v`.