### PR TITLE
new(pari.math.u-bordeaux.fr): pari 2.17.3

### DIFF
--- a/projects/pari.math.u-bordeaux.fr/package.yml
+++ b/projects/pari.math.u-bordeaux.fr/package.yml
@@ -1,0 +1,39 @@
+distributable:
+  url: https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://pari.math.u-bordeaux.fr/pub/pari/unix/
+  match: /pari-\d+\.\d+\.\d+\.tar\.gz/
+  strip:
+    - /^pari-/
+    - /\.tar\.gz$/
+
+dependencies:
+  gnu.org/gmp: '*'
+  gnu.org/readline: '*'
+
+build:
+  # PARI/GP ships a custom `./Configure` (capital C, hand-written, NOT autotools).
+  # `--with-gmp=DIR` selects the GMP bignum kernel; `--with-readline=DIR` gives gp
+  # line editing. Configure then writes a Makefile under O<os>-<arch>/.
+  script:
+    - ./Configure
+        --prefix={{prefix}}
+        --with-gmp={{deps.gnu.org/gmp.prefix}}
+        --with-readline={{deps.gnu.org/readline.prefix}}
+    - make --jobs {{ hw.concurrency }} gp
+    - make install
+
+    # gp is a dylib-linked binary; strip stray debug bundles on darwin
+    - run: rm -rf {{prefix}}/bin/*.dSYM
+      if: darwin
+
+provides:
+  - bin/gp
+  - bin/gphelp
+  - bin/tex2mail
+
+test:
+  - gp --version 2>&1 | grep {{version}}
+  - run: echo 'print(2+2)' | gp -q 2>&1 | grep 4

--- a/projects/pari.math.u-bordeaux.fr/package.yml
+++ b/projects/pari.math.u-bordeaux.fr/package.yml
@@ -14,14 +14,16 @@ dependencies:
   gnu.org/readline: '*'
 
 build:
+  env:
+    ARGS:
+      - --prefix={{prefix}}
+      - --with-gmp={{deps.gnu.org/gmp.prefix}}
+      - --with-readline={{deps.gnu.org/readline.prefix}}
   # PARI/GP ships a custom `./Configure` (capital C, hand-written, NOT autotools).
   # `--with-gmp=DIR` selects the GMP bignum kernel; `--with-readline=DIR` gives gp
   # line editing. Configure then writes a Makefile under O<os>-<arch>/.
   script:
-    - ./Configure
-        --prefix={{prefix}}
-        --with-gmp={{deps.gnu.org/gmp.prefix}}
-        --with-readline={{deps.gnu.org/readline.prefix}}
+    - ./Configure $ARGS
     - make --jobs {{ hw.concurrency }} gp
     - make install
 
@@ -35,5 +37,6 @@ provides:
   - bin/tex2mail
 
 test:
-  - gp --version 2>&1 | grep {{version}}
+  - gp --version 2>&1 | tee out
+  - grep {{version}} out
   - run: echo 'print(2+2)' | gp -q 2>&1 | grep 4


### PR DESCRIPTION
Adds **PARI/GP** — a computer algebra system for fast number theory; provides the `gp` calculator (+ gphelp, tex2mail). Upstream's custom `./Configure` (not autotools); built with the GMP bignum kernel (`--with-gmp`) + readline. Verified end-to-end on darwin/arm64 (Configure detects GMP 6.3.0 + readline 8.3; `2+2`->`4`).