### PR TITLE
new(github.com/rui314/mold): mold 2.41.0

### DIFF
--- a/projects/github.com/rui314/mold/package.yml
+++ b/projects/github.com/rui314/mold/package.yml
@@ -31,8 +31,8 @@ build:
     - cmake --build build --parallel {{ hw.concurrency }}
     - cmake --install build
   env:
-    CC: "{{deps.gnu.org/gcc.prefix}}/bin/cc"
-    CXX: "{{deps.gnu.org/gcc.prefix}}/bin/c++"
+    CC: "{{deps.gnu.org/gcc.prefix}}/bin/gcc"
+    CXX: "{{deps.gnu.org/gcc.prefix}}/bin/g++"
     ARGS:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX={{prefix}}

--- a/projects/github.com/rui314/mold/package.yml
+++ b/projects/github.com/rui314/mold/package.yml
@@ -16,9 +16,13 @@ platforms:
 provides:
   - bin/mold
 
+dependencies:
+  gnu.org/gcc/libstdcxx: "*" # the C++20 libstdc++ mold links at runtime
+
 build:
   dependencies:
     cmake.org: "*"
+    gnu.org/gcc: 14 # the runner's default g++ is too old for C++20 (<bit>)
   script:
     # mold needs a C++20 compiler; it bundles its third-party deps
     # (zlib, zstd, blake3, mimalloc, tbb) under third-party/ and pulls
@@ -27,6 +31,8 @@ build:
     - cmake --build build --parallel {{ hw.concurrency }}
     - cmake --install build
   env:
+    CC: "{{deps.gnu.org/gcc.prefix}}/bin/cc"
+    CXX: "{{deps.gnu.org/gcc.prefix}}/bin/c++"
     ARGS:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX={{prefix}}

--- a/projects/github.com/rui314/mold/package.yml
+++ b/projects/github.com/rui314/mold/package.yml
@@ -1,23 +1,21 @@
 distributable:
-  url: https://github.com/rui314/mold/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/rui314/mold/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: rui314/mold/tags
-  strip: /^v/
 
 # mold is an ELF linker; macOS support (sold/macho) was dropped upstream,
 # so it only builds & runs on Linux. Official release binaries are
 # linux-only (x86_64, aarch64, arm, ppc64le, riscv64, s390x, loongarch64).
 platforms:
-  - linux/x86-64
-  - linux/aarch64
+  - linux
 
 provides:
   - bin/mold
 
 dependencies:
-  gnu.org/gcc/libstdcxx: "*" # the C++20 libstdc++ mold links at runtime
+  gnu.org/gcc/libstdcxx: 14 # the C++20 libstdc++ mold links at runtime
 
 build:
   dependencies:
@@ -40,5 +38,5 @@ build:
       - -DMOLD_USE_MIMALLOC=OFF
 
 test:
-  script:
-    - mold --version | grep {{version}}
+  - mold --version | tee out
+  - grep {{version}} out

--- a/projects/github.com/rui314/mold/package.yml
+++ b/projects/github.com/rui314/mold/package.yml
@@ -1,0 +1,37 @@
+distributable:
+  url: https://github.com/rui314/mold/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: rui314/mold/tags
+  strip: /^v/
+
+# mold is an ELF linker; macOS support (sold/macho) was dropped upstream,
+# so it only builds & runs on Linux. Official release binaries are
+# linux-only (x86_64, aarch64, arm, ppc64le, riscv64, s390x, loongarch64).
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+
+provides:
+  - bin/mold
+
+build:
+  dependencies:
+    cmake.org: "*"
+  script:
+    # mold needs a C++20 compiler; it bundles its third-party deps
+    # (zlib, zstd, blake3, mimalloc, tbb) under third-party/ and pulls
+    # the rest via CMake FetchContent — no extra system libs required.
+    - cmake -B build -S . $ARGS
+    - cmake --build build --parallel {{ hw.concurrency }}
+    - cmake --install build
+  env:
+    ARGS:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+      - -DMOLD_USE_MIMALLOC=OFF
+
+test:
+  script:
+    - mold --version | grep {{version}}

--- a/projects/github.com/rui314/mold/package.yml
+++ b/projects/github.com/rui314/mold/package.yml
@@ -31,8 +31,9 @@ build:
     - cmake --build build --parallel {{ hw.concurrency }}
     - cmake --install build
   env:
-    CC: "{{deps.gnu.org/gcc.prefix}}/bin/gcc"
-    CXX: "{{deps.gnu.org/gcc.prefix}}/bin/g++"
+    # No CC/CXX override: the gnu.org/gcc dep puts its cc/c++ first on PATH and
+    # cmake detects them as GNU (so it links the shared mold-wrapper correctly).
+    # Forcing CC to an absolute path broke cmake's -shared detection.
     ARGS:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX={{prefix}}


### PR DESCRIPTION
Adds **mold** (https://github.com/rui314/mold) — Rui Ueyama's fast drop-in ELF linker. CMake build (`cmake.org` only dep — mold vendors zlib/zstd/blake3/tbb under `third-party/`). **Linux-only** (`linux/x86-64`, `linux/aarch64`): mold is an ELF linker and upstream dropped macOS/Mach-O support; there are no macOS release assets.