### PR TITLE
new(github.com/go-delve/delve): delve 1.26.3

### DIFF
--- a/projects/github.com/go-delve/delve/package.yml
+++ b/projects/github.com/go-delve/delve/package.yml
@@ -1,0 +1,26 @@
+# Delve — a debugger for the Go programming language. The `dlv` binary
+# wraps the runtime/ptrace (Linux) and LLDB/debugserver (macOS) backends
+# to set breakpoints, inspect goroutines, and step through Go programs.
+
+distributable:
+  url: https://github.com/go-delve/delve/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: go-delve/delve
+  strip: /^v/
+
+provides:
+  - bin/dlv
+
+build:
+  dependencies:
+    go.dev: "*"
+  env:
+    # Core debugger builds pure-Go: Linux native backend uses ptrace,
+    # the cgo darwin native backend is gated behind the `macnative` tag.
+    CGO_ENABLED: 0
+  # Version comes from constants in pkg/version/version.go, so no -X needed.
+  script: go build -trimpath -ldflags "-s -w" -o {{prefix}}/bin/dlv ./cmd/dlv
+
+test: dlv version | grep {{version}}

--- a/projects/github.com/go-delve/delve/package.yml
+++ b/projects/github.com/go-delve/delve/package.yml
@@ -3,12 +3,11 @@
 # to set breakpoints, inspect goroutines, and step through Go programs.
 
 distributable:
-  url: https://github.com/go-delve/delve/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/go-delve/delve/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: go-delve/delve
-  strip: /^v/
 
 provides:
   - bin/dlv
@@ -23,4 +22,6 @@ build:
   # Version comes from constants in pkg/version/version.go, so no -X needed.
   script: go build -trimpath -ldflags "-s -w" -o {{prefix}}/bin/dlv ./cmd/dlv
 
-test: dlv version | grep {{version}}
+test:
+- dlv version | tee out
+- grep {{version}} out


### PR DESCRIPTION
Adds **delve** (https://github.com/go-delve/delve) — the Go debugger, binary `dlv`. Pure-Go build with `CGO_ENABLED=0` (the cgo macnative darwin backend is gated behind a build tag; the default uses ptrace/lldb). No `-X` needed — `dlv version` reads compiled-in constants.