### PR TITLE
new(gnu.org/gsl): gsl 2.8

### DIFF
--- a/projects/gnu.org/gsl/package.yml
+++ b/projects/gnu.org/gsl/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/gsl/gsl-{{version}}.tar.gz
+  url: https://ftp.gnu.org/gnu/gsl/gsl-{{version.raw}}.tar.gz
   strip-components: 1
 
 versions:
@@ -20,4 +20,4 @@ provides:
   - bin/gsl-histogram
 
 test:
-  - gsl-config --version | grep {{version}}
+  - gsl-config --version | grep {{version.raw}}

--- a/projects/gnu.org/gsl/package.yml
+++ b/projects/gnu.org/gsl/package.yml
@@ -12,7 +12,11 @@ versions:
 build:
   script:
     - ./configure --prefix={{prefix}}
-    - make --jobs {{hw.concurrency}} install
+    # `make all` first so BUILT_SOURCES (the gsl/ header-symlink dir) is built
+    # before the subdirs compile; a combined parallel `make install` skips it
+    # and races (gsl/gsl_minmax.h not found).
+    - make --jobs {{hw.concurrency}}
+    - make install
 
 provides:
   - bin/gsl-config

--- a/projects/gnu.org/gsl/package.yml
+++ b/projects/gnu.org/gsl/package.yml
@@ -1,0 +1,23 @@
+distributable:
+  url: https://ftp.gnu.org/gnu/gsl/gsl-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://ftp.gnu.org/gnu/gsl/
+  match: /gsl-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /^gsl-/
+    - /\.tar\.gz$/
+
+build:
+  script:
+    - ./configure --prefix={{prefix}}
+    - make --jobs {{hw.concurrency}} install
+
+provides:
+  - bin/gsl-config
+  - bin/gsl-randist
+  - bin/gsl-histogram
+
+test:
+  - gsl-config --version | grep {{version}}


### PR DESCRIPTION
Adds the **GNU Scientific Library** (GSL) — numerical routines for scientific computing (integration, FFT, RNG, linear algebra, special functions). Standard GNU autotools C library, self-contained (ships its own CBLAS). Provides gsl-config/gsl-randist/gsl-histogram.