### PR TITLE
new(gnu.org/glpk): glpk 5.0

### DIFF
--- a/projects/gnu.org/glpk/package.yml
+++ b/projects/gnu.org/glpk/package.yml
@@ -1,0 +1,30 @@
+distributable:
+  url: https://ftp.gnu.org/gnu/glpk/glpk-{{version.raw}}.tar.gz
+  strip-components: 1
+
+versions:
+  url: https://ftp.gnu.org/gnu/glpk/
+  match: /glpk-\d+\.\d+\.tar\.gz/
+  strip:
+    - /^glpk-/
+    - /\.tar\.gz$/
+
+provides:
+  - bin/glpsol
+
+build:
+  script:
+    - ./configure $ARGS
+    - make --jobs {{hw.concurrency}}
+    - make install
+  env:
+    ARGS:
+      - --prefix={{prefix}}
+      - --disable-dependency-tracking
+
+test:
+  - (glpsol --version 2>&1 || true) | grep "{{version.raw}}"
+  - run: |
+      printf 'maximize obj: x + y\nsubject to c1: x + 2 y <= 14\nc2: 3 x - y >= 0\nc3: x - y <= 2\nend\n' > model.lp
+      glpsol --lp model.lp -o out.sol
+      grep OPTIMAL out.sol

--- a/projects/gnu.org/glpk/package.yml
+++ b/projects/gnu.org/glpk/package.yml
@@ -23,8 +23,15 @@ build:
       - --disable-dependency-tracking
 
 test:
-  - (glpsol --version 2>&1 || true) | grep "{{version.raw}}"
-  - run: |
-      printf 'maximize obj: x + y\nsubject to c1: x + 2 y <= 14\nc2: 3 x - y >= 0\nc3: x - y <= 2\nend\n' > model.lp
-      glpsol --lp model.lp -o out.sol
-      grep OPTIMAL out.sol
+  - (glpsol --version 2>&1 || true) | tee out
+  - grep "{{version.raw}}" out
+  - run: glpsol --lp $FIXTURE -o out.sol
+    fixture:
+      extname: lp
+      content: |
+        maximize obj: x + y
+        subject to c1: x + 2 y <= 14
+        c2: 3 x - y >= 0
+        c3: x - y <= 2
+        end
+  - grep OPTIMAL out.sol


### PR DESCRIPTION
GNU Linear Programming Kit — the `glpsol` LP/MIP solver. Pure C/autotools. 2-component GNU version → `{{version.raw}}` URL + ftp.gnu.org scrape. Verified linux/arm64: solves an inline LP to OPTIMAL.