### PR TITLE
new(github.com/ecmwf/eccodes): eccodes 2.47.2

### DIFF
--- a/projects/github.com/ecmwf/eccodes/package.yml
+++ b/projects/github.com/ecmwf/eccodes/package.yml
@@ -13,7 +13,7 @@ runtime:
 
 dependencies:
   linux:
-    gnu.org/gcc/libstdcxx: '*'
+    gnu.org/gcc/libstdcxx: 14
 
 build:
   dependencies:
@@ -45,8 +45,5 @@ provides:
   - bin/bufr_dump
 
 test:
-  script:
-    - run: |
-        set -e -o pipefail
-        (codes_info 2>&1 || true) | grep '{{version.raw}}'
-        (grib_ls {{prefix}}/share/eccodes/samples/GRIB2.tmpl 2>&1 || true) | grep regular_ll
+  - (codes_info 2>&1 || true) | grep '{{version.raw}}'
+  - (grib_ls {{prefix}}/share/eccodes/samples/GRIB2.tmpl 2>&1 || true) | grep regular_ll

--- a/projects/github.com/ecmwf/eccodes/package.yml
+++ b/projects/github.com/ecmwf/eccodes/package.yml
@@ -1,0 +1,52 @@
+distributable:
+  url: https://github.com/ecmwf/eccodes/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: ecmwf/eccodes
+
+# definitions+samples paths are baked at configure time; reset them post-relocation
+runtime:
+  env:
+    ECCODES_DEFINITION_PATH: ${{prefix}}/share/eccodes/definitions
+    ECCODES_SAMPLES_PATH: ${{prefix}}/share/eccodes/samples
+
+dependencies:
+  linux:
+    gnu.org/gcc/libstdcxx: '*'
+
+build:
+  dependencies:
+    cmake.org: '*'
+    linux:
+      gnu.org/gcc: 14
+  script:
+    - cmake -B build -S . $ARGS
+    - cmake --build build --parallel {{ hw.concurrency }}
+    - cmake --install build
+  env:
+    ARGS:
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DENABLE_FORTRAN=OFF
+      - -DENABLE_PYTHON=OFF
+      - -DENABLE_NETCDF=OFF
+      - -DENABLE_JPG=OFF
+      - -DENABLE_AEC=OFF
+      - -DENABLE_MEMFS=OFF
+
+provides:
+  - bin/codes_info
+  - bin/grib_ls
+  - bin/grib_dump
+  - bin/grib_get
+  - bin/grib_copy
+  - bin/grib_set
+  - bin/bufr_dump
+
+test:
+  script:
+    - run: |
+        set -e -o pipefail
+        (codes_info 2>&1 || true) | grep '{{version.raw}}'
+        (grib_ls {{prefix}}/share/eccodes/samples/GRIB2.tmpl 2>&1 || true) | grep regular_ll


### PR DESCRIPTION
Adds **ecCodes** — ECMWF's GRIB/BUFR decoding toolkit (`grib_ls`, `grib_dump`, `bufr_dump`, `codes_info`, …). C++/CMake. Minimal build: Fortran/Python/NetCDF/JPEG2000/AEC/MEMFS all OFF (degrade gracefully). **Critical**: ecCodes bakes its definitions+samples dir at configure time and aborts post-relocation (`Unable to find boot.def`), so `runtime.env ECCODES_DEFINITION_PATH`/`ECCODES_SAMPLES_PATH` are set to `${{prefix}}/share/eccodes/...` — the single most important lines. C++ -> gcc 14 build + libstdcxx runtime on linux (darwin = Apple clang). Verified on linux/arm64: configure (all optional deps off), build, install, `codes_info` -> 2.47.2, and `grib_ls` on a shipped GRIB2 sample with definitions found post-relocation.