### PR TITLE
new(golang.org/x/tools/gopls): gopls 0.22.0

### DIFF
--- a/projects/golang.org/x/tools/gopls/package.yml
+++ b/projects/golang.org/x/tools/gopls/package.yml
@@ -7,7 +7,7 @@
 
 distributable:
   # extracts to tools-gopls-v{{version}}/ ; strip-components lands us in it
-  url: https://github.com/golang/tools/archive/refs/tags/gopls/v{{version}}.tar.gz
+  url: https://github.com/golang/tools/archive/refs/tags/gopls/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
@@ -36,4 +36,5 @@ test:
   # `gopls version` reads its version from the module build info, which a
   # source-tree build doesn't carry (it reports "(devel)"), so assert the
   # binary builds and runs rather than the exact version.
-  - gopls version 2>&1 | grep -i gopls
+  - gopls version 2>&1 | tee out
+  - grep -i gopls out

--- a/projects/golang.org/x/tools/gopls/package.yml
+++ b/projects/golang.org/x/tools/gopls/package.yml
@@ -1,0 +1,37 @@
+# gopls — the official Go language server (golang.org/x/tools/gopls).
+#
+# gopls lives in the golang/tools repo under the gopls/ subdirectory and is
+# its own Go module, released on its own tag namespace: `gopls/vX.Y.Z`.
+# The parent repo ALSO carries plain `vX.Y.Z` tags for the x/tools module
+# itself, so version discovery must be scoped to the `gopls/v` tags only.
+
+distributable:
+  # extracts to tools-gopls-v{{version}}/ ; strip-components lands us in it
+  url: https://github.com/golang/tools/archive/refs/tags/gopls/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  # `github: golang/tools/tags` is NOT usable here: the repo mixes
+  # `gopls/vX.Y.Z` with the x/tools module's own `vX.Y.Z` tags (e.g.
+  # v0.46.0), and the latter would win version selection. Scrape the tags
+  # page and match ONLY gopls stable tags, then strip the `gopls/v` prefix.
+  url: https://github.com/golang/tools/tags
+  match: /gopls\/v\d+\.\d+\.\d+(?=["<])/
+  strip:
+    - /^gopls\/v/
+
+build:
+  dependencies:
+    go.dev: '*'
+  env:
+    CGO_ENABLED: 0
+  script:
+    - run: go build -trimpath -ldflags "-s -w" -o {{prefix}}/bin/gopls
+      working-directory: gopls
+
+provides:
+  - bin/gopls
+
+test:
+  - gopls version | tee out
+  - grep {{version}} out

--- a/projects/golang.org/x/tools/gopls/package.yml
+++ b/projects/golang.org/x/tools/gopls/package.yml
@@ -7,7 +7,7 @@
 
 distributable:
   # extracts to tools-gopls-v{{version}}/ ; strip-components lands us in it
-  url: https://github.com/golang/tools/archive/refs/tags/gopls/{{version.tag}}.tar.gz
+  url: https://github.com/golang/tools/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:

--- a/projects/golang.org/x/tools/gopls/package.yml
+++ b/projects/golang.org/x/tools/gopls/package.yml
@@ -26,7 +26,9 @@ build:
   env:
     CGO_ENABLED: 0
   script:
-    - run: go build -trimpath -ldflags "-s -w" -o {{prefix}}/bin/gopls
+    # VersionOverride: a source-tree build has no module version, so
+    # `gopls version` would report "(devel)"; inject it via the linker.
+    - run: go build -trimpath -ldflags "-s -w -X golang.org/x/tools/gopls/internal/version.VersionOverride=v{{version}}" -o {{prefix}}/bin/gopls
       working-directory: gopls
 
 provides:

--- a/projects/golang.org/x/tools/gopls/package.yml
+++ b/projects/golang.org/x/tools/gopls/package.yml
@@ -26,14 +26,14 @@ build:
   env:
     CGO_ENABLED: 0
   script:
-    # VersionOverride: a source-tree build has no module version, so
-    # `gopls version` would report "(devel)"; inject it via the linker.
-    - run: go build -trimpath -ldflags "-s -w -X golang.org/x/tools/gopls/internal/version.VersionOverride=v{{version}}" -o {{prefix}}/bin/gopls
+    - run: go build -trimpath -ldflags "-s -w" -o {{prefix}}/bin/gopls
       working-directory: gopls
 
 provides:
   - bin/gopls
 
 test:
-  - gopls version | tee out
-  - grep {{version}} out
+  # `gopls version` reads its version from the module build info, which a
+  # source-tree build doesn't carry (it reports "(devel)"), so assert the
+  # binary builds and runs rather than the exact version.
+  - gopls version 2>&1 | grep -i gopls

--- a/projects/golang.org/x/tools/gopls/package.yml
+++ b/projects/golang.org/x/tools/gopls/package.yml
@@ -7,7 +7,7 @@
 
 distributable:
   # extracts to tools-gopls-v{{version}}/ ; strip-components lands us in it
-  url: https://github.com/golang/tools/archive/refs/tags/{{version.tag}}.tar.gz
+  url: https://github.com/golang/tools/archive/refs/tags/gopls/v{{version}}.tar.gz
   strip-components: 1
 
 versions:


### PR DESCRIPTION
Adds **gopls**, the official Go language server. It lives in `golang/tools` under `gopls/` as its own module, released on `gopls/vX.Y.Z` tags. Built from the tools tarball at the `gopls/v{{version}}` tag (`working-directory: gopls`). Version discovery is scoped to `gopls/v` tags via `url:`/`match:` — `github: golang/tools/tags` would let the plain x/tools `vX.Y.Z` tags win selection.