### PR TITLE
new(qalculate.github.io): qalculate 5.11.0

### DIFF
--- a/projects/qalculate.github.io/package.yml
+++ b/projects/qalculate.github.io/package.yml
@@ -1,0 +1,56 @@
+distributable:
+  url: https://github.com/Qalculate/libqalculate/releases/download/{{version.tag}}/libqalculate-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: Qalculate/libqalculate
+
+# libqalculate bakes its data dir (PACKAGE_DATA_DIR) at configure time; brewkit
+# doesn't rewrite it inside libqalculate.so, so after relocation out of +brewing
+# it can't find the definition XMLs ("Failed to load global definitions"). 5.11.0
+# honors QALCULATE_DEFINITIONS_DIR (NOT XDG_DATA_DIRS) — point it at the install.
+runtime:
+  env:
+    QALCULATE_DEFINITIONS_DIR: ${{prefix}}/share/qalculate
+
+dependencies:
+  ginac.de/cln: "*"
+  gnu.org/gmp: "*"
+  gnu.org/mpfr: "*"
+  gnome.org/libxml2: "*"
+  unicode.org: "*"
+  gnu.org/readline: ^8
+  linux:
+    gnu.org/gcc/libstdcxx: 14
+  darwin:
+    gnu.org/gettext: ^0
+
+build:
+  dependencies:
+    freedesktop.org/pkg-config: "*"
+    gnu.org/gettext: ^0 # msgfmt --xml generates the definition data
+    linux:
+      gnu.org/gcc: 14
+  env:
+    # ICU 78 headers require C++17 (Apple clang defaults to an older std and
+    # fails "'auto' not allowed in template parameter"; gcc 14 on linux is C++17)
+    CXXFLAGS: -std=c++17
+    ARGS:
+      - --prefix={{prefix}}
+      - --disable-dependency-tracking
+      - --without-libcurl
+  script:
+    - ./configure $ARGS
+    - make --jobs {{hw.concurrency}}
+    - make install
+
+test:
+  env:
+    QALCULATE_DEFINITIONS_DIR: ${{prefix}}/share/qalculate
+  script:
+    - (qalc --version 2>&1 || true) | grep "{{version.raw}}"
+    - qalc -t "2+2" 2>&1 | tee out
+    - grep "^4$" out
+
+provides:
+  - bin/qalc

--- a/projects/qalculate.github.io/package.yml
+++ b/projects/qalculate.github.io/package.yml
@@ -20,21 +20,18 @@ dependencies:
   gnome.org/libxml2: "*"
   unicode.org: "*"
   gnu.org/readline: ^8
+  gnu.org/gettext: ^0
   linux:
     gnu.org/gcc/libstdcxx: 14
-  darwin:
-    gnu.org/gettext: ^0
 
 build:
   dependencies:
-    freedesktop.org/pkg-config: "*"
-    gnu.org/gettext: ^0 # msgfmt --xml generates the definition data
     linux:
       gnu.org/gcc: 14
   env:
     # ICU 78 headers require C++17 (Apple clang defaults to an older std and
     # fails "'auto' not allowed in template parameter"; gcc 14 on linux is C++17)
-    CXXFLAGS: -std=c++17
+    CXXFLAGS: $CXXFLAGS -std=c++17
     ARGS:
       - --prefix={{prefix}}
       - --disable-dependency-tracking


### PR DESCRIPTION
Adds **Qalculate!** — the powerful `qalc` desktop calculator (libqalculate). C++/autotools, from the release tarball. Deps: `ginac.de/cln` + gmp + mpfr (bignum), `gnome.org/libxml2` (definitions), **`unicode.org` (ICU — mandatory, configure errors `No package 'icu-uc'` without it)**, readline (CLI editing). `gnu.org/gettext` is a **build** dep too — `msgfmt --xml` generates the functions/units/variables definition XMLs (without it `make install` fails on `functions.xml`); kept as a darwin runtime dep for libintl. `--without-libcurl` drops only built-in exchange-rate fetch. gcc 14 build + libstdcxx runtime on linux. Verified on linux/arm64: configure finds cln/icu/libxml2/readline, `qalc --version` -> 5.11.0, `qalc -t '2+2'` -> `4` (definitions load from share/, no relocation issue).