### PR TITLE
new(github.com/eradman/entr): entr 5.8

### DIFF
--- a/projects/github.com/eradman/entr/package.yml
+++ b/projects/github.com/eradman/entr/package.yml
@@ -22,6 +22,6 @@ test:
   # entr has no --version flag; run with no args, which prints "usage: entr"
   # to stderr and exits non-zero. Capture (tolerating the exit) so pipefail
   # doesn't fail the test on entr's non-zero status, then grep the banner.
-  script: |
-    out="$(entr 2>&1 || true)"
-    echo "$out" | grep -iE "usage|entr"
+  script:
+    - ( entr 2>&1 || true ) | tee out
+    - grep -iE "usage|entr" out

--- a/projects/github.com/eradman/entr/package.yml
+++ b/projects/github.com/eradman/entr/package.yml
@@ -19,6 +19,9 @@ provides:
   - bin/entr
 
 test:
-  # entr has no --version flag; run with no args, which prints
-  # "usage: entr ..." to stderr and exits non-zero.
-  - entr 2>&1 | grep -iE "usage|entr"
+  # entr has no --version flag; run with no args, which prints "usage: entr"
+  # to stderr and exits non-zero. Capture (tolerating the exit) so pipefail
+  # doesn't fail the test on entr's non-zero status, then grep the banner.
+  script: |
+    out="$(entr 2>&1 || true)"
+    echo "$out" | grep -iE "usage|entr"

--- a/projects/github.com/eradman/entr/package.yml
+++ b/projects/github.com/eradman/entr/package.yml
@@ -1,0 +1,24 @@
+distributable:
+  url: https://github.com/eradman/entr/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: eradman/entr/tags
+
+build:
+  # entr ships a hand-written ./configure that only copies a per-OS
+  # Makefile; PREFIX/DESTDIR are read from the environment by the Makefile.
+  env:
+    PREFIX: "{{prefix}}"
+  script:
+    - ./configure
+    - make
+    - make install
+
+provides:
+  - bin/entr
+
+test:
+  # entr has no --version flag; run with no args, which prints
+  # "usage: entr ..." to stderr and exits non-zero.
+  - entr 2>&1 | grep -iE "usage|entr"


### PR DESCRIPTION
Adds **entr** (https://github.com/eradman/entr, https://eradman.com/entrproject/) — run arbitrary commands when files change. entr's `./configure` is a hand-written sh script (not autotools) that just selects a per-OS Makefile; `PREFIX`/`DESTDIR` are honored by the Makefile's install target, so the recipe sets `PREFIX={{prefix}}`. entr has no `--version`, so the test runs it bare and greps the usage banner.