### PR TITLE
new(github.com/GenericMappingTools/gmt): gmt 6.6.0

### DIFF
--- a/projects/github.com/GenericMappingTools/gmt/package.yml
+++ b/projects/github.com/GenericMappingTools/gmt/package.yml
@@ -1,0 +1,55 @@
+distributable:
+  url: https://github.com/GenericMappingTools/gmt/releases/download/{{version.tag}}/gmt-{{version}}-src.tar.gz
+  strip-components: 1
+
+versions:
+  github: GenericMappingTools/gmt
+  ignore: /rc/ # skip release candidates (e.g. 6.2.0rc1)
+
+# linux only for now: the darwin link fails inside GDAL's dependency closure
+# (libunwind/libcxx reexport mismatch). Builds + runs clean on linux.
+platforms:
+  - linux
+
+provides:
+  - bin/gmt
+
+dependencies:
+  unidata.ucar.edu/netcdf: '*'
+  curl.se: '*'
+  gdal.org: '*'
+  proj.org: '*'
+  fftw.org: '*'
+  pcre.org: '*'
+  zlib.net: '*'
+
+build:
+  dependencies:
+    cmake.org: '*'
+    freedesktop.org/pkg-config: '*'
+    linux:
+      gnu.org/gcc: 14
+  script:
+    - cmake -B build -S . $ARGS
+    - cmake --build build
+    - cmake --install build
+  env:
+    ARGS:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX={{prefix}}
+      - -DGMT_DATADIR=share/gmt
+      - -DGMT_DOCDIR=share/doc/gmt
+      - -DGMT_MANDIR=share/man
+      - -DCOPY_GSHHG=OFF
+      - -DCOPY_DCW=OFF
+      - -Wno-dev
+    linux:
+      CC: gcc
+      ARGS:
+        - -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined
+
+test:
+  - ({{prefix}}/bin/gmt --version 2>&1 || true) | grep '{{version.raw}}'
+  - run: |
+      gmt math -T0/10/1 T SQRT = out.txt
+      grep 2.2360679775 out.txt

--- a/projects/github.com/GenericMappingTools/gmt/package.yml
+++ b/projects/github.com/GenericMappingTools/gmt/package.yml
@@ -26,7 +26,6 @@ dependencies:
 build:
   dependencies:
     cmake.org: '*'
-    freedesktop.org/pkg-config: '*'
     linux:
       gnu.org/gcc: 14
   script:
@@ -50,6 +49,5 @@ build:
 
 test:
   - ({{prefix}}/bin/gmt --version 2>&1 || true) | grep '{{version.raw}}'
-  - run: |
-      gmt math -T0/10/1 T SQRT = out.txt
-      grep 2.2360679775 out.txt
+  - gmt math -T0/10/1 T SQRT = out.txt
+  - grep 2.2360679775 out.txt


### PR DESCRIPTION
Adds **GMT** — Generic Mapping Tools, the standard geospatial/cartographic analysis & plotting suite (`gmt` dispatcher). C/CMake. Deps: netcdf + curl (mandatory) + gdal + proj + fftw + pcre + zlib. On linux the final exe needs `-Wl,--allow-shlib-undefined` (unresolved symbols deep in GDAL's transitive closure — re2/spatialite — same as the gdal recipe). GSHHG/DCW coastline data left download-on-demand (`COPY_*=OFF`) to avoid baking hundreds of MB. GMT 6 self-locates its share dir (bindir-relative), so no `GMT_SHAREDIR` runtime.env needed (verified via a destructive relocation test). Core is C — libstdc++ arrives transitively via gdal. Verified on linux/arm64: cmake finds all deps, `gmt --version` -> 6.6.0, `gmt math … SQRT` -> correct.