### PR TITLE
new(libntl.org): ntl 11.6.0

### DIFF
--- a/projects/libntl.org/package.yml
+++ b/projects/libntl.org/package.yml
@@ -1,0 +1,39 @@
+distributable:
+  url: https://github.com/libntl/ntl/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: libntl/ntl/tags
+  strip: /^v/
+
+dependencies:
+  gnu.org/gmp: ^6
+  linux:
+    gnu.org/gcc/libstdcxx: ^14 # libstdc++
+
+build:
+  dependencies:
+    perl.org: ^5 # ./configure is a shell wrapper around `perl DoConfig`
+    gnu.org/make: "*" # configure runs a test compile via make
+    linux:
+      gnu.org/gcc: ^14
+  working-directory: src
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    ARGS:
+      - PREFIX={{ prefix }}
+      - GMP_PREFIX={{ deps.gnu.org/gmp.prefix }}
+      - NTL_GMP_LIP=on # use GMP as the long-integer backend
+      - SHARED=on # also build libntl.so/.dylib (+ ntl.pc); static stays on
+      - CXX=c++ # resolves to gcc on PATH when gcc is a dep, system clang on macOS
+
+test:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+  # SHARED=on installs ntl.pc; pkg-config avoids the clang-vs-gcc libstdc++
+  # ABI mismatch a compile-link test would otherwise hit on linux
+  script:
+    - pkg-config --modversion ntl | grep {{ version }}

--- a/projects/libntl.org/package.yml
+++ b/projects/libntl.org/package.yml
@@ -1,10 +1,9 @@
 distributable:
-  url: https://github.com/libntl/ntl/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/libntl/ntl/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: libntl/ntl/tags
-  strip: /^v/
 
 dependencies:
   gnu.org/gmp: ^6
@@ -14,7 +13,6 @@ dependencies:
 build:
   dependencies:
     perl.org: ^5 # ./configure is a shell wrapper around `perl DoConfig`
-    gnu.org/make: "*" # configure runs a test compile via make
     linux:
       gnu.org/gcc: ^14
   working-directory: src
@@ -35,5 +33,4 @@ test:
     freedesktop.org/pkg-config: '*'
   # SHARED=on installs ntl.pc; pkg-config avoids the clang-vs-gcc libstdc++
   # ABI mismatch a compile-link test would otherwise hit on linux
-  script:
-    - pkg-config --modversion ntl | grep {{ version }}
+  script: pkg-config --modversion ntl | grep {{ version }}


### PR DESCRIPTION
Adds **NTL** — Victor Shoup's Number Theory Library (C++), with GMP as the long-integer backend (`NTL_GMP_LIP=on`). NTL's `src/configure` is a `/bin/sh` wrapper around `perl DoConfig` and runs a live test-compile via `make`, so both `perl.org` and `gnu.org/make` are build deps; args are `KEY=VALUE` space-separated (not `--flags`). I set `SHARED=on` so it also builds `libntl.so` + a `ntl.pc` (upstream defaults to static-only, no .pc) for cleaner downstream use; the static lib still builds. On linux, gcc 14 (build) + libstdcxx (runtime); the test compiles with the same `c++` (gcc) that built the lib to avoid the clang/gcc libstdc++ ABI trap. Verified end-to-end on linux/arm64: shared + static link of an `NTL::ZZ` fixture both print `65537`.