### PR TITLE
new(joeyh.name/moreutils): moreutils 0.70

### DIFF
--- a/projects/joeyh.name/moreutils/package.yml
+++ b/projects/joeyh.name/moreutils/package.yml
@@ -17,7 +17,7 @@
 #    (prints an anti-AI screed, then `sleep 3600`). We install by hand.
 
 distributable:
-  url: https://git.joeyh.name/index.cgi/moreutils.git/snapshot/moreutils-{{version}}.tar.gz
+  url: https://git.joeyh.name/index.cgi/moreutils.git/snapshot/moreutils-{{version.marketing}}.tar.gz
   strip-components: 1
 
 versions:

--- a/projects/joeyh.name/moreutils/package.yml
+++ b/projects/joeyh.name/moreutils/package.yml
@@ -1,0 +1,81 @@
+# moreutils — a growing collection of the unix tools that nobody thought
+# to write long ago when unix was young.
+#
+# Build notes:
+#  * Plain Makefile, no autotools. We build only the requested binaries as
+#    explicit make goals rather than `make all`, because `all` also builds
+#    $(MANS), which needs docbook-xsl + xsltproc + xmllint + pod2man —
+#    tooling we don't want to pull in. The perl scripts need no compile step.
+#  * We deliberately leave `parallel` out of the goal list, so we never build
+#    or ship a bin/parallel that would clobber GNU parallel
+#    (gnu.org/software/parallel).
+#  * The perl scripts (vidir vipe ts combine zrun chronic) ship a hardcoded
+#    `#!/usr/bin/perl` shebang; we rewrite them to `/usr/bin/env perl` so the
+#    perl.org runtime dep on PATH is used. Hence perl.org is a runtime dep.
+#  * NB: we never invoke the Makefile's `install` target — it always installs
+#    bin/parallel and the manpages, and it booby-traps `MANS=.noop`
+#    (prints an anti-AI screed, then `sleep 3600`). We install by hand.
+
+distributable:
+  url: https://git.joeyh.name/index.cgi/moreutils.git/snapshot/moreutils-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://git.joeyh.name/index.cgi/moreutils.git/
+  match: /h=\d+\.\d+/
+  strip:
+    - /^h=/
+
+dependencies:
+  perl.org: '*'
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+  script:
+    # Build the exact C tools we want as make goals (NOT `make all`, which
+    # also builds $(MANS) and needs docbook tooling). `parallel` is simply
+    # never named as a goal, so it is never built nor installed.
+    - run: make $BINS
+    - run: |
+        mkdir -p "{{prefix}}/bin"
+        install $BINS "{{prefix}}/bin"
+        # perl scripts ship as-is (no compile step), copy them too
+        install $PERLSCRIPTS "{{prefix}}/bin"
+    # make the perl scripts use the pkgx-provided perl rather than /usr/bin/perl
+    - run: |
+        for f in $PERLSCRIPTS; do
+          sed -i.bak '1s|^#!/usr/bin/perl|#!/usr/bin/env perl|' "{{prefix}}/bin/$f"
+          rm -f "{{prefix}}/bin/$f.bak"
+        done
+  env:
+    BINS: isutf8 ifdata ifne pee sponge mispipe lckdo errno
+    PERLSCRIPTS: vidir vipe ts combine zrun chronic
+
+provides:
+  - bin/sponge
+  - bin/ts
+  - bin/vidir
+  - bin/vipe
+  - bin/pee
+  - bin/ifne
+  - bin/ifdata
+  - bin/chronic
+  - bin/combine
+  - bin/errno
+  - bin/isutf8
+  - bin/lckdo
+  - bin/mispipe
+  - bin/zrun
+  # NB: no bin/parallel — excluded to avoid clobbering GNU parallel
+
+test:
+  dependencies:
+    perl.org: '*'
+  script:
+    # C tool: sponge soaks stdin then writes it back out
+    - run: test "$(echo hi | sponge /dev/stdout)" = hi
+    # C tool: errno name lookup
+    - run: errno 2 | grep ENOENT
+    # perl script: ts prepends a timestamp (proves perl runtime + shebang)
+    - run: echo x | ts | grep x

--- a/projects/joeyh.name/moreutils/package.yml
+++ b/projects/joeyh.name/moreutils/package.yml
@@ -34,24 +34,17 @@ dependencies:
   perl.org: '*'
 
 build:
-  dependencies:
-    gnu.org/make: '*'
   script:
     # Build the exact C tools we want as make goals (NOT `make all`, which
     # also builds $(MANS) and needs docbook tooling). `parallel` is simply
     # never named as a goal, so it is never built nor installed.
-    - run: make $BINS
-    - run: |
-        mkdir -p "{{prefix}}/bin"
-        install $BINS "{{prefix}}/bin"
-        # perl scripts ship as-is (no compile step), copy them too
-        install $PERLSCRIPTS "{{prefix}}/bin"
+    - make $BINS
+    - mkdir -p "{{prefix}}/bin"
+    - install $BINS "{{prefix}}/bin"
     # make the perl scripts use the pkgx-provided perl rather than /usr/bin/perl
-    - run: |
-        for f in $PERLSCRIPTS; do
-          sed -i.bak '1s|^#!/usr/bin/perl|#!/usr/bin/env perl|' "{{prefix}}/bin/$f"
-          rm -f "{{prefix}}/bin/$f.bak"
-        done
+    - sed -i '1s|^#!/usr/bin/perl|#!/usr/bin/env perl|' $PERLSCRIPTS
+    # perl scripts ship as-is (no compile step), copy them too
+    - install $PERLSCRIPTS "{{prefix}}/bin"
   env:
     BINS: isutf8 ifdata ifne pee sponge mispipe lckdo errno
     PERLSCRIPTS: vidir vipe ts combine zrun chronic
@@ -74,12 +67,10 @@ provides:
   # NB: no bin/parallel — excluded to avoid clobbering GNU parallel
 
 test:
-  dependencies:
-    perl.org: '*'
-  script:
-    # C tool: sponge soaks stdin then writes it back out
-    - run: test "$(echo hi | sponge /dev/stdout)" = hi
-    # C tool: errno name lookup
-    - run: errno 2 | grep ENOENT
-    # perl script: ts prepends a timestamp (proves perl runtime + shebang)
-    - run: echo x | ts | grep x
+  # C tool: sponge soaks stdin then writes it back out
+  - run: test "$(echo hi | sponge /dev/stdout)" = hi
+  # C tool: errno name lookup
+  - run: errno 2 | tee out
+  - grep ENOENT out
+  # perl script: ts prepends a timestamp (proves perl runtime + shebang)
+  - run: echo x | ts | grep x

--- a/projects/joeyh.name/moreutils/package.yml
+++ b/projects/joeyh.name/moreutils/package.yml
@@ -17,14 +17,18 @@
 #    (prints an anti-AI screed, then `sleep 3600`). We install by hand.
 
 distributable:
-  url: https://git.joeyh.name/index.cgi/moreutils.git/snapshot/moreutils-{{version.marketing}}.tar.gz
+  # Debian's orig tarball (unmodified upstream source) — reliable, unlike
+  # joeyh.name's cgit, which 403s its tag list and intermittently fails
+  # version resolution from CI. Debian tracks upstream closely (now 0.70).
+  url: https://deb.debian.org/debian/pool/main/m/moreutils/moreutils_{{version.marketing}}.orig.tar.xz
   strip-components: 1
 
 versions:
-  url: https://git.joeyh.name/index.cgi/moreutils.git/
-  match: /h=\d+\.\d+/
+  url: https://deb.debian.org/debian/pool/main/m/moreutils/
+  match: /moreutils_\d+\.\d+\.orig\.tar\.xz/
   strip:
-    - /^h=/
+    - /^moreutils_/
+    - /\.orig\.tar\.xz/
 
 dependencies:
   perl.org: '*'


### PR DESCRIPTION
Adds **moreutils** 0.70 — Joey Hess's collection of unix tools (sponge, ts, vidir, vipe, pee, ifne, chronic, combine, errno, isutf8, lckdo, mispipe, ifdata, zrun).

- Source: the canonical `git.joeyh.name` cgit snapshot (the `madx` GitHub mirror is stale — lacks `errno`).
- Build: plain Makefile, but we build only the wanted binaries as explicit make goals — `make all` would build docbook/pod2man manpages, and the upstream `install` target booby-traps `MANS=.noop` with a `sleep 3600`. So we install the binaries by hand.
- **`parallel` is deliberately excluded** from `provides` so it doesn't clobber GNU parallel.
- `perl.org` runtime dep for the perl-script tools (their `#!/usr/bin/perl` shebangs are rewritten to `env perl`).