### PR TITLE
new(hmmer.org): hmmer 3.4

### DIFF
--- a/projects/hmmer.org/package.yml
+++ b/projects/hmmer.org/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: http://eddylab.org/software/hmmer/hmmer-{{version}}.tar.gz
+  url: http://eddylab.org/software/hmmer/hmmer-{{version.raw}}.tar.gz
   strip-components: 1
 
 versions:

--- a/projects/hmmer.org/package.yml
+++ b/projects/hmmer.org/package.yml
@@ -1,0 +1,33 @@
+distributable:
+  url: http://eddylab.org/software/hmmer/hmmer-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: http://eddylab.org/software/hmmer/
+  match: /hmmer-\d+\.\d+(\.\d+)?\.tar\.gz/
+  strip:
+    - /hmmer-/
+    - /.tar.gz/
+
+# HMMER bundles Easel and ships a pre-generated `configure`, so no
+# autoreconf is needed and there are no external deps. SIMD is
+# auto-detected: SSE on x86, NEON on ARM (armv7/aarch64), VMX on
+# PowerPC. Verified that hmmer 3.4's configure has the
+# esl_have_neon_aarch64 probe, so darwin/arm64 + linux/arm64 build fine.
+build:
+  script:
+    - ./configure --prefix="{{prefix}}"
+    - make --jobs {{ hw.concurrency }}
+    - make install
+
+provides:
+  - bin/hmmsearch
+  - bin/hmmscan
+  - bin/phmmer
+  - bin/jackhmmer
+  - bin/hmmbuild
+  - bin/hmmalign
+  - bin/nhmmer
+
+test: |
+  hmmsearch -h 2>&1 | grep -i {{version}}

--- a/projects/hmmer.org/package.yml
+++ b/projects/hmmer.org/package.yml
@@ -30,4 +30,4 @@ provides:
   - bin/nhmmer
 
 test: |
-  hmmsearch -h 2>&1 | grep -i {{version}}
+  hmmsearch -h 2>&1 | grep -i {{version.raw}}

--- a/projects/hmmer.org/package.yml
+++ b/projects/hmmer.org/package.yml
@@ -15,10 +15,9 @@ versions:
 # PowerPC. Verified that hmmer 3.4's configure has the
 # esl_have_neon_aarch64 probe, so darwin/arm64 + linux/arm64 build fine.
 build:
-  script:
-    - ./configure --prefix="{{prefix}}"
-    - make --jobs {{ hw.concurrency }}
-    - make install
+  - ./configure --prefix="{{prefix}}"
+  - make --jobs {{ hw.concurrency }}
+  - make install
 
 provides:
   - bin/hmmsearch
@@ -29,5 +28,6 @@ provides:
   - bin/hmmalign
   - bin/nhmmer
 
-test: |
-  hmmsearch -h 2>&1 | grep -i {{version.raw}}
+test:
+  - hmmsearch -h 2>&1 | tee out
+  - grep -i {{version.raw}} out


### PR DESCRIPTION
Adds **HMMER** — biosequence analysis with profile hidden Markov models (hmmsearch/hmmscan/phmmer/jackhmmer/hmmbuild/hmmalign/nhmmer). C autotools, bundles Easel (no external deps), ships a pre-generated configure. SIMD auto-detected: SSE on x86, NEON on aarch64 (3.4 supports arm64), so all platforms build.