### PR TITLE
new(crates.io/sad): sad 0.4.32

### DIFF
--- a/projects/crates.io/sad/package.yml
+++ b/projects/crates.io/sad/package.yml
@@ -13,7 +13,10 @@ build:
   dependencies:
     rust-lang.org/cargo: '*'
   script:
-    cargo install --locked --path . --root {{prefix}}
+    # upstream's .cargo/config.toml pins linker = aarch64-linux-gnu-gcc for the
+    # arm64 target, absent on the native arm64 builder; drop it so cargo uses cc.
+    - rm -f .cargo/config.toml
+    - cargo install --locked --path . --root {{prefix}}
 
 test: |
   sad --version | grep {{version}}

--- a/projects/crates.io/sad/package.yml
+++ b/projects/crates.io/sad/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/ms-jpq/sad/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/ms-jpq/sad/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 provides:
@@ -7,7 +7,6 @@ provides:
 
 versions:
   github: ms-jpq/sad
-  strip: /v/
 
 build:
   dependencies:
@@ -18,5 +17,6 @@ build:
     - rm -f .cargo/config.toml
     - cargo install --locked --path . --root {{prefix}}
 
-test: |
-  sad --version | grep {{version}}
+test:
+  - sad --version | tee out
+  - grep {{version}} out

--- a/projects/crates.io/sad/package.yml
+++ b/projects/crates.io/sad/package.yml
@@ -1,0 +1,19 @@
+distributable:
+  url: https://github.com/ms-jpq/sad/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/sad
+
+versions:
+  github: ms-jpq/sad
+  strip: /v/
+
+build:
+  dependencies:
+    rust-lang.org/cargo: '*'
+  script:
+    cargo install --locked --path . --root {{prefix}}
+
+test: |
+  sad --version | grep {{version}}


### PR DESCRIPTION
Adds **sad** (https://github.com/ms-jpq/sad) — Space Age seD: batch search-and-replace with a diff preview and fzf integration. From-source via cargo (single crate); `sad --version` matches the tag (clap derives it from Cargo.toml).