### PR TITLE
new(crates.io/erdtree): erdtree 3.1.2

### DIFF
--- a/projects/crates.io/erdtree/package.yml
+++ b/projects/crates.io/erdtree/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/solidiquis/erdtree/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/solidiquis/erdtree/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,13 +7,12 @@ provides:
 
 versions:
   github: solidiquis/erdtree
-  strip: /v/
 
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path . --root {{prefix}}
+  script: cargo install --locked --path . --root {{prefix}}
 
-test: |
-  erd --version | grep {{version}}
+test:
+  - erd --version | tee out
+  - grep {{version}} out

--- a/projects/crates.io/erdtree/package.yml
+++ b/projects/crates.io/erdtree/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/solidiquis/erdtree/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/erd
+
+versions:
+  github: solidiquis/erdtree
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  erd --version | grep {{version}}


### PR DESCRIPTION
Adds **erdtree** (https://github.com/solidiquis/erdtree) — a modern `tree` + `du`. Crate `erdtree`, binary **`erd`** (`provides: [bin/erd]`).