### PR TITLE
new(github.com/gpertea/gffread): gffread 0.12.9

### DIFF
--- a/projects/github.com/gpertea/gffread/package.yml
+++ b/projects/github.com/gpertea/gffread/package.yml
@@ -27,5 +27,13 @@ provides:
 test:
   - (gffread --version 2>&1 || true) | tee out
   - grep '{{version}}' out
-  - gffread test.gff3 -T -o out.gtf
+  - run: gffread $FIXTURE -T -o out.gtf
+    fixture:
+      extname: gff3
+      content: |
+        ##gff-version 3
+        chr1	test	gene	1000	2000	.	+	.	ID=gene1
+        chr1	test	mRNA	1000	2000	.	+	.	ID=mrna1;Parent=gene1
+        chr1	test	exon	1000	1500	.	+	.	Parent=mrna1
+        chr1	test	exon	1600	2000	.	+	.	Parent=mrna1
   - grep 'transcript_id' out.gtf

--- a/projects/github.com/gpertea/gffread/package.yml
+++ b/projects/github.com/gpertea/gffread/package.yml
@@ -1,0 +1,31 @@
+distributable:
+  url: https://github.com/gpertea/gffread/releases/download/{{version.tag}}/gffread-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: gpertea/gffread
+
+# the release-download tarball bundles a curated gclib/ subset and defaults
+# GCLDIR to ./gclib, so no sibling ../gclib clone is needed
+
+dependencies:
+  linux:
+    gnu.org/gcc/libstdcxx: 14
+
+build:
+  dependencies:
+    linux:
+      gnu.org/gcc: 14
+  script:
+    # Makefile hardcodes g++; force the toolchain c++ (Apple clang on darwin)
+    - make CXX=c++ LINKER=c++ release
+    - install -Dm0755 gffread "{{prefix}}"/bin/gffread
+
+provides:
+  - bin/gffread
+
+test:
+  - run: |
+      (gffread --version 2>&1 || true) | grep '{{version}}'
+      gffread test.gff3 -T -o out.gtf
+      grep 'transcript_id' out.gtf

--- a/projects/github.com/gpertea/gffread/package.yml
+++ b/projects/github.com/gpertea/gffread/package.yml
@@ -25,7 +25,7 @@ provides:
   - bin/gffread
 
 test:
-  - run: |
-      (gffread --version 2>&1 || true) | grep '{{version}}'
-      gffread test.gff3 -T -o out.gtf
-      grep 'transcript_id' out.gtf
+  - (gffread --version 2>&1 || true) | tee out
+  - grep '{{version}}' out
+  - gffread test.gff3 -T -o out.gtf
+  - grep 'transcript_id' out.gtf

--- a/projects/github.com/gpertea/gffread/test.gff3
+++ b/projects/github.com/gpertea/gffread/test.gff3
@@ -1,5 +1,0 @@
-##gff-version 3
-chr1	test	gene	1000	2000	.	+	.	ID=gene1
-chr1	test	mRNA	1000	2000	.	+	.	ID=mrna1;Parent=gene1
-chr1	test	exon	1000	1500	.	+	.	Parent=mrna1
-chr1	test	exon	1600	2000	.	+	.	Parent=mrna1

--- a/projects/github.com/gpertea/gffread/test.gff3
+++ b/projects/github.com/gpertea/gffread/test.gff3
@@ -1,0 +1,5 @@
+##gff-version 3
+chr1	test	gene	1000	2000	.	+	.	ID=gene1
+chr1	test	mRNA	1000	2000	.	+	.	ID=mrna1;Parent=gene1
+chr1	test	exon	1000	1500	.	+	.	Parent=mrna1
+chr1	test	exon	1600	2000	.	+	.	Parent=mrna1


### PR DESCRIPTION
gffread — GFF/GTF conversion. C++. Uses the release-download tarball (bundles gclib → no sibling clone). Ships companion `test.gff3` (real tabs). gcc14/libstdcxx on linux. Verified linux/arm64: GFF3→GTF.