### PR TITLE
new(github.com/esnet/iperf): iperf3 3.21

### DIFF
--- a/projects/github.com/esnet/iperf/package.yml
+++ b/projects/github.com/esnet/iperf/package.yml
@@ -17,8 +17,6 @@ dependencies:
   openssl.org: '*'
 
 build:
-  dependencies:
-    freedesktop.org/pkg-config: '*'
   script:
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}
@@ -35,4 +33,5 @@ provides:
 test:
   # iperf reports its bare upstream version (e.g. "iperf 3.21"); pantry pads
   # the 2-component tag to 3.21.0, so grep the marketing (major.minor) form.
-  script: iperf3 --version 2>&1 | grep {{version.marketing}}
+  - iperf3 --version 2>&1 | tee out
+  - grep {{version.marketing}} out

--- a/projects/github.com/esnet/iperf/package.yml
+++ b/projects/github.com/esnet/iperf/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/esnet/iperf/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+display-name: iperf3
+
+versions:
+  github: esnet/iperf/tags
+  # tags are bare numeric (e.g. `3.21`); ignore the legacy `iperf-3.x` /
+  # `trunk` / `iperf3` tags by stripping any non-numeric prefix.
+  strip:
+    - /^iperf-/
+
+dependencies:
+  # iperf3 uses OpenSSL for authenticated tests (-A / RSA public-key auth).
+  # configure auto-detects it; we include it for the full feature set.
+  openssl.org: '*'
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - --prefix={{prefix}}
+      - --disable-dependency-tracking
+      - --with-openssl={{deps.openssl.org.prefix}}
+
+provides:
+  - bin/iperf3
+
+test:
+  script: iperf3 --version 2>&1 | grep {{version}}

--- a/projects/github.com/esnet/iperf/package.yml
+++ b/projects/github.com/esnet/iperf/package.yml
@@ -33,4 +33,6 @@ provides:
   - bin/iperf3
 
 test:
-  script: iperf3 --version 2>&1 | grep {{version}}
+  # iperf reports its bare upstream version (e.g. "iperf 3.21"); pantry pads
+  # the 2-component tag to 3.21.0, so grep the marketing (major.minor) form.
+  script: iperf3 --version 2>&1 | grep {{version.marketing}}


### PR DESCRIPTION
Adds **iperf3** (https://github.com/esnet/iperf) — the ESnet active-measurement network throughput tool (TCP/UDP/SCTP bandwidth/jitter/loss). Autotools build; tags are bare numeric (legacy `iperf-` tags stripped). Links `openssl.org` (`--with-openssl`) for optional `-A` authenticated tests.