### PR TITLE
new(github.com/intel/isa-l): isa-l 2.32.0

### DIFF
--- a/projects/github.com/intel/isa-l/package.yml
+++ b/projects/github.com/intel/isa-l/package.yml
@@ -1,0 +1,31 @@
+distributable:
+  url: https://github.com/intel/isa-l/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: intel/isa-l/tags
+  strip: /^v/
+
+build:
+  dependencies:
+    gnu.org/autoconf: '*'
+    gnu.org/automake: '*'
+    gnu.org/libtool: '*'
+    gnu.org/make: '*'
+    x86-64:
+      nasm.us: ^2
+  script:
+    - ./autogen.sh
+    - ./configure --prefix="{{prefix}}"
+    - make --jobs {{hw.concurrency}}
+    - make install
+
+provides:
+  - bin/igzip
+
+test:
+  dependencies:
+    freedesktop.org/pkg-config: '*'
+  script:
+    - test "$(pkg-config --modversion libisal)" = "{{version}}"
+    - igzip --version | grep "{{version}}"

--- a/projects/github.com/intel/isa-l/package.yml
+++ b/projects/github.com/intel/isa-l/package.yml
@@ -1,17 +1,15 @@
 distributable:
-  url: https://github.com/intel/isa-l/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/intel/isa-l/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   github: intel/isa-l/tags
-  strip: /^v/
 
 build:
   dependencies:
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'
     gnu.org/libtool: '*'
-    gnu.org/make: '*'
     x86-64:
       nasm.us: ^2
   script:
@@ -28,4 +26,5 @@ test:
     freedesktop.org/pkg-config: '*'
   script:
     - test "$(pkg-config --modversion libisal)" = "{{version}}"
-    - igzip --version | grep "{{version}}"
+    - igzip --version | tee out
+    - grep "{{version}}" out


### PR DESCRIPTION
Adds **isa-l** — Intel's Intelligent Storage Acceleration Library (the `igzip` fast deflate CLI + `libisal`). Needed as a dependency for fastp (links `-lisal`, includes `<isa-l/igzip_lib.h>`).

autotools-from-git (`./autogen.sh && ./configure && make && make install`). nasm is gated to `x86-64:` only — aarch64 assembles the bundled `.S` files with the C compiler (no nasm). Installs `bin/igzip`, `libisal` + `libisal.pc`, and `include/isa-l/*.h`. Verified end-to-end on linux/arm64 (no-nasm path): full autogen+configure+make+install, `pkg-config --modversion libisal` -> `2.32.0`, `igzip --version` matches.