### PR TITLE
new(crates.io/choose): choose 1.3.7

### DIFF
--- a/projects/crates.io/choose/package.yml
+++ b/projects/crates.io/choose/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/theryangeary/choose/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/theryangeary/choose/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,14 +7,13 @@ provides:
 
 versions:
   github: theryangeary/choose
-  strip: /v/
 
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path . --root {{prefix}}
+  script: cargo install --locked --path . --root {{prefix}}
 
-test: |
-  choose --version | grep {{version}}
-  test "$(echo 'a b c' | choose 1)" = "b"
+test:
+  - choose --version | tee out
+  - grep {{version}} out
+  - test "$(echo 'a b c' | choose 1)" = "b"

--- a/projects/crates.io/choose/package.yml
+++ b/projects/crates.io/choose/package.yml
@@ -1,0 +1,20 @@
+distributable:
+  url: https://github.com/theryangeary/choose/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/choose
+
+versions:
+  github: theryangeary/choose
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  choose --version | grep {{version}}
+  test "$(echo 'a b c' | choose 1)" = "b"


### PR DESCRIPTION
Adds **choose** (https://github.com/theryangeary/choose) — a fast, human-friendly alternative to `cut`/`awk` for field selection. Test: `echo 'a b c' | choose 1` -> `b`.