### PR TITLE
new(visidata.org): visidata 3.3

### DIFF
--- a/projects/visidata.org/package.yml
+++ b/projects/visidata.org/package.yml
@@ -32,4 +32,6 @@ provides:
   - bin/visidata
 
 test:
-  - vd --version 2>&1 | grep "{{version}}"
+  # vd prints the bare upstream version (saul.pw/VisiData v3.3); pantry pads
+  # the 2-component release to 3.3.0, so grep the marketing (major.minor) form.
+  - vd --version 2>&1 | grep "{{version.marketing}}"

--- a/projects/visidata.org/package.yml
+++ b/projects/visidata.org/package.yml
@@ -1,15 +1,11 @@
 # https://visidata.org
 # terminal spreadsheet multitool for discovering & arranging tabular data
-distributable: ~
+distributable:
+  url: https://github.com/saulpw/visidata/archive/refs/tags/v3.3.tar.gz
+  strip-components: 1
 
 versions:
-  # Match the sdist filename on the simple index; the JSON API's bare-number
-  # match grabbed a stray number (resolved a bogus 59.813244.0).
-  url: https://pypi.org/simple/visidata/
-  match: /visidata-\d+(\.\d+)+\.tar\.gz/
-  strip:
-    - /visidata-/
-    - /\.tar\.gz/
+  github: saulpw/visidata
 
 dependencies:
   pkgx.sh: ">=1"
@@ -24,7 +20,7 @@ build:
     python.org: "~3.11"
   script:
     - bkpyvenv stage {{prefix}} {{version}}
-    - "{{prefix}}/venv/bin/pip install visidata=={{version}}"
+    - ${{prefix}}/venv/bin/pip install .
     - bkpyvenv seal {{prefix}} vd visidata
 
 provides:
@@ -34,4 +30,5 @@ provides:
 test:
   # vd prints the bare upstream version (saul.pw/VisiData v3.3); pantry pads
   # the 2-component release to 3.3.0, so grep the marketing (major.minor) form.
-  - vd --version 2>&1 | grep "{{version.marketing}}"
+  - vd --version 2>&1 | tee out
+  - grep "{{version.marketing}}" out

--- a/projects/visidata.org/package.yml
+++ b/projects/visidata.org/package.yml
@@ -3,8 +3,13 @@
 distributable: ~
 
 versions:
-  url: https://pypi.org/pypi/visidata/json
-  match: /\d+(\.\d+)+/
+  # Match the sdist filename on the simple index; the JSON API's bare-number
+  # match grabbed a stray number (resolved a bogus 59.813244.0).
+  url: https://pypi.org/simple/visidata/
+  match: /visidata-\d+(\.\d+)+\.tar\.gz/
+  strip:
+    - /visidata-/
+    - /\.tar\.gz/
 
 dependencies:
   pkgx.sh: ">=1"

--- a/projects/visidata.org/package.yml
+++ b/projects/visidata.org/package.yml
@@ -1,0 +1,30 @@
+# https://visidata.org
+# terminal spreadsheet multitool for discovering & arranging tabular data
+distributable: ~
+
+versions:
+  url: https://pypi.org/pypi/visidata/json
+  match: /\d+(\.\d+)+/
+
+dependencies:
+  pkgx.sh: ">=1"
+  python.org: "~3.11"
+
+runtime:
+  env:
+    PYTHONPATH: ${{prefix}}/venv/lib/python{{deps.python.org.version.marketing}}/site-packages
+
+build:
+  dependencies:
+    python.org: "~3.11"
+  script:
+    - bkpyvenv stage {{prefix}} {{version}}
+    - "{{prefix}}/venv/bin/pip install visidata=={{version}}"
+    - bkpyvenv seal {{prefix}} vd visidata
+
+provides:
+  - bin/vd
+  - bin/visidata
+
+test:
+  - vd --version 2>&1 | grep "{{version}}"


### PR DESCRIPTION
Adds **VisiData** (https://visidata.org) — a terminal interactive multitool for tabular data (CSV/JSON/SQLite/xlsx/…). Provides `vd` and `visidata`. Python app installed into a venv via bkpyvenv; core is pure-Python (no compiler). `vd --version` prints `saul.pw/VisiData v3.3`.