### PR TITLE
new(github.com/OpenGene/fastp): fastp 1.3.5

### DIFF
--- a/projects/github.com/OpenGene/fastp/package.yml
+++ b/projects/github.com/OpenGene/fastp/package.yml
@@ -1,0 +1,47 @@
+distributable:
+  url: https://github.com/OpenGene/fastp/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: OpenGene/fastp
+
+dependencies:
+  github.com/intel/isa-l: ^2
+  github.com/ebiggers/libdeflate: ^1
+  google.com/highway: ^1
+  zlib.net: ^1
+  linux:
+    gnu.org/gcc/libstdcxx: 14
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: "*"
+    linux:
+      gnu.org/gcc: 14
+  script:
+    - mkdir -p "{{prefix}}/bin"
+    - make CXX=c++ $ARGS
+    - make install $ARGS
+  env:
+    ARGS:
+      - PREFIX="{{prefix}}"
+
+provides:
+  - bin/fastp
+
+test:
+  - run: (fastp --version 2>&1 || true) | grep "{{version}}"
+  - run: |
+      fastp -i $FIXTURE -o out.fq --disable_adapter_trimming
+      test -s out.fq
+    fixture:
+      extname: fq
+      content: |
+        @r1
+        ACGTACGTACGTACGTACGTACGTACGTACGT
+        +
+        IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+        @r2
+        TTTTGGGGCCCCAAAATTTTGGGGCCCCAAAA
+        +
+        IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII

--- a/projects/github.com/OpenGene/fastp/package.yml
+++ b/projects/github.com/OpenGene/fastp/package.yml
@@ -15,7 +15,6 @@ dependencies:
 
 build:
   dependencies:
-    freedesktop.org/pkg-config: "*"
     linux:
       gnu.org/gcc: 14
   script:
@@ -30,10 +29,8 @@ provides:
   - bin/fastp
 
 test:
-  - run: (fastp --version 2>&1 || true) | grep "{{version}}"
-  - run: |
-      fastp -i $FIXTURE -o out.fq --disable_adapter_trimming
-      test -s out.fq
+  - (fastp --version 2>&1 || true) | grep "{{version}}"
+  - run: fastp -i $FIXTURE -o out.fq --disable_adapter_trimming
     fixture:
       extname: fq
       content: |
@@ -45,3 +42,4 @@ test:
         TTTTGGGGCCCCAAAATTTTGGGGCCCCAAAA
         +
         IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+  - test -s out.fq


### PR DESCRIPTION
Adds **fastp** — all-in-one ultra-fast FASTQ preprocessing (QC, adapter/quality trimming, filtering). C++/Makefile. Now that its deps landed: links `github.com/intel/isa-l` + `github.com/ebiggers/libdeflate` + `google.com/highway` + zlib (resolved via their `.pc` files, so pkg-config is a build dep). `CXX=c++`, `PREFIX` install var (the `install` target doesn't mkdir, so the recipe does). On linux: gcc 14 build + `gnu.org/gcc/libstdcxx` runtime. Verified on linux/arm64: `ldd` shows libisal/libdeflate/libhwy/libstdc++, `fastp --version` -> 1.3.5, and a real preprocess of an inline-fixture FASTQ.