### PR TITLE
new(crates.io/presenterm): presenterm 0.16.1

### DIFF
--- a/projects/crates.io/presenterm/package.yml
+++ b/projects/crates.io/presenterm/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/mfontanini/presenterm/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/presenterm
+
+versions:
+  github: mfontanini/presenterm
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  presenterm --version | grep {{version}}

--- a/projects/crates.io/presenterm/package.yml
+++ b/projects/crates.io/presenterm/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/mfontanini/presenterm/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/mfontanini/presenterm/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,13 +7,12 @@ provides:
 
 versions:
   github: mfontanini/presenterm
-  strip: /v/
 
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path . --root {{prefix}}
+  script: cargo install --locked --path . --root {{prefix}}
 
-test: |
-  presenterm --version | grep {{version}}
+test:
+  - presenterm --version | tee out
+  - grep {{version}} out


### PR DESCRIPTION
Adds **presenterm** (https://github.com/mfontanini/presenterm) — markdown-based terminal slideshows. From-source via cargo; `syntect`'s bundled Oniguruma compiles via cc.