### PR TITLE
new(github.com/traviscross/mtr): mtr 0.96

### DIFF
--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -24,7 +24,7 @@ build:
   env:
     # Force-link ncurses after the objects: lld (single-pass) drops a curses
     # lib that configure places before the objects, leaving stdscr undefined.
-    LIBS: -lncurses
+    LIBS: -lncursesw
     ARGS:
       - --prefix={{prefix}}
       - --without-gtk # skip the GTK+ GUI; keep curses `mtr` + `mtr-packet`

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -22,6 +22,9 @@ build:
     - make --jobs {{ hw.concurrency }}
     - make install
   env:
+    # Force-link ncurses after the objects: lld (single-pass) drops a curses
+    # lib that configure places before the objects, leaving stdscr undefined.
+    LIBS: -lncurses
     ARGS:
       - --prefix={{prefix}}
       - --without-gtk # skip the GTK+ GUI; keep curses `mtr` + `mtr-packet`
@@ -32,4 +35,5 @@ provides:
 
 # mtr needs raw-socket / setuid privileges to actually trace at runtime,
 # but `--version` parses args and exits before any privilege/socket setup.
-test: mtr --version 2>&1 | grep {{version}}
+# mtr reports its bare upstream version (mtr 0.96); pantry pads it to 0.96.0.
+test: mtr --version 2>&1 | grep {{version.marketing}}

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -22,12 +22,9 @@ build:
     - make --jobs {{ hw.concurrency }}
     - make install
   env:
-    # Point at the pantry ncursesw headers so stdscr binds to the lib's
-    # (reentrant) accessor; without them mtr found a fallback curses.h and
-    # referenced stdscr as a plain symbol the lib doesn't export. lld also
-    # needs the lib after the objects, hence LIBS.
-    # lld defaults to --as-needed and drops libncursesw (seen before the objects
-    # that reference stdscr/raw), leaving them undefined; force it to keep the lib.
+    # configure detects ncursesw and adds -lncursesw, but lld defaults to
+    # --as-needed and drops it (seen before the objects that reference
+    # stdscr/raw), leaving them undefined; force it to keep the lib.
     LDFLAGS: -Wl,--no-as-needed
     LIBS: -lncursesw
     ARGS:

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -4,7 +4,6 @@ distributable:
 
 versions:
   github: traviscross/mtr/tags
-  strip: /^v/
 
 dependencies:
   invisible-island.net/ncurses: 6
@@ -13,7 +12,6 @@ build:
   dependencies:
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
-    freedesktop.org/pkg-config: '*' # provides PKG_CHECK_MODULES m4 macros for bootstrap.sh
   script:
     # the GitHub source archive ships configure.ac + bootstrap.sh but no
     # pre-generated configure (no dist tarball is published on GitHub Releases)
@@ -40,4 +38,6 @@ provides:
 # mtr needs raw-socket / setuid privileges to actually trace at runtime,
 # but `--version` parses args and exits before any privilege/socket setup.
 # mtr reports its bare upstream version (mtr 0.96); pantry pads it to 0.96.0.
-test: mtr --version 2>&1 | grep {{version.marketing}}
+test:
+  - mtr --version 2>&1 | tee out
+  - grep {{version.marketing}} out

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -19,13 +19,9 @@ build:
     # pre-generated configure (no dist tarball is published on GitHub Releases)
     - ./bootstrap.sh
     - ./configure $ARGS
-    - make --jobs {{ hw.concurrency }}
+    - make --jobs {{ hw.concurrency }} V=1
     - make install
   env:
-    # configure detects ncursesw and adds -lncursesw, but lld defaults to
-    # --as-needed and drops it (seen before the objects that reference
-    # stdscr/raw), leaving them undefined; force it to keep the lib.
-    LDFLAGS: -Wl,--no-as-needed
     LIBS: -lncursesw
     ARGS:
       - --prefix={{prefix}}

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -19,10 +19,16 @@ build:
     # pre-generated configure (no dist tarball is published on GitHub Releases)
     - ./bootstrap.sh
     - ./configure $ARGS
-    - make --jobs {{ hw.concurrency }} V=1
+    - make --jobs {{ hw.concurrency }}
     - make install
   env:
     LIBS: -lncursesw
+    linux:
+      # On linux the pantry ncurses splits stdscr/raw (and the other curses
+      # globals) into libtinfow; libncursesw only NEEDs it transitively, and
+      # lld won't resolve the executable's symbols from a transitive dep, so
+      # link libtinfow directly. (darwin's ncurses isn't split this way.)
+      LIBS: -lncursesw -ltinfow
     ARGS:
       - --prefix={{prefix}}
       - --without-gtk # skip the GTK+ GUI; keep curses `mtr` + `mtr-packet`

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -1,0 +1,35 @@
+distributable:
+  url: https://github.com/traviscross/mtr/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: traviscross/mtr/tags
+  strip: /^v/
+
+dependencies:
+  invisible-island.net/ncurses: 6
+
+build:
+  dependencies:
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
+    freedesktop.org/pkg-config: '*' # provides PKG_CHECK_MODULES m4 macros for bootstrap.sh
+  script:
+    # the GitHub source archive ships configure.ac + bootstrap.sh but no
+    # pre-generated configure (no dist tarball is published on GitHub Releases)
+    - ./bootstrap.sh
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - --prefix={{prefix}}
+      - --without-gtk # skip the GTK+ GUI; keep curses `mtr` + `mtr-packet`
+
+provides:
+  - bin/mtr
+  - bin/mtr-packet
+
+# mtr needs raw-socket / setuid privileges to actually trace at runtime,
+# but `--version` parses args and exits before any privilege/socket setup.
+test: mtr --version 2>&1 | grep {{version}}

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -12,6 +12,7 @@ build:
   dependencies:
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
+    freedesktop.org/pkg-config: '*'
   script:
     # the GitHub source archive ships configure.ac + bootstrap.sh but no
     # pre-generated configure (no dist tarball is published on GitHub Releases)

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -22,8 +22,11 @@ build:
     - make --jobs {{ hw.concurrency }}
     - make install
   env:
-    # Force-link ncurses after the objects: lld (single-pass) drops a curses
-    # lib that configure places before the objects, leaving stdscr undefined.
+    # Point at the pantry ncursesw headers so stdscr binds to the lib's
+    # (reentrant) accessor; without them mtr found a fallback curses.h and
+    # referenced stdscr as a plain symbol the lib doesn't export. lld also
+    # needs the lib after the objects, hence LIBS.
+    CPPFLAGS: -I{{deps.invisible-island.net/ncurses.prefix}}/include
     LIBS: -lncursesw
     ARGS:
       - --prefix={{prefix}}

--- a/projects/github.com/traviscross/mtr/package.yml
+++ b/projects/github.com/traviscross/mtr/package.yml
@@ -26,7 +26,9 @@ build:
     # (reentrant) accessor; without them mtr found a fallback curses.h and
     # referenced stdscr as a plain symbol the lib doesn't export. lld also
     # needs the lib after the objects, hence LIBS.
-    CPPFLAGS: -I{{deps.invisible-island.net/ncurses.prefix}}/include
+    # lld defaults to --as-needed and drops libncursesw (seen before the objects
+    # that reference stdscr/raw), leaving them undefined; force it to keep the lib.
+    LDFLAGS: -Wl,--no-as-needed
     LIBS: -lncursesw
     ARGS:
       - --prefix={{prefix}}


### PR DESCRIPTION
Adds **mtr** (My TraceRoute, https://github.com/traviscross/mtr) — combined ping + traceroute. C/autotools; the tag archive has no pre-generated `configure`, so the build runs `./bootstrap.sh` (autoconf/automake; pkg-config needed for `PKG_CHECK_MODULES` at bootstrap). `--without-gtk` keeps the curses `mtr` + `mtr-packet`; runtime dep `invisible-island.net/ncurses`. The `--version` test runs unprivileged (prints/exits before any raw-socket/setuid setup).