### PR TITLE
new(crates.io/mcfly): mcfly 0.9.4

### DIFF
--- a/projects/crates.io/mcfly/package.yml
+++ b/projects/crates.io/mcfly/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/cantino/mcfly/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/mcfly
+
+versions:
+  github: cantino/mcfly
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  mcfly --version | grep {{version}}

--- a/projects/crates.io/mcfly/package.yml
+++ b/projects/crates.io/mcfly/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/cantino/mcfly/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/cantino/mcfly/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,13 +7,12 @@ provides:
 
 versions:
   github: cantino/mcfly
-  strip: /v/
 
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path . --root {{prefix}}
+  script: cargo install --locked --path . --root {{prefix}}
 
-test: |
-  mcfly --version | grep {{version}}
+test:
+  - mcfly --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds **mcfly** (https://github.com/cantino/mcfly) — smart shell history search (a neural Ctrl-R replacement). From-source via cargo.