### PR TITLE
new(github.com/magic-wormhole/magic-wormhole): magic-wormhole 0.24.0

### DIFF
--- a/projects/github.com/magic-wormhole/magic-wormhole/package.yml
+++ b/projects/github.com/magic-wormhole/magic-wormhole/package.yml
@@ -1,0 +1,36 @@
+# https://github.com/magic-wormhole/magic-wormhole
+# get things from one computer to another, safely (short-code file transfer)
+
+distributable:
+  url: https://files.pythonhosted.org/packages/source/m/magic-wormhole/magic_wormhole-{{version}}.tar.gz
+
+versions:
+  url: https://pypi.org/simple/magic-wormhole/
+  match: /magic_wormhole-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /magic_wormhole-/
+    - /\.tar\.gz/
+
+dependencies:
+  pkgx.sh: ">=1"
+  python.org: "~3.11"
+
+runtime:
+  env:
+    PYTHONPATH: ${{prefix}}/venv/lib/python{{deps.python.org.version.marketing}}/site-packages
+
+build:
+  dependencies:
+    python.org: "~3.11"
+  script:
+    - bkpyvenv stage {{prefix}} {{version}}
+    # pip pulls binary wheels for the C-extension deps (pynacl/libsodium,
+    # cryptography); no compiler needed on the supported platforms.
+    - "{{prefix}}/venv/bin/pip install magic-wormhole=={{version}}"
+    - bkpyvenv seal {{prefix}} wormhole
+
+provides:
+  - bin/wormhole
+
+test:
+  - wormhole --version 2>&1 | grep {{version}}

--- a/projects/github.com/magic-wormhole/magic-wormhole/package.yml
+++ b/projects/github.com/magic-wormhole/magic-wormhole/package.yml
@@ -15,8 +15,7 @@ versions:
 # wheel, and the rust+openssl source build is impractical there. The other
 # platforms install cryptography/cbor2/pynacl from wheels cleanly.
 platforms:
-  - linux/x86-64
-  - linux/aarch64
+  - linux
   - darwin/aarch64
 
 dependencies:
@@ -34,11 +33,12 @@ build:
     - bkpyvenv stage {{prefix}} {{version}}
     # pip resolves binary wheels for the C/Rust deps (cryptography, pynacl,
     # cbor2) on these platforms; no compiler/toolchain needed.
-    - "{{prefix}}/venv/bin/pip install magic-wormhole=={{version}}"
+    - "{{prefix}}/venv/bin/pip install ."
     - bkpyvenv seal {{prefix}} wormhole
 
 provides:
   - bin/wormhole
 
 test:
-  - wormhole --version 2>&1 | grep {{version}}
+  - wormhole --version 2>&1 | tee out
+  - grep {{version}} out

--- a/projects/github.com/magic-wormhole/magic-wormhole/package.yml
+++ b/projects/github.com/magic-wormhole/magic-wormhole/package.yml
@@ -3,6 +3,7 @@
 
 distributable:
   url: https://files.pythonhosted.org/packages/source/m/magic-wormhole/magic_wormhole-{{version}}.tar.gz
+  strip-components: 1
 
 versions:
   url: https://pypi.org/simple/magic-wormhole/

--- a/projects/github.com/magic-wormhole/magic-wormhole/package.yml
+++ b/projects/github.com/magic-wormhole/magic-wormhole/package.yml
@@ -11,6 +11,14 @@ versions:
     - /magic_wormhole-/
     - /\.tar\.gz/
 
+# darwin/x86-64 omitted: its pantry python has no matching cryptography
+# wheel, and the rust+openssl source build is impractical there. The other
+# platforms install cryptography/cbor2/pynacl from wheels cleanly.
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+  - darwin/aarch64
+
 dependencies:
   pkgx.sh: ">=1"
   python.org: "~3.11"
@@ -22,19 +30,10 @@ runtime:
 build:
   dependencies:
     python.org: "~3.11"
-    # cryptography/pynacl have no prebuilt wheel for the pantry darwin-x64
-    # python, so pip source-builds them: cryptography needs rust + openssl,
-    # the C extensions need a compiler (present).
-    rust-lang.org/cargo: '*'
-    openssl.org: '*'
-  env:
-    OPENSSL_DIR: "${{deps.openssl.org.prefix}}"
-    CBOR2_BUILD_C_EXTENSION: "0" # build cbor2 pure-Python (no wheel needed)
   script:
     - bkpyvenv stage {{prefix}} {{version}}
-    # Upgrade pip so it matches current wheel tags; where no wheel exists
-    # (pantry darwin-x64 python) cryptography source-builds via rust+openssl.
-    - "{{prefix}}/venv/bin/pip install --upgrade pip"
+    # pip resolves binary wheels for the C/Rust deps (cryptography, pynacl,
+    # cbor2) on these platforms; no compiler/toolchain needed.
     - "{{prefix}}/venv/bin/pip install magic-wormhole=={{version}}"
     - bkpyvenv seal {{prefix}} wormhole
 

--- a/projects/github.com/magic-wormhole/magic-wormhole/package.yml
+++ b/projects/github.com/magic-wormhole/magic-wormhole/package.yml
@@ -24,10 +24,16 @@ build:
     python.org: "~3.11"
   script:
     - bkpyvenv stage {{prefix}} {{version}}
-    # pip pulls binary wheels for the C-extension deps (pynacl/libsodium,
-    # cryptography); no compiler needed on the supported platforms.
+    # The staged pip (24.0) is too old to match the current macOS/manylinux
+    # wheel tags for cryptography, so it fell back to a (failing) source build.
+    # Upgrade pip first so it resolves the prebuilt wheels.
+    - "{{prefix}}/venv/bin/pip install --upgrade pip"
     - "{{prefix}}/venv/bin/pip install magic-wormhole=={{version}}"
     - bkpyvenv seal {{prefix}} wormhole
+  env:
+    # cbor2's C extension is optional; build it pure-Python so no C toolchain
+    # is needed if its wheel is ever missing.
+    CBOR2_BUILD_C_EXTENSION: "0"
 
 provides:
   - bin/wormhole

--- a/projects/github.com/magic-wormhole/magic-wormhole/package.yml
+++ b/projects/github.com/magic-wormhole/magic-wormhole/package.yml
@@ -22,18 +22,21 @@ runtime:
 build:
   dependencies:
     python.org: "~3.11"
+    # cryptography/pynacl have no prebuilt wheel for the pantry darwin-x64
+    # python, so pip source-builds them: cryptography needs rust + openssl,
+    # the C extensions need a compiler (present).
+    rust-lang.org/cargo: '*'
+    openssl.org: '*'
+  env:
+    OPENSSL_DIR: "${{deps.openssl.org.prefix}}"
+    CBOR2_BUILD_C_EXTENSION: "0" # build cbor2 pure-Python (no wheel needed)
   script:
     - bkpyvenv stage {{prefix}} {{version}}
-    # The staged pip (24.0) is too old to match the current macOS/manylinux
-    # wheel tags for cryptography, so it fell back to a (failing) source build.
-    # Upgrade pip first so it resolves the prebuilt wheels.
+    # Upgrade pip so it matches current wheel tags; where no wheel exists
+    # (pantry darwin-x64 python) cryptography source-builds via rust+openssl.
     - "{{prefix}}/venv/bin/pip install --upgrade pip"
     - "{{prefix}}/venv/bin/pip install magic-wormhole=={{version}}"
     - bkpyvenv seal {{prefix}} wormhole
-  env:
-    # cbor2's C extension is optional; build it pure-Python so no C toolchain
-    # is needed if its wheel is ever missing.
-    CBOR2_BUILD_C_EXTENSION: "0"
 
 provides:
   - bin/wormhole


### PR DESCRIPTION
Adds **magic-wormhole** (https://github.com/magic-wormhole/magic-wormhole) — securely transfer files between computers via a short one-time code (SPAKE2-negotiated). Binary `wormhole`. Python app installed into a venv via the `bkpyvenv` idiom (modeled on `localstack.cloud/awscli-local`). pip resolves wheels for the C/Rust extensions (pynacl, cryptography).