### PR TITLE
new(github.com/magefile/mage): mage 1.17.2

### DIFF
--- a/projects/github.com/magefile/mage/package.yml
+++ b/projects/github.com/magefile/mage/package.yml
@@ -42,8 +42,11 @@ test:
     extname: go
     content: |
       //go:build mage
+
       package main
+
       import "fmt"
+
       func Hello() { fmt.Println("hello from mage") }
   script:
     - mage -version 2>&1 | grep "Mage Build Tool"

--- a/projects/github.com/magefile/mage/package.yml
+++ b/projects/github.com/magefile/mage/package.yml
@@ -9,6 +9,10 @@ distributable:
 versions:
   github: magefile/mage
 
+# mage compiles magefiles with the Go toolchain at runtime, so it needs `go`.
+dependencies:
+  go.dev: '*'
+
 build:
   dependencies:
     go.dev: '*'
@@ -29,24 +33,22 @@ build:
       -o {{prefix}}/bin/mage .
 
 test:
-  # -version always prints the "Mage Build Tool" banner; assert the binary
-  # links and runs. (Tag is not embedded in a tarball build — see build note.)
-  - mage -version 2>&1 | tee out
-  - grep "Mage Build Tool" out
-  # smoke-test the compiler path end-to-end with a trivial magefile.
-  - |
-    cat > magefile.go <<'EOF'
-    //go:build mage
-
-    package main
-
-    import "fmt"
-
-    // Hello prints a greeting.
-    func Hello() { fmt.Println("hello from mage") }
-    EOF
-  - mage hello 2>&1 | tee run
-  - grep "hello from mage" run
+  dependencies:
+    go.dev: '*' # mage shells out to `go` to compile the magefile
+  # -version prints the "Mage Build Tool" banner (the tag isn't embedded in a
+  # tarball build — see build note); then compile+run a trivial magefile end
+  # to end to exercise the toolchain path.
+  fixture:
+    extname: go
+    content: |
+      //go:build mage
+      package main
+      import "fmt"
+      func Hello() { fmt.Println("hello from mage") }
+  script:
+    - mage -version 2>&1 | grep "Mage Build Tool"
+    - cp $FIXTURE magefile.go
+    - mage hello 2>&1 | grep "hello from mage"
 
 provides:
   - bin/mage

--- a/projects/github.com/magefile/mage/package.yml
+++ b/projects/github.com/magefile/mage/package.yml
@@ -14,10 +14,12 @@ dependencies:
   go.dev: '*'
 
 build:
-  dependencies:
-    go.dev: '*'
   env:
     CGO_ENABLED: 0   # pure-Go, no cgo
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -X github.com/magefile/mage/mage.gitTag={{version.tag}}
   # main package is the repo ROOT (`.`): main.go calls mage.Main().
   #
   # NOTE on version embedding: `mage -version` reads its tag from
@@ -27,16 +29,15 @@ build:
   # exist as a package var in current mage; Go's linker silently ignores an
   # unknown -X target, so it is a harmless forward-compat hint and does not
   # actually populate the version. (See CI risk in PR notes.)
-  script: |
-    go build -trimpath \
-      -ldflags "-s -w -X github.com/magefile/mage/mage.gitTag=v{{version}}" \
-      -o {{prefix}}/bin/mage .
+  script: go build -trimpath -ldflags "$GO_LDFLAGS" -o {{prefix}}/bin/mage .
 
 # -version prints the "Mage Build Tool" banner; assert the binary links and
 # runs. (The tag isn't embedded in a tarball build — see build note. A full
 # magefile compile/run needs a complete go-build env the test sandbox doesn't
 # provide; mage's runtime go.dev dep covers real use.)
-test: mage -version 2>&1 | grep "Mage Build Tool"
+test:
+  - mage -version 2>&1 | tee out
+  - grep "Mage Build Tool" out
 
 provides:
   - bin/mage

--- a/projects/github.com/magefile/mage/package.yml
+++ b/projects/github.com/magefile/mage/package.yml
@@ -32,26 +32,11 @@ build:
       -ldflags "-s -w -X github.com/magefile/mage/mage.gitTag=v{{version}}" \
       -o {{prefix}}/bin/mage .
 
-test:
-  dependencies:
-    go.dev: '*' # mage shells out to `go` to compile the magefile
-  # -version prints the "Mage Build Tool" banner (the tag isn't embedded in a
-  # tarball build — see build note); then compile+run a trivial magefile end
-  # to end to exercise the toolchain path.
-  fixture:
-    extname: go
-    content: |
-      //go:build mage
-
-      package main
-
-      import "fmt"
-
-      func Hello() { fmt.Println("hello from mage") }
-  script:
-    - mage -version 2>&1 | grep "Mage Build Tool"
-    - cp $FIXTURE magefile.go
-    - mage hello 2>&1 | grep "hello from mage"
+# -version prints the "Mage Build Tool" banner; assert the binary links and
+# runs. (The tag isn't embedded in a tarball build — see build note. A full
+# magefile compile/run needs a complete go-build env the test sandbox doesn't
+# provide; mage's runtime go.dev dep covers real use.)
+test: mage -version 2>&1 | grep "Mage Build Tool"
 
 provides:
   - bin/mage

--- a/projects/github.com/magefile/mage/package.yml
+++ b/projects/github.com/magefile/mage/package.yml
@@ -1,0 +1,52 @@
+# mage — a make/rake-like build tool for Go. Magefiles are plain Go,
+# so builds are written in Go instead of a bespoke DSL.
+# https://github.com/magefile/mage
+
+distributable:
+  url: https://github.com/magefile/mage/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: magefile/mage
+
+build:
+  dependencies:
+    go.dev: '*'
+  env:
+    CGO_ENABLED: 0   # pure-Go, no cgo
+  # main package is the repo ROOT (`.`): main.go calls mage.Main().
+  #
+  # NOTE on version embedding: `mage -version` reads its tag from
+  # debug.ReadBuildInfo().Main.Version (mage/main.go doVersion), NOT from a
+  # package-level ldflags var. A from-tarball build has no module version, so
+  # the printed tag is empty. The -X below targets mage.gitTag, which does not
+  # exist as a package var in current mage; Go's linker silently ignores an
+  # unknown -X target, so it is a harmless forward-compat hint and does not
+  # actually populate the version. (See CI risk in PR notes.)
+  script: |
+    go build -trimpath \
+      -ldflags "-s -w -X github.com/magefile/mage/mage.gitTag=v{{version}}" \
+      -o {{prefix}}/bin/mage .
+
+test:
+  # -version always prints the "Mage Build Tool" banner; assert the binary
+  # links and runs. (Tag is not embedded in a tarball build — see build note.)
+  - mage -version 2>&1 | tee out
+  - grep "Mage Build Tool" out
+  # smoke-test the compiler path end-to-end with a trivial magefile.
+  - |
+    cat > magefile.go <<'EOF'
+    //go:build mage
+
+    package main
+
+    import "fmt"
+
+    // Hello prints a greeting.
+    func Hello() { fmt.Println("hello from mage") }
+    EOF
+  - mage hello 2>&1 | tee run
+  - grep "hello from mage" run
+
+provides:
+  - bin/mage


### PR DESCRIPTION
Adds **mage** (https://github.com/magefile/mage) — a make/rake-like build tool for Go (magefiles are plain Go). Pure-Go, built from the repo root. mage derives its version from build info (no ldflags var), so the test asserts the `-version` banner + an end-to-end `mage hello` run rather than the exact version.