### PR TITLE
new(github.com/lh3/seqtk): seqtk 1.5

### DIFF
--- a/projects/github.com/lh3/seqtk/package.yml
+++ b/projects/github.com/lh3/seqtk/package.yml
@@ -1,0 +1,30 @@
+distributable:
+  url: https://github.com/lh3/seqtk/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: lh3/seqtk
+
+dependencies:
+  zlib.net: '*'
+
+build:
+  # brewkit's CPATH/LIBRARY_PATH already point at the zlib dep, so the
+  # Makefile's default rule finds zlib.h / -lz without extra flags
+  - make --jobs {{hw.concurrency}} CC=cc
+  - install -Dm0755 seqtk "{{prefix}}/bin/seqtk"
+
+provides:
+  - bin/seqtk
+
+test:
+  script:
+    # seqtk with no args prints its banner ("Version: 1.5-r133") then exits 1;
+    # swallow that for pipefail, and grep the raw 2-component version
+    - (seqtk 2>&1 || true) | grep '{{version.raw}}'
+    - cp $FIXTURE test.fa
+    - test "$(seqtk seq -r test.fa | grep -v '^>')" = "TTGGCCAA"
+    - test "$(seqtk comp test.fa | cut -f2)" = "8"
+  fixture: |
+    >read1
+    TTGGCCAA


### PR DESCRIPTION
Adds **seqtk** — Heng Li's tiny FASTA/FASTQ Swiss-army knife. Single-Makefile C, zlib only; the Makefile ignores env CFLAGS/LDFLAGS so the zlib paths ride in on `CFLAGS` at the make line. Verified on linux/arm64: links pkgx zlib (`ldd`), `seqtk seq -r` round-trips a palindrome and `seqtk comp` reports the right length. Test greps `{{version}}` (the banner prints `1.5-r133`, not the `v`-prefixed tag).