### PR TITLE
new(gnu.org/plotutils): plotutils 2.6

### DIFF
--- a/projects/gnu.org/plotutils/package.yml
+++ b/projects/gnu.org/plotutils/package.yml
@@ -1,20 +1,29 @@
 distributable:
   url: https://ftp.gnu.org/gnu/plotutils/plotutils-{{version.raw}}.tar.gz
   strip-components: 1
+
 versions:
   url: https://ftp.gnu.org/gnu/plotutils/
   match: /plotutils-\d+\.\d+(\.\d+)?\.tar\.gz/
   strip:
     - /plotutils-/
     - /.tar.gz/
+
 dependencies:
   libpng.org: ^1.6
-  libraw.org: ^0.21
+  zlib.net: ^1
+  linux:
+    gnu.org/gcc/libstdcxx: 14
+
 build:
+  dependencies:
+    linux:
+      gnu.org/gcc: 14
   script:
-    # warning: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+    # ISO C++17 does not allow the 'register' storage class specifier
     - run: sed -i "s|register ||g" pic2plot/gram.cc
       if: linux
+    # libpng >= 1.5 hid the jmp_buf member; use the accessor macro
     - run: sed -i "s|png_ptr->jmpbuf|png_jmpbuf (png_ptr)|g" z_write.c
       working-directory: libplot
     - ./configure $ARGS
@@ -22,26 +31,28 @@ build:
     - make --jobs {{ hw.concurrency }} install
   env:
     ARGS:
+      - --prefix={{prefix}}
       - --disable-debug
       - --disable-dependency-tracking
       - --disable-silent-rules
-      - --prefix={{prefix}}
       - --enable-libplotter
-    darwin:
-      ARGS:
-        - --without-x
+      - --without-x
     linux/aarch64:
       ARGS:
         - --build=aarch64-unknown-linux-gnu
+
 provides:
   - bin/double
   - bin/graph
+  - bin/hersheydemo
   - bin/ode
   - bin/pic2plot
   - bin/plot
   - bin/plotfont
   - bin/spline
   - bin/tek2plot
+
 test:
-  - plot --version | grep {{version.marketing}}
-  - graph -T png test.dat > test.png
+  - graph --version 2>&1 | grep {{version.raw}}
+  - printf "0 0\n1 1\n2 4\n" | graph -T ps > out.ps
+  - test -s out.ps


### PR DESCRIPTION
Adds **GNU plotutils** — the `graph`, `plot`, `spline`, `ode`, `pic2plot`, `tek2plot`, `plotfont`, `hersheydemo`, `double` utilities plus libplot/libplotter. autotools. Built `--without-x` (drops the whole X11 stack; PS/PNG/SVG/etc. drivers + all 9 CLIs remain). 2-component version -> `{{version.raw}}` in the tarball URL (2.6, not padded 2.6.0). libpng+zlib are real runtime deps (confirmed via `ldd`); C++ libplotter kept (`--enable-libplotter`) so gcc14/libstdcxx on linux. Two source patches needed for a modern toolchain: C++17 rejects `register` in `pic2plot/gram.cc`, and libpng>=1.5 hides `jmpbuf` (use `png_jmpbuf()`). Verified end-to-end on linux/arm64: `graph --version` -> 2.6, PS + PNG output valid.