### PR TITLE
new(gnu.org/units): units 2.27

### DIFF
--- a/projects/gnu.org/units/package.yml
+++ b/projects/gnu.org/units/package.yml
@@ -1,0 +1,24 @@
+distributable:
+  url: https://ftp.gnu.org/gnu/units/units-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://ftp.gnu.org/gnu/units/
+  match: /units-\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /^units-/
+    - /\.tar\.gz$/
+
+build:
+  script:
+    - ./configure --prefix={{prefix}}
+    - make --jobs {{hw.concurrency}} install
+  env:
+    PATH: ${{prefix}}/bin:$PATH
+
+provides:
+  - bin/units
+
+test:
+  - units --version 2>&1 | grep {{version.marketing}}
+  - test "$(units -t '2 m' 'ft' | cut -d. -f1)" = 6

--- a/projects/gnu.org/units/package.yml
+++ b/projects/gnu.org/units/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://ftp.gnu.org/gnu/units/units-{{version}}.tar.gz
+  url: https://ftp.gnu.org/gnu/units/units-{{version.raw}}.tar.gz
   strip-components: 1
 
 versions:

--- a/projects/gnu.org/units/package.yml
+++ b/projects/gnu.org/units/package.yml
@@ -9,6 +9,12 @@ versions:
     - /^units-/
     - /\.tar\.gz$/
 
+runtime:
+  env:
+    # units bakes the data-file path to the (build-time) +brewing staging dir,
+    # which doesn't exist at runtime; point it at the final install location.
+    UNITSFILE: ${{prefix}}/share/units/definitions.units
+
 build:
   script:
     - ./configure --prefix={{prefix}}


### PR DESCRIPTION
Adds **GNU units** — unit conversion and calculation. GNU autotools; readline omitted (only the interactive REPL needs it; batch `units -t` works without). Provides `bin/units` (the optional python `units_cur` currency script is intentionally not provided). 2-component version, tested against `{{version.marketing}}`.