### PR TITLE
new(gnu.org/datamash): datamash 1.9

### DIFF
--- a/projects/gnu.org/datamash/package.yml
+++ b/projects/gnu.org/datamash/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/datamash/datamash-{{version}}.tar.gz
+  url: https://ftp.gnu.org/gnu/datamash/datamash-{{version.raw}}.tar.gz
   strip-components: 1
 
 versions:
@@ -18,5 +18,5 @@ provides:
   - bin/datamash
 
 test:
-  - datamash --version 2>&1 | grep {{version}}
+  - datamash --version 2>&1 | grep {{version.raw}}
   - test "$(printf '1\n2\n3\n' | datamash sum 1)" = "6"

--- a/projects/gnu.org/datamash/package.yml
+++ b/projects/gnu.org/datamash/package.yml
@@ -1,0 +1,22 @@
+distributable:
+  url: https://ftp.gnu.org/gnu/datamash/datamash-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://ftp.gnu.org/gnu/datamash/
+  match: /datamash-\d+\.\d+\.tar\.gz/
+  strip:
+    - /^datamash-/
+    - /\.tar\.gz$/
+
+build:
+  script:
+    - ./configure --prefix={{prefix}}
+    - make --jobs {{hw.concurrency}} install
+
+provides:
+  - bin/datamash
+
+test:
+  - datamash --version 2>&1 | grep {{version}}
+  - test "$(printf '1\n2\n3\n' | datamash sum 1)" = "6"


### PR DESCRIPTION
Adds **GNU datamash** — command-line numeric/statistical operations on textual input (sum, mean, median, group-by, transpose…). GNU autotools, no deps. Test: `printf '1\n2\n3\n' | datamash sum 1` -> `6`.