### PR TITLE
new(crates.io/bandwhich): bandwhich 0.23.1

### DIFF
--- a/projects/crates.io/bandwhich/package.yml
+++ b/projects/crates.io/bandwhich/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/imsnif/bandwhich/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/imsnif/bandwhich/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,13 +7,12 @@ provides:
 
 versions:
   github: imsnif/bandwhich
-  strip: /v/
 
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path . --root {{prefix}}
+  script: cargo install --locked --path . --root {{prefix}}
 
-test: |
-  bandwhich --version | grep {{version}}
+test:
+  - bandwhich --version | tee out
+  - grep {{version}} out

--- a/projects/crates.io/bandwhich/package.yml
+++ b/projects/crates.io/bandwhich/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/imsnif/bandwhich/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/bandwhich
+
+versions:
+  github: imsnif/bandwhich
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  bandwhich --version | grep {{version}}


### PR DESCRIPTION
Adds **bandwhich** (https://github.com/imsnif/bandwhich) — terminal bandwidth utilization by process/connection. From-source via cargo, modeled on zoxide.