### PR TITLE
new(crates.io/ouch): ouch 0.8.0

### DIFF
--- a/projects/crates.io/ouch/package.yml
+++ b/projects/crates.io/ouch/package.yml
@@ -1,0 +1,18 @@
+distributable:
+  url: https://github.com/ouch-org/ouch/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/ouch
+
+versions:
+  github: ouch-org/ouch
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  ouch --version | grep {{version}}

--- a/projects/crates.io/ouch/package.yml
+++ b/projects/crates.io/ouch/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/ouch-org/ouch/archive/refs/tags/{{version}}.tar.gz
+  url: https://github.com/ouch-org/ouch/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -11,12 +11,12 @@ versions:
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    # Drop the default `unrar` feature: it builds the vendored unrar-ng C++
-    # sources, which need a full C++ toolchain the build sandbox lacks (clang
-    # can't find <new>). rar is a proprietary read-only format; everything else
-    # (tar/zip/gz/zst/bz2/bz3/7z/brotli/lz4) stays.
-    cargo install --locked --no-default-features --features use_zlib,use_zstd_thin,bzip3 --path . --root {{prefix}}
+  # Drop the default `unrar` feature: it builds the vendored unrar-ng C++
+  # sources, which need a full C++ toolchain the build sandbox lacks (clang
+  # can't find <new>). rar is a proprietary read-only format; everything else
+  # (tar/zip/gz/zst/bz2/bz3/7z/brotli/lz4) stays.
+  script: cargo install --locked --no-default-features --features use_zlib,use_zstd_thin,bzip3 --path . --root {{prefix}}
 
-test: |
-  ouch --version | grep {{version}}
+test:
+  - ouch --version | tee out
+  - grep {{version}} out

--- a/projects/crates.io/ouch/package.yml
+++ b/projects/crates.io/ouch/package.yml
@@ -12,7 +12,11 @@ build:
   dependencies:
     rust-lang.org/cargo: '*'
   script:
-    cargo install --locked --path . --root {{prefix}}
+    # Drop the default `unrar` feature: it builds the vendored unrar-ng C++
+    # sources, which need a full C++ toolchain the build sandbox lacks (clang
+    # can't find <new>). rar is a proprietary read-only format; everything else
+    # (tar/zip/gz/zst/bz2/bz3/7z/brotli/lz4) stays.
+    cargo install --locked --no-default-features --features use_zlib,use_zstd_thin,bzip3 --path . --root {{prefix}}
 
 test: |
   ouch --version | grep {{version}}


### PR DESCRIPTION
Adds **ouch** (Obvious Unified Compression Helper, https://github.com/ouch-org/ouch) — one CLI for tar/zip/gz/zst/bz2/7z/… Single-crate build; all compression backends are vendored (zstd-sys, libbz2-rs, unrar-ng via cc), no system compression libs. Tags have no `v` prefix (edition 2024 → needs a current Rust).