### PR TITLE
new(crates.io/cargo-nextest): cargo-nextest 0.9.137

### DIFF
--- a/projects/crates.io/cargo-nextest/package.yml
+++ b/projects/crates.io/cargo-nextest/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/nextest-rs/nextest/archive/refs/tags/cargo-nextest-{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/cargo-nextest
+
+versions:
+  github: nextest-rs/nextest
+  strip: /^cargo-nextest-/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path cargo-nextest --root {{prefix}}
+
+test: |
+  cargo-nextest --version | grep {{version}}

--- a/projects/crates.io/cargo-nextest/package.yml
+++ b/projects/crates.io/cargo-nextest/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/nextest-rs/nextest/archive/refs/tags/cargo-nextest-{{version}}.tar.gz
+  url: https://github.com/nextest-rs/nextest/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -12,8 +12,8 @@ versions:
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path cargo-nextest --root {{prefix}}
+  script: cargo install --locked --path cargo-nextest --root {{prefix}}
 
-test: |
-  cargo-nextest --version | grep {{version}}
+test:
+  - cargo-nextest --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds **cargo-nextest** (https://github.com/nextest-rs/nextest) — a next-generation test runner for Rust. Workspace; bin is the `cargo-nextest/` member. Tags are prefixed `cargo-nextest-X.Y.Z` (handled via `strip`).