### PR TITLE
new(github.com/fullstorydev/grpcui): grpcui 1.4.3

### DIFF
--- a/projects/github.com/fullstorydev/grpcui/package.yml
+++ b/projects/github.com/fullstorydev/grpcui/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/fullstorydev/grpcui/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: fullstorydev/grpcui
+
+provides:
+  - bin/grpcui
+
+build:
+  dependencies:
+    go.dev: '*'
+  script: |
+    go mod download
+    mkdir -p "{{ prefix }}"/bin
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/grpcui
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: "{{prefix}}/bin/grpcui"
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+    linux:
+      # or segmentation fault
+      # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+        - -buildmode=pie
+
+test:
+  script:
+    - grpcui -version 2>&1 | grep {{version}}

--- a/projects/github.com/fullstorydev/grpcui/package.yml
+++ b/projects/github.com/fullstorydev/grpcui/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/fullstorydev/grpcui/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/fullstorydev/grpcui/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
@@ -11,26 +11,22 @@ provides:
 build:
   dependencies:
     go.dev: '*'
-  script: |
-    go mod download
-    mkdir -p "{{ prefix }}"/bin
-    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC ./cmd/grpcui
+  script:
+    - go mod download
+    - go build -v -trimpath -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/grpcui ./cmd/grpcui
   env:
-    GOPROXY: https://proxy.golang.org,direct
-    GOSUMDB: sum.golang.org
     GO111MODULE: on
     CGO_ENABLED: 0
-    BUILDLOC: "{{prefix}}/bin/grpcui"
-    LDFLAGS:
+    GO_LDFLAGS:
       - -s
       - -w
       - -X main.version={{version}}
     linux:
       # or segmentation fault
       # fix found here https://github.com/docker-library/golang/issues/402#issuecomment-982204575
-      LDFLAGS:
+      GO_LDFLAGS:
         - -buildmode=pie
 
 test:
-  script:
-    - grpcui -version 2>&1 | grep {{version}}
+  - grpcui -version 2>&1 | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds **grpcui** (https://github.com/fullstorydev/grpcui) — an interactive web UI for gRPC servers, the companion to grpcurl. Mirrors the existing grpcurl recipe: pure-Go `./cmd/grpcui`, `CGO_ENABLED=0` (+ `-buildmode=pie` on linux), version via `-X main.version`. Test: `grpcui -version` (single dash, prints to stderr).