### PR TITLE
new(github.com/k0sproject/k0s): k0s 1.36.1+k0s.0

### DIFF
--- a/projects/github.com/k0sproject/k0s/package.yml
+++ b/projects/github.com/k0sproject/k0s/package.yml
@@ -1,7 +1,7 @@
 distributable:
   # k0s tags are v<semver>+k0s.<N> (N is ~always 0); the +k0s.N build-metadata
   # is stripped from the version below, so reconstruct the real tag here.
-  url: https://github.com/k0sproject/k0s/archive/refs/tags/v{{version}}+k0s.0.tar.gz
+  url: https://github.com/k0sproject/k0s/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
@@ -13,8 +13,7 @@ versions:
 # k0s is a Linux Kubernetes distribution. The control-plane and worker
 # components only run on Linux, so we only build the k0s binary there.
 platforms:
-  - linux/x86-64
-  - linux/aarch64
+  - linux
 
 provides:
   - bin/k0s
@@ -22,24 +21,27 @@ provides:
 build:
   dependencies:
     go.dev: ^1.26
-  script:
-    # Build only the k0s Go binary, without the embedded component binaries
-    # (kubelet, containerd, etcd, ...). Those are normally produced by a
-    # Docker-based embedded-bins build and appended to the binary tail; that
-    # toolchain is unavailable in the build sandbox. The resulting binary is a
-    # fully functional k0s CLI; embedded artifacts can be fetched at runtime.
-    # Mirrors the upstream Makefile `k0s.bare` recipe (CGO disabled, osusergo,
-    # trimpath, static link) with EMBEDDED_BINS_BUILDMODE=none.
-    - |
-      CGO_ENABLED=0 go build \
-        -tags=osusergo \
-        -trimpath \
-        -buildvcs=false \
-        -ldflags="-w -s -X github.com/k0sproject/k0s/pkg/build.Version=v{{version}}+k0s.0 -extldflags=-static" \
-        -o k0s \
-        main.go
-    - install -D k0s {{prefix}}/bin/k0s
+  env:
+    CGO_ENABLED: 0
+    ARGS:
+      # Build only the k0s Go binary, without the embedded component binaries
+      # (kubelet, containerd, etcd, ...). Those are normally produced by a
+      # Docker-based embedded-bins build and appended to the binary tail; that
+      # toolchain is unavailable in the build sandbox. The resulting binary is a
+      # fully functional k0s CLI; embedded artifacts can be fetched at runtime.
+      # Mirrors the upstream Makefile `k0s.bare` recipe (CGO disabled, osusergo,
+      # trimpath, static link) with EMBEDDED_BINS_BUILDMODE=none.
+      - -tags=osusergo
+      - -trimpath
+      - -buildvcs=false
+    GO_LDFLAGS:
+      - -w
+      - -s
+      - -X github.com/k0sproject/k0s/pkg/build.Version={{version.tag}}
+      - -extldflags=-static
+  script: go build $ARGS -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/k0s main.go
 
 test:
   # {{version}} (e.g. 1.36.1) is a substring of the printed v1.36.1+k0s.0
-  - k0s version 2>&1 | grep {{version}}
+  - k0s version 2>&1 | tee out
+  - grep {{version}} out

--- a/projects/github.com/k0sproject/k0s/package.yml
+++ b/projects/github.com/k0sproject/k0s/package.yml
@@ -1,0 +1,40 @@
+distributable:
+  url: https://github.com/k0sproject/k0s/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: k0sproject/k0s
+
+# k0s is a Linux Kubernetes distribution. The control-plane and worker
+# components only run on Linux, so we only build the k0s binary there.
+platforms:
+  - linux/x86-64
+  - linux/aarch64
+
+provides:
+  - bin/k0s
+
+build:
+  dependencies:
+    go.dev: ^1.26
+  script:
+    # Build only the k0s Go binary, without the embedded component binaries
+    # (kubelet, containerd, etcd, ...). Those are normally produced by a
+    # Docker-based embedded-bins build and appended to the binary tail; that
+    # toolchain is unavailable in the build sandbox. The resulting binary is a
+    # fully functional k0s CLI; embedded artifacts can be fetched at runtime.
+    # Mirrors the upstream Makefile `k0s.bare` recipe (CGO disabled, osusergo,
+    # trimpath, static link) with EMBEDDED_BINS_BUILDMODE=none.
+    - |
+      CGO_ENABLED=0 go build \
+        -tags=osusergo \
+        -trimpath \
+        -buildvcs=false \
+        -ldflags="-w -s -X github.com/k0sproject/k0s/pkg/build.Version={{version.tag}} -extldflags=-static" \
+        -o k0s \
+        main.go
+    - install -D k0s {{prefix}}/bin/k0s
+
+test:
+  # -F: the version.tag has a literal '+' (v1.36.1+k0s.0) which is a regex metachar
+  - k0s version 2>&1 | grep -F {{version.tag}}

--- a/projects/github.com/k0sproject/k0s/package.yml
+++ b/projects/github.com/k0sproject/k0s/package.yml
@@ -1,9 +1,14 @@
 distributable:
-  url: https://github.com/k0sproject/k0s/archive/refs/tags/{{version.tag}}.tar.gz
+  # k0s tags are v<semver>+k0s.<N> (N is ~always 0); the +k0s.N build-metadata
+  # is stripped from the version below, so reconstruct the real tag here.
+  url: https://github.com/k0sproject/k0s/archive/refs/tags/v{{version}}+k0s.0.tar.gz
   strip-components: 1
 
 versions:
   github: k0sproject/k0s
+  strip:
+    - /^v/
+    - /\+k0s\.\d+$/ # build-metadata suffix pantry's semver parser rejects
 
 # k0s is a Linux Kubernetes distribution. The control-plane and worker
 # components only run on Linux, so we only build the k0s binary there.
@@ -30,11 +35,11 @@ build:
         -tags=osusergo \
         -trimpath \
         -buildvcs=false \
-        -ldflags="-w -s -X github.com/k0sproject/k0s/pkg/build.Version={{version.tag}} -extldflags=-static" \
+        -ldflags="-w -s -X github.com/k0sproject/k0s/pkg/build.Version=v{{version}}+k0s.0 -extldflags=-static" \
         -o k0s \
         main.go
     - install -D k0s {{prefix}}/bin/k0s
 
 test:
-  # -F: the version.tag has a literal '+' (v1.36.1+k0s.0) which is a regex metachar
-  - k0s version 2>&1 | grep -F {{version.tag}}
+  # {{version}} (e.g. 1.36.1) is a substring of the printed v1.36.1+k0s.0
+  - k0s version 2>&1 | grep {{version}}


### PR DESCRIPTION
Adds **k0s** (https://github.com/k0sproject/k0s) — a zero-friction, single-binary Kubernetes distribution.

Builds **only the k0s Go binary** (`go build main.go`), not the embedded component binaries (kubelet, containerd, etcd, runc…). Upstream's default `make build` produces those via a **Docker-based** embedded-bins compile and appends them to the binary tail (`cat *.zip >> k0s`) — unavailable in the build sandbox. The Makefile opts out via `EMBEDDED_BINS_BUILDMODE=none`, and the artifacts aren't `go:embed`-linked, so the binary builds, links statically, and runs (`k0s version`); components are fetched at runtime. Generated code is committed in the tarball (no codegen needed).

Flags mirror upstream's `k0s.bare`: `CGO_ENABLED=0 -tags=osusergo -trimpath -buildvcs=false`, static link, `pkg/build.Version` ldflag. **linux/x86-64 + linux/aarch64** (k0s is a Linux k8s distro). Smoke-tested locally: builds ~4min on arm64, `k0s version` -> `v1.36.1+k0s.0`.