### PR TITLE
new(github.com/lh3/minimap2): minimap2 2.31

### DIFF
--- a/projects/github.com/lh3/minimap2/package.yml
+++ b/projects/github.com/lh3/minimap2/package.yml
@@ -10,24 +10,26 @@ distributable:
 
 versions:
   github: lh3/minimap2
-  strip: /^v/ # tags are vX.Y (e.g. v2.31)
 
 dependencies:
   zlib.net: "*"
 
 build:
+  env:
+    aarch64:
+      EXTRA:
+        - arm_neon=1
+        - aarch64=1
   # Plain Makefile. x86 builds with SSE2/SSE4.1 dispatch by default; aarch64
   # needs `aarch64=1` (sets arm_neon=1) to use the bundled sse2neon shim.
   # CC=cc so make uses pkgx's compiler (the Makefile otherwise hardcodes gcc).
   script:
-    - |
-      EXTRA=
-      case "$(uname -m)" in aarch64|arm64) EXTRA="arm_neon=1 aarch64=1" ;; esac
-      make --jobs {{hw.concurrency}} CC=cc $EXTRA
+    - make --jobs {{hw.concurrency}} CC=cc $EXTRA
     - install -D minimap2 {{prefix}}/bin/minimap2
 
 provides:
   - bin/minimap2
 
 test:
-  - minimap2 --version 2>&1 | grep {{version.raw}}
+  - minimap2 --version 2>&1 | tee out
+  - grep {{version.raw}} out

--- a/projects/github.com/lh3/minimap2/package.yml
+++ b/projects/github.com/lh3/minimap2/package.yml
@@ -1,0 +1,36 @@
+# minimap2 — fast sequence alignment for long reads and assemblies.
+#
+# Aligns DNA/mRNA against a large reference DB. Builds with a plain
+# Makefile (no configure); produces a single `minimap2` binary that is
+# copied into place (there is no PREFIX-aware `make install`).
+
+distributable:
+  url: https://github.com/lh3/minimap2/releases/download/{{version.tag}}/minimap2-{{version.raw}}.tar.bz2
+  strip-components: 1
+
+versions:
+  github: lh3/minimap2
+  strip: /^v/ # tags are vX.Y (e.g. v2.31)
+
+dependencies:
+  zlib.net: "*"
+
+build:
+  # Plain Makefile. x86 builds with SSE2/SSE4.1 dispatch by default; aarch64
+  # needs `aarch64=1` (sets arm_neon=1) to use the bundled sse2neon shim.
+  # CC=cc so make uses pkgx's compiler (the Makefile otherwise hardcodes gcc).
+  script:
+    - make --jobs {{hw.concurrency}} CC=cc $ARGS
+    - install -D minimap2 {{prefix}}/bin/minimap2
+  env:
+    ARGS: ""
+    linux/aarch64:
+      ARGS: arm_neon=1 aarch64=1
+    darwin/aarch64:
+      ARGS: arm_neon=1 aarch64=1
+
+provides:
+  - bin/minimap2
+
+test:
+  - minimap2 --version 2>&1 | grep {{version.raw}}

--- a/projects/github.com/lh3/minimap2/package.yml
+++ b/projects/github.com/lh3/minimap2/package.yml
@@ -20,14 +20,11 @@ build:
   # needs `aarch64=1` (sets arm_neon=1) to use the bundled sse2neon shim.
   # CC=cc so make uses pkgx's compiler (the Makefile otherwise hardcodes gcc).
   script:
-    - make --jobs {{hw.concurrency}} CC=cc $ARGS
+    - |
+      EXTRA=
+      case "$(uname -m)" in aarch64|arm64) EXTRA="arm_neon=1 aarch64=1" ;; esac
+      make --jobs {{hw.concurrency}} CC=cc $EXTRA
     - install -D minimap2 {{prefix}}/bin/minimap2
-  env:
-    ARGS: ""
-    linux/aarch64:
-      ARGS: arm_neon=1 aarch64=1
-    darwin/aarch64:
-      ARGS: arm_neon=1 aarch64=1
 
 provides:
   - bin/minimap2


### PR DESCRIPTION
Adds **minimap2** — a fast sequence aligner for long reads / assemblies. Plain Makefile (no configure); x86 uses SSE2/SSE4.1 dispatch, aarch64 builds with `arm_neon=1 aarch64=1` (the bundled sse2neon shim). `CC=cc` so make uses pkgx's compiler. Dep: zlib. 2-component version (`{{version.raw}}`).