### PR TITLE
new(github.com/hanslub42/rlwrap): rlwrap 0.48

### DIFF
--- a/projects/github.com/hanslub42/rlwrap/package.yml
+++ b/projects/github.com/hanslub42/rlwrap/package.yml
@@ -1,7 +1,7 @@
 distributable:
   # release tarball ships a pre-generated `configure` (verified: configure
   # + Makefile.in present), so no autoreconf/autoconf/automake needed
-  url: https://github.com/hanslub42/rlwrap/releases/download/v{{version}}/rlwrap-{{version}}.tar.gz
+  url: https://github.com/hanslub42/rlwrap/releases/download/v{{version.marketing}}/rlwrap-{{version.marketing}}.tar.gz
   strip-components: 1
 
 display-name: rlwrap
@@ -28,4 +28,4 @@ provides:
   - bin/rlwrap
 
 test:
-  - rlwrap --version 2>&1 | grep {{version}}
+  - rlwrap --version 2>&1 | grep {{version.marketing}}

--- a/projects/github.com/hanslub42/rlwrap/package.yml
+++ b/projects/github.com/hanslub42/rlwrap/package.yml
@@ -23,6 +23,7 @@ build:
     ARGS:
       - --prefix={{prefix}}
       - --disable-dependency-tracking
+      - --without-libptytty # optional pty lib, not in pantry; rlwrap works without it
 
 provides:
   - bin/rlwrap

--- a/projects/github.com/hanslub42/rlwrap/package.yml
+++ b/projects/github.com/hanslub42/rlwrap/package.yml
@@ -13,8 +13,6 @@ dependencies:
   gnu.org/readline: '*'
 
 build:
-  dependencies:
-    freedesktop.org/pkg-config: '*'
   script:
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}
@@ -29,4 +27,5 @@ provides:
   - bin/rlwrap
 
 test:
-  - rlwrap --version 2>&1 | grep {{version.marketing}}
+  - rlwrap --version 2>&1 | tee out
+  - grep {{version.marketing}} out

--- a/projects/github.com/hanslub42/rlwrap/package.yml
+++ b/projects/github.com/hanslub42/rlwrap/package.yml
@@ -1,0 +1,31 @@
+distributable:
+  # release tarball ships a pre-generated `configure` (verified: configure
+  # + Makefile.in present), so no autoreconf/autoconf/automake needed
+  url: https://github.com/hanslub42/rlwrap/releases/download/v{{version}}/rlwrap-{{version}}.tar.gz
+  strip-components: 1
+
+display-name: rlwrap
+
+versions:
+  github: hanslub42/rlwrap/tags
+
+dependencies:
+  gnu.org/readline: '*'
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - --prefix={{prefix}}
+      - --disable-dependency-tracking
+
+provides:
+  - bin/rlwrap
+
+test:
+  - rlwrap --version 2>&1 | grep {{version}}


### PR DESCRIPTION
Adds **rlwrap** (https://github.com/hanslub42/rlwrap) — wraps any command with GNU readline editing/history/completion. Built from the release tarball (ships a pre-generated `configure`, no autoreconf). Deps: `gnu.org/readline` (runtime), pkg-config (build).