### PR TITLE
new(hpjansson.org/chafa): chafa 1.18.2

### DIFF
--- a/projects/hpjansson.org/chafa/package.yml
+++ b/projects/hpjansson.org/chafa/package.yml
@@ -9,8 +9,6 @@ dependencies:
   gnome.org/glib: '*'
 
 build:
-  dependencies:
-    freedesktop.org/pkg-config: '*'
   script:
     - ./configure $ARGS
     - make --jobs {{ hw.concurrency }}
@@ -23,4 +21,6 @@ build:
 provides:
   - bin/chafa
 
-test: chafa --version 2>&1 | grep {{version}}
+test:
+  - chafa --version 2>&1 | tee out
+  - grep {{version}} out

--- a/projects/hpjansson.org/chafa/package.yml
+++ b/projects/hpjansson.org/chafa/package.yml
@@ -1,0 +1,26 @@
+distributable:
+  url: https://github.com/hpjansson/chafa/releases/download/{{version}}/chafa-{{version}}.tar.xz
+  strip-components: 1
+
+versions:
+  github: hpjansson/chafa/tags
+
+dependencies:
+  gnome.org/glib: '*'
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - --prefix={{prefix}}
+      - --disable-dependency-tracking
+
+provides:
+  - bin/chafa
+
+test: chafa --version 2>&1 | grep {{version}}


### PR DESCRIPTION
Adds **chafa** (https://hpjansson.org/chafa/) — renders images as ANSI/sixel/kitty/iTerm2 terminal graphics. Built from the release tarball (`.tar.xz`, ships `configure`). Only hard dep is `gnome.org/glib`; optional format backends autodetect.