### PR TITLE
new(github.com/mr-karan/doggo): doggo 1.1.7

### DIFF
--- a/projects/github.com/mr-karan/doggo/package.yml
+++ b/projects/github.com/mr-karan/doggo/package.yml
@@ -13,11 +13,11 @@ build:
     go.dev: '*'
   env:
     CGO_ENABLED: 0
-  script: |
-    go build -trimpath -ldflags "-s -w -X main.buildVersion={{version}}" -o {{prefix}}/bin/doggo ./cmd/doggo
+  script: go build -trimpath -ldflags "-s -w -X main.buildVersion={{version}}" -o {{prefix}}/bin/doggo ./cmd/doggo
 
 provides:
   - bin/doggo
 
 test:
-  - doggo --version 2>&1 | grep {{version}}
+  - doggo --version 2>&1 | tee out
+  - grep {{version}} out

--- a/projects/github.com/mr-karan/doggo/package.yml
+++ b/projects/github.com/mr-karan/doggo/package.yml
@@ -1,0 +1,23 @@
+# doggo — a modern command-line DNS client (like dig), written in Go.
+# Supports DoH, DoT, DoQ, DNSCrypt, JSON output, and colored tabular results.
+
+distributable:
+  url: https://github.com/mr-karan/doggo/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: mr-karan/doggo
+
+build:
+  dependencies:
+    go.dev: '*'
+  env:
+    CGO_ENABLED: 0
+  script: |
+    go build -trimpath -ldflags "-s -w -X main.buildVersion={{version}}" -o {{prefix}}/bin/doggo ./cmd/doggo
+
+provides:
+  - bin/doggo
+
+test:
+  - doggo --version 2>&1 | grep {{version}}


### PR DESCRIPTION
Adds **doggo** (https://github.com/mr-karan/doggo) — a modern command-line DNS client (dig replacement) with DoH/DoT/DoQ/DNSCrypt + JSON output. Pure-Go `./cmd/doggo`, `CGO_ENABLED=0`, version stamped via `-X main.buildVersion` (matching upstream Makefile/goreleaser).