### PR TITLE
new(crates.io/cargo-watch): cargo-watch 8.5.3

### DIFF
--- a/projects/crates.io/cargo-watch/package.yml
+++ b/projects/crates.io/cargo-watch/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/watchexec/cargo-watch/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/cargo-watch
+
+versions:
+  github: watchexec/cargo-watch
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  cargo-watch --version | grep {{version}}

--- a/projects/crates.io/cargo-watch/package.yml
+++ b/projects/crates.io/cargo-watch/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/watchexec/cargo-watch/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/watchexec/cargo-watch/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,13 +7,12 @@ provides:
 
 versions:
   github: watchexec/cargo-watch
-  strip: /v/
 
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path . --root {{prefix}}
+  script: cargo install --locked --path . --root {{prefix}}
 
-test: |
-  cargo-watch --version | grep {{version}}
+test:
+  - cargo-watch --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds **cargo-watch** (https://github.com/watchexec/cargo-watch) — watches a Cargo project and runs build/test/run on change. From-source via cargo.