### PR TITLE
new(microbesonline.org/fasttree): fasttree 2.2.0

### DIFF
--- a/projects/microbesonline.org/fasttree/package.yml
+++ b/projects/microbesonline.org/fasttree/package.yml
@@ -1,24 +1,31 @@
 distributable:
-  url: https://github.com/morgannprice/fasttree/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/morgannprice/fasttree/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
   # the repo publishes tags but no GitHub releases, so read /tags
   github: morgannprice/fasttree/tags
-  strip: /^v/
 
 provides:
   - bin/FastTree
 
 build:
-  script:
-    - cc -O3 -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
-    - install -Dm0755 FastTree "{{prefix}}/bin/FastTree"
+  - cc -O3 -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
+  - install -Dm0755 FastTree "{{prefix}}/bin/FastTree"
 
 test:
-  script:
-    # FastTree with no args prints its banner then exits non-zero; swallow it
-    - (FastTree 2>&1 || true) | grep '{{version.raw}}'
-    - printf '%s\n' ">a" "ACGTACGTAC" ">b" "ACGTACGTTC" ">c" "ACGAACGTAC" ">d" "TCGTACGTAC" > seqs.fasta
-    - FastTree -nt seqs.fasta > tree.nwk
-    - grep ")" tree.nwk
+  # FastTree with no args prints its banner then exits non-zero; swallow it
+  - (FastTree 2>&1 || true) | grep '{{version.raw}}'
+  - run: FastTree -nt $FIXTURE > tree.nwk
+    fixture:
+      extname: fasta
+      content: |
+        >a
+        ACGTACGTAC
+        >b
+        ACGTACGTTC
+        >c
+        ACGAACGTAC
+        >d
+        TCGTACGTAC
+  - grep ")" tree.nwk

--- a/projects/microbesonline.org/fasttree/package.yml
+++ b/projects/microbesonline.org/fasttree/package.yml
@@ -1,0 +1,24 @@
+distributable:
+  url: https://github.com/morgannprice/fasttree/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  # the repo publishes tags but no GitHub releases, so read /tags
+  github: morgannprice/fasttree/tags
+  strip: /^v/
+
+provides:
+  - bin/FastTree
+
+build:
+  script:
+    - cc -O3 -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
+    - install -Dm0755 FastTree "{{prefix}}/bin/FastTree"
+
+test:
+  script:
+    # FastTree with no args prints its banner then exits non-zero; swallow it
+    - (FastTree 2>&1 || true) | grep '{{version.raw}}'
+    - printf '%s\n' ">a" "ACGTACGTAC" ">b" "ACGTACGTTC" ">c" "ACGAACGTAC" ">d" "TCGTACGTAC" > seqs.fasta
+    - FastTree -nt seqs.fasta > tree.nwk
+    - grep ")" tree.nwk


### PR DESCRIPTION
Adds **FastTree** — approximately-maximum-likelihood phylogenetic trees from large sequence alignments. Single C source file compiled with `cc -O3 -finline-functions -funroll-loops -lm` (no Makefile). Sourced from the morgannprice/fasttree GitHub mirror (tagged `v2.2.0`, contains `FastTree.c`), homepage-keyed at microbesonline.org. Verified end-to-end on linux/arm64: builds with system cc, prints `FastTree Version 2.2.0`, and infers a Newick tree from a 4-sequence fixture.