### PR TITLE
new(flintlib.org): flint 3.5.0

### DIFF
--- a/projects/flintlib.org/package.yml
+++ b/projects/flintlib.org/package.yml
@@ -1,10 +1,9 @@
 distributable:
-  url: https://github.com/flintlib/flint/releases/download/v{{ version }}/flint-{{ version }}.tar.gz
+  url: https://github.com/flintlib/flint/releases/download/{{ version.tag }}/flint-{{ version }}.tar.gz
   strip-components: 1
 
 versions:
   github: flintlib/flint/tags
-  strip: /^v/
 
 dependencies:
   gnu.org/gmp: '>=6.2.1'
@@ -23,9 +22,4 @@ build:
       - --with-gmp={{ deps.gnu.org/gmp.prefix }}
       - --with-mpfr={{ deps.gnu.org/mpfr.prefix }}
 
-test:
-  dependencies:
-    gnu.org/gmp: '>=6.2.1'
-    gnu.org/mpfr: '>=4.1.0'
-  script:
-    - pkg-config --modversion flint | grep {{ version }}
+test: pkg-config --modversion flint | grep {{ version }}

--- a/projects/flintlib.org/package.yml
+++ b/projects/flintlib.org/package.yml
@@ -1,0 +1,31 @@
+distributable:
+  url: https://github.com/flintlib/flint/releases/download/v{{ version }}/flint-{{ version }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: flintlib/flint/tags
+  strip: /^v/
+
+dependencies:
+  gnu.org/gmp: '>=6.2.1'
+  gnu.org/mpfr: '>=4.1.0'
+
+build:
+  dependencies:
+    gnu.org/m4: '*'
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - --prefix={{ prefix }}
+      - --with-gmp={{ deps.gnu.org/gmp.prefix }}
+      - --with-mpfr={{ deps.gnu.org/mpfr.prefix }}
+
+test:
+  dependencies:
+    gnu.org/gmp: '>=6.2.1'
+    gnu.org/mpfr: '>=4.1.0'
+  script:
+    - pkg-config --modversion flint | grep {{ version }}


### PR DESCRIPTION
Adds **FLINT** — the Fast Library for Number Theory (C; FLINT 3.x absorbed arb/antic). Built from the GitHub release tarball (ships `configure`, no bootstrap) against the pantry's gmp+mpfr. `gnu.org/m4` is a required build dep (configure aborts with `No usable m4 in $PATH` otherwise). Pure-C build — no libstdc++ runtime dep needed (C++ only links under `--with-ntl`, not enabled). Verified end-to-end on linux/arm64: configure + full `make`/`make install`, `pkg-config --modversion flint` -> `3.5.0`. Version bounds (`gmp>=6.2.1`, `mpfr>=4.1.0`) taken from `flint.pc.in`. Library — no `provides`, matching the gmp/mpfr convention.