### PR TITLE
new(crates.io/websocat): websocat 1.14.1

### DIFF
--- a/projects/crates.io/websocat/package.yml
+++ b/projects/crates.io/websocat/package.yml
@@ -1,0 +1,27 @@
+distributable:
+  url: https://github.com/vi/websocat/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/websocat
+
+versions:
+  github: vi/websocat
+  strip: /v/
+
+# websocat's default features include `ssl`, which pulls in
+# native-tls -> openssl-sys, so we need a system OpenSSL at build and runtime.
+dependencies:
+  openssl.org: '*'
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+    openssl.org: '*'
+  env:
+    OPENSSL_DIR: '{{deps.openssl.org.prefix}}'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  websocat --version | grep {{version}}

--- a/projects/crates.io/websocat/package.yml
+++ b/projects/crates.io/websocat/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/vi/websocat/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/vi/websocat/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,7 +7,6 @@ provides:
 
 versions:
   github: vi/websocat
-  strip: /v/
 
 # websocat's default features include `ssl`, which pulls in
 # native-tls -> openssl-sys, so we need a system OpenSSL at build and runtime.
@@ -17,11 +16,10 @@ dependencies:
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-    openssl.org: '*'
   env:
     OPENSSL_DIR: '{{deps.openssl.org.prefix}}'
-  script:
-    cargo install --locked --path . --root {{prefix}}
+  script: cargo install --locked --path . --root {{prefix}}
 
-test: |
-  websocat --version | grep {{version}}
+test:
+  - websocat --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds **websocat** (https://github.com/vi/websocat) — a netcat/socat-like CLI for `ws://`/`wss://`. websocat's default `ssl` feature pulls `native-tls` → `openssl-sys`, so the recipe depends on `openssl.org` and sets `OPENSSL_DIR` (keeps `wss://` TLS support).