### PR TITLE
new(crates.io/television): television 0.15.9

### DIFF
--- a/projects/crates.io/television/package.yml
+++ b/projects/crates.io/television/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/alexpasmantier/television/archive/refs/tags/{{version}}.tar.gz
+  url: https://github.com/alexpasmantier/television/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -11,8 +11,8 @@ versions:
 build:
   dependencies:
     rust-lang.org/cargo: '*'
-  script:
-    cargo install --locked --path . --root {{prefix}}
+  script: cargo install --locked --path . --root {{prefix}}
 
-test: |
-  tv --version | grep {{version}}
+test:
+  - tv --version | tee out
+  - grep {{version}} out

--- a/projects/crates.io/television/package.yml
+++ b/projects/crates.io/television/package.yml
@@ -1,0 +1,18 @@
+distributable:
+  url: https://github.com/alexpasmantier/television/archive/refs/tags/{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/tv
+
+versions:
+  github: alexpasmantier/television
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  tv --version | grep {{version}}


### PR DESCRIPTION
Adds **television** (https://github.com/alexpasmantier/television) — a fast, hackable fuzzy-finder TUI. Binary **`tv`**. Tags are bare semver (no `v` prefix). From-source via cargo.