### PR TITLE
new(micans.org): mcl 14.137

### DIFF
--- a/projects/micans.org/graph.abc
+++ b/projects/micans.org/graph.abc
@@ -1,0 +1,7 @@
+a	b	10
+a	c	9
+b	c	8
+c	d	1
+d	e	10
+d	f	9
+e	f	8

--- a/projects/micans.org/package.yml
+++ b/projects/micans.org/package.yml
@@ -1,0 +1,64 @@
+distributable:
+  # upstream version is dotless date-ish "YY-DDD" (e.g. 14-137).
+  # we store it as semver "14.137" and rebuild the dash form for the URL.
+  url: https://micans.org/mcl/src/mcl-{{ version.major }}-{{ version.minor }}.tar.gz
+  strip-components: 1
+
+versions:
+  # upstream src/ listing serves mcl-<YY>-<DDD>.tar.gz. The "-" is not valid
+  # semver (pkgx would read it as a prerelease tag and misorder), and pkgx
+  # `strip` cannot rewrite "-" to ".", so we cannot scrape straight into a
+  # version. The newest tarball (22-282) also ships a broken source tree
+  # (missing tingea/types.h), so auto-bumping to "latest" would not build.
+  # We therefore pin the last known-good release, mapped to semver 14.137:
+  #   url: https://micans.org/mcl/src/
+  #   match: /mcl-\d+-\d+\.tar\.gz/
+  #   strip:
+  #     - /^mcl-/
+  #     - /\.tar\.gz$/
+  - 14.137
+
+# linux only: the 14-137 release bundles a 2014 config.sub/config.guess that
+# rejects arm64-apple-darwin (and can't guess darwin arm64), and the newer mcl
+# that fixed autotools (22-282) doesn't compile. Builds cleanly on linux.
+platforms:
+  - linux
+
+provides:
+  - bin/mcl
+  - bin/mcx
+  - bin/mcxload
+  - bin/mcxdump
+  - bin/mcxarray
+  - bin/mcxassemble
+  - bin/mcxi
+  - bin/mcxmap
+  - bin/mcxrand
+  - bin/mcxsubs
+  - bin/clm
+  - bin/clmformat
+  - bin/clxdo
+  - bin/mclcm
+  - bin/mclpipeline
+
+build:
+  dependencies:
+    gnu.org/make: '*'
+  script:
+    # config.guess from 2014 doesn't recognize aarch64 -> pass an explicit triple.
+    # -fcommon: pre-C99-tentative globals defined in headers (GCC 10+ defaults to -fno-common).
+    # -Wno-implicit-function-declaration: K&R-era implicit decls are errors under GCC 14 / clang 16.
+    - ./configure
+      --prefix="{{ prefix }}"
+      --build="{{ hw.target }}"
+      --disable-dependency-tracking
+    - make --jobs {{ hw.concurrency }} install
+  env:
+    CC: cc
+    CFLAGS: -fcommon -Wno-implicit-function-declaration -O2
+
+test:
+  script:
+    - (mcl --version 2>&1 || true) | grep "mcl 14-137"
+    - mcl graph.abc --abc -o out.mcl
+    - test -s out.mcl

--- a/projects/micans.org/package.yml
+++ b/projects/micans.org/package.yml
@@ -42,8 +42,6 @@ provides:
   - bin/mclpipeline
 
 build:
-  dependencies:
-    gnu.org/make: '*'
   script:
     # config.guess from 2014 doesn't recognize aarch64 -> pass an explicit triple.
     # -fcommon: pre-C99-tentative globals defined in headers (GCC 10+ defaults to -fno-common).
@@ -58,7 +56,6 @@ build:
     CFLAGS: -fcommon -Wno-implicit-function-declaration -O2
 
 test:
-  script:
-    - (mcl --version 2>&1 || true) | grep "mcl 14-137"
-    - mcl graph.abc --abc -o out.mcl
-    - test -s out.mcl
+  - (mcl --version 2>&1 || true) | grep "mcl 14-137"
+  - mcl graph.abc --abc -o out.mcl
+  - test -s out.mcl


### PR DESCRIPTION
Adds **MCL** — Stijn van Dongen's Markov Cluster algorithm for graph clustering (`mcl`, `mcx`, `clm`, …; 15 binaries). Pure C/autotools, no external deps. Upstream versions are `YY-DDD` (dash, not semver), so the version is stored as `14.137` and the dash rebuilt in the URL. **Pinned to 14-137**: the newest tarball (22-282) ships a half-renamed tree (`src/clew` references a nonexistent `tingea/types.h`) and doesn't compile — 14-137 is the last clean release (documented in the recipe). Modern-toolchain fixes: `--build={{hw.target}}` (2014 config.guess can't detect aarch64), `-fcommon` + `-Wno-implicit-function-declaration`. Verified on linux/arm64: builds, installs 15 binaries, `mcl --version` -> `mcl 14-137`, and clusters a shipped `graph.abc` into the correct partition.