### PR TITLE
new(crates.io/fclones): fclones 0.35.0

### DIFF
--- a/projects/crates.io/fclones/package.yml
+++ b/projects/crates.io/fclones/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/pkolaczk/fclones/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/fclones
+
+versions:
+  github: pkolaczk/fclones
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path fclones --root {{prefix}}
+
+test: |
+  fclones --version | grep {{version}}

--- a/projects/crates.io/fclones/package.yml
+++ b/projects/crates.io/fclones/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/pkolaczk/fclones/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/pkolaczk/fclones/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,13 +7,12 @@ provides:
 
 versions:
   github: pkolaczk/fclones
-  strip: /v/
 
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path fclones --root {{prefix}}
+  script: cargo install --locked --path fclones --root {{prefix}}
 
-test: |
-  fclones --version | grep {{version}}
+test:
+  - fclones --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds **fclones** (https://github.com/pkolaczk/fclones) — an efficient duplicate file finder & remover. Cargo workspace; the bin is the `fclones/` member.