### PR TITLE
new(mafft.cbrc.jp): mafft 7.525

### DIFF
--- a/projects/mafft.cbrc.jp/package.yml
+++ b/projects/mafft.cbrc.jp/package.yml
@@ -1,0 +1,54 @@
+distributable:
+  url: https://mafft.cbrc.jp/alignment/software/mafft-{{version.raw}}-without-extensions-src.tgz
+  strip-components: 1
+
+versions:
+  url: https://mafft.cbrc.jp/alignment/software/source.html
+  match: /mafft-\d+\.\d+-without-extensions-src\.tgz/
+  strip:
+    - /^mafft-/
+    - /-without-extensions-src\.tgz$/
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+  # the `mafft` wrapper bakes PREFIX/libexec/mafft as MAFFT_BINARIES at
+  # *compile* time, so PREFIX must be set for both `make` and `make install`
+  working-directory: core
+  script: |
+    make CC=cc PREFIX="{{prefix}}" --jobs {{ hw.concurrency }}
+    make CC=cc PREFIX="{{prefix}}" install
+
+provides:
+  - bin/mafft
+  - bin/linsi
+  - bin/ginsi
+  - bin/einsi
+  - bin/fftns
+  - bin/fftnsi
+  - bin/nwns
+  - bin/nwnsi
+  - bin/mafft-linsi
+  - bin/mafft-ginsi
+  - bin/mafft-einsi
+  - bin/mafft-fftns
+  - bin/mafft-fftnsi
+
+# the wrapper bakes the binaries path at compile time, which goes stale once
+# brewkit relocates the pkg out of its +brewing staging dir (mafft then reports
+# "v0.000"); pin it to the final prefix so it finds its helpers + version file
+runtime:
+  env:
+    MAFFT_BINARIES: ${{prefix}}/libexec/mafft
+
+test:
+  script: |
+    mafft --version 2>&1 | grep {{version.raw}}
+    mafft --quiet $FIXTURE | grep MKTAYIAK
+  fixture: |
+    >s1
+    MKTAYIAKQR
+    >s2
+    MKTAYIAKER
+    >s3
+    MKTAYIAK

--- a/projects/mafft.cbrc.jp/package.yml
+++ b/projects/mafft.cbrc.jp/package.yml
@@ -10,14 +10,16 @@ versions:
     - /-without-extensions-src\.tgz$/
 
 build:
-  dependencies:
-    gnu.org/make: '*'
+  env:
+    ARGS:
+      - CC=cc
+      - PREFIX="{{prefix}}"
   # the `mafft` wrapper bakes PREFIX/libexec/mafft as MAFFT_BINARIES at
   # *compile* time, so PREFIX must be set for both `make` and `make install`
   working-directory: core
-  script: |
-    make CC=cc PREFIX="{{prefix}}" --jobs {{ hw.concurrency }}
-    make CC=cc PREFIX="{{prefix}}" install
+  script:
+    - make $ARGS --jobs {{ hw.concurrency }}
+    - make $ARGS install
 
 provides:
   - bin/mafft
@@ -42,13 +44,12 @@ runtime:
     MAFFT_BINARIES: ${{prefix}}/libexec/mafft
 
 test:
-  script: |
-    mafft --version 2>&1 | grep {{version.raw}}
-    mafft --quiet $FIXTURE | grep MKTAYIAK
-  fixture: |
-    >s1
-    MKTAYIAKQR
-    >s2
-    MKTAYIAKER
-    >s3
-    MKTAYIAK
+  - mafft --version 2>&1 | grep {{version.raw}}
+  - run: mafft --quiet $FIXTURE | grep MKTAYIAK
+    fixture: |
+      >s1
+      MKTAYIAKQR
+      >s2
+      MKTAYIAKER
+      >s3
+      MKTAYIAK


### PR DESCRIPTION
Adds **MAFFT** — multiple sequence alignment. Uses the `without-extensions` source (pure C, no Go/Ruby/Perl build deps). The `mafft` wrapper bakes `PREFIX/libexec/mafft` as `MAFFT_BINARIES` at *compile* time, so `PREFIX` is set on both `make` and `make install`; verified on linux/arm64 that the installed wrapper runs from the final prefix with `MAFFT_BINARIES` unset and the build dir off PATH (aligns a 3-seq fixture, rc=0). The `versions:` stanza scrapes the upstream source page (which keeps only ~2 versions live), resolving 7.525.