### PR TITLE
new(github.com/arq5x/bedtools2): bedtools 2.31.1

### DIFF
--- a/projects/github.com/arq5x/bedtools2/package.yml
+++ b/projects/github.com/arq5x/bedtools2/package.yml
@@ -1,0 +1,39 @@
+distributable:
+  # Release asset (NOT the git archive): bundles htslib & other vendored deps.
+  url: https://github.com/arq5x/bedtools2/releases/download/v{{version}}/bedtools-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: arq5x/bedtools2/tags
+  strip: /^v/
+
+provides:
+  - bin/bedtools
+
+dependencies:
+  zlib.net: '*'
+  sourceware.org/bzip2: '*'
+  tukaani.org/xz: '*'
+  # Linux: default clang/libc++ lacks the libstdc++ C++ headers bedtools' bundled
+  # htslib needs (<bit>/<new>). Provide a real libstdc++ at runtime.
+  linux/gnu.org/gcc/libstdcxx: '*'
+
+build:
+  dependencies:
+    # Makefile (no autotools/cmake). It hardcodes CXX=g++ at the top but honors
+    # an overriding CXX from the environment. On linux build with GCC to match
+    # the libstdc++ runtime above and avoid the clang/libc++ C++ header gaps.
+    linux/gnu.org/gcc: 14
+  script:
+    - |
+      if test "{{ hw.platform }}" = "linux"; then
+        export CXX="$(command -v g++-14 || command -v g++)"
+      fi
+    - make -j {{ hw.concurrency }}
+    # install target is `install: all`; copies bin/* into $(prefix)/bin.
+    # prefix var is LOWERCASE.
+    - make install prefix="{{prefix}}"
+
+test:
+  script:
+    - bedtools --version 2>&1 | grep {{version}}

--- a/projects/github.com/arq5x/bedtools2/package.yml
+++ b/projects/github.com/arq5x/bedtools2/package.yml
@@ -14,9 +14,9 @@ dependencies:
   zlib.net: '*'
   sourceware.org/bzip2: '*'
   tukaani.org/xz: '*'
-  # Linux: default clang/libc++ lacks the libstdc++ C++ headers bedtools' bundled
-  # htslib needs (<bit>/<new>). Provide a real libstdc++ at runtime.
-  linux/gnu.org/gcc/libstdcxx: '*'
+  linux:
+    # bundled htslib links libstdc++ (built with gcc); keep it at runtime.
+    gnu.org/gcc/libstdcxx: '*'
 
 build:
   dependencies:

--- a/projects/github.com/arq5x/bedtools2/package.yml
+++ b/projects/github.com/arq5x/bedtools2/package.yml
@@ -20,10 +20,11 @@ dependencies:
 
 build:
   dependencies:
-    # Makefile (no autotools/cmake). It hardcodes CXX=g++ at the top but honors
-    # an overriding CXX from the environment. On linux build with GCC to match
-    # the libstdc++ runtime above and avoid the clang/libc++ C++ header gaps.
-    linux/gnu.org/gcc: 14
+    # Makefile (no autotools/cmake) hardcodes CXX=g++ but honors an env CXX.
+    # On linux build with GCC to match the libstdc++ runtime above and avoid
+    # the clang/libc++ C++ header gaps in the bundled htslib.
+    linux:
+      gnu.org/gcc: 14
   script:
     - |
       if test "{{ hw.platform }}" = "linux"; then

--- a/projects/github.com/arq5x/bedtools2/package.yml
+++ b/projects/github.com/arq5x/bedtools2/package.yml
@@ -5,7 +5,6 @@ distributable:
 
 versions:
   github: arq5x/bedtools2/tags
-  strip: /^v/
 
 provides:
   - bin/bedtools
@@ -16,7 +15,7 @@ dependencies:
   tukaani.org/xz: '*'
   linux:
     # bundled htslib links libstdc++ (built with gcc); keep it at runtime.
-    gnu.org/gcc/libstdcxx: '*'
+    gnu.org/gcc/libstdcxx: 14
 
 build:
   dependencies:
@@ -26,16 +25,15 @@ build:
     # the clang/libc++ C++ header gaps in the bundled htslib.
     linux:
       gnu.org/gcc: 14
+  env:
+    linux:
+      CXX: g++
   script:
-    - |
-      if test "{{ hw.platform }}" = "linux"; then
-        export CXX="$(command -v g++-14 || command -v g++)"
-      fi
     - make -j {{ hw.concurrency }}
     # install target is `install: all`; copies bin/* into $(prefix)/bin.
     # prefix var is LOWERCASE.
     - make install prefix="{{prefix}}"
 
 test:
-  script:
-    - bedtools --version 2>&1 | grep {{version}}
+    - bedtools --version 2>&1 | tee out
+    - grep {{version}} out

--- a/projects/github.com/arq5x/bedtools2/package.yml
+++ b/projects/github.com/arq5x/bedtools2/package.yml
@@ -20,6 +20,7 @@ dependencies:
 
 build:
   dependencies:
+    python.org: '*' # the Makefile's "old CLI" step shells out to python3
     # Makefile (no autotools/cmake) hardcodes CXX=g++ but honors an env CXX.
     # On linux build with GCC to match the libstdc++ runtime above and avoid
     # the clang/libc++ C++ header gaps in the bundled htslib.


### PR DESCRIPTION
Adds **bedtools** — genome arithmetic (intersect/merge/coverage… on genomic intervals). C++; built from the release asset (bundles htslib) via `make && make install prefix={{prefix}}`. Deps: zlib + bzip2 + xz (bundled htslib links them); on linux, gnu.org/gcc 14 + libstdcxx for the C++17/libstdc++ the bundled htslib needs.