### PR TITLE
new(passwordstore.org): pass 1.7.4

### DIFF
--- a/projects/passwordstore.org/package.yml
+++ b/projects/passwordstore.org/package.yml
@@ -1,0 +1,27 @@
+distributable:
+  url: https://git.zx2c4.com/password-store/snapshot/password-store-{{version}}.tar.xz
+  strip-components: 1
+
+versions:
+  github: zx2c4/password-store/tags
+
+# pass is a bash script; there is nothing to compile. The Makefile honors
+# DESTDIR + PREFIX (BINDIR=$PREFIX/bin, MANDIR=$PREFIX/share/man, etc).
+runtime:
+  dependencies:
+    gnu.org/bash: '*'
+    gnupg.org: '*'
+    gitlab.com/OldManProgrammer/unix-tree: '*'
+    git-scm.org: '*'
+
+build:
+  script:
+    - make install PREFIX={{prefix}}
+
+test:
+  # `pass version` (and `pass --version`) print a banner containing `v<version>`
+  - pass version 2>&1 | grep 'v{{version}}'
+  - pass --version 2>&1 | grep 'v{{version}}'
+
+provides:
+  - bin/pass

--- a/projects/passwordstore.org/package.yml
+++ b/projects/passwordstore.org/package.yml
@@ -7,21 +7,19 @@ versions:
 
 # pass is a bash script; there is nothing to compile. The Makefile honors
 # DESTDIR + PREFIX (BINDIR=$PREFIX/bin, MANDIR=$PREFIX/share/man, etc).
-runtime:
-  dependencies:
-    gnu.org/bash: '*'
-    gnupg.org: '*'
-    gitlab.com/OldManProgrammer/unix-tree: '*'
-    git-scm.org: '*'
+companions:
+  gnupg.org: '*'
+  gitlab.com/OldManProgrammer/unix-tree: '*'
+  git-scm.org: '*'
 
-build:
-  script:
-    - make install PREFIX={{prefix}}
+build: make install PREFIX={{prefix}}
 
 test:
   # `pass version` (and `pass --version`) print a banner containing `v<version>`
-  - pass version 2>&1 | grep 'v{{version}}'
-  - pass --version 2>&1 | grep 'v{{version}}'
+  - pass version 2>&1 | tee out
+  - grep 'v{{version}}' out
+  - pass --version 2>&1 | tee out
+  - grep 'v{{version}}' out
 
 provides:
   - bin/pass


### PR DESCRIPTION
Adds **pass** (https://www.passwordstore.org/) — the standard unix password manager (password-store) by Jason A. Donenfeld. A bash script installed via its Makefile (`make install PREFIX={{prefix}}`). Runtime deps: `gnu.org/bash`, `gnupg.org` (gpg), `gitlab.com/OldManProgrammer/unix-tree` (tree, for `pass ls`), `git-scm.org` (optional `pass git`). Source: the zx2c4 canonical snapshot tarball.