### PR TITLE
new(github.com/gpertea/stringtie): stringtie 3.0.3

### DIFF
--- a/projects/github.com/gpertea/stringtie/package.yml
+++ b/projects/github.com/gpertea/stringtie/package.yml
@@ -1,0 +1,36 @@
+distributable:
+  url: https://github.com/gpertea/stringtie/releases/download/{{version.tag}}/stringtie-{{version}}.offline.tar.gz
+  strip-components: 1
+
+versions:
+  github: gpertea/stringtie
+
+# the `.offline` release asset bundles gclib/ + htslib/ + htslib's xlibs
+# (libdeflate/bzip2/xz) and defaults the include paths, so a plain `make
+# release` builds with no fetch; the bare stringtie-{{version}}.tar.gz instead
+# git-clones/curls those xlibs mid-build, which a clean build cannot do
+
+dependencies:
+  zlib.net: ^1
+  linux:
+    gnu.org/gcc/libstdcxx: 14
+
+build:
+  dependencies:
+    linux:
+      gnu.org/gcc: 14
+  script:
+    # bundled htslib Makefile hardcodes x86 SIMD flags; strip them off x86 or
+    # g++ rejects -msse*/-mpopcnt on arm64/riscv64/loong64
+    - if test "{{hw.arch}}" != "x86-64"; then sed -i.bak 's/-msse4.1//g; s/-mssse3//g; s/-mpopcnt//g' htslib/Makefile; fi
+    # Makefile hardcodes g++; force the toolchain c++ (Apple clang on darwin)
+    - make CXX=c++ LINKER=c++ release
+    - install -Dm0755 stringtie "{{prefix}}"/bin/stringtie
+
+provides:
+  - bin/stringtie
+
+test:
+  - run: |
+      (stringtie --version 2>&1 || true) | grep '{{version.raw}}'
+      (stringtie --help 2>&1 || true) | grep 'StringTie v{{version.raw}}'

--- a/projects/github.com/gpertea/stringtie/package.yml
+++ b/projects/github.com/gpertea/stringtie/package.yml
@@ -22,7 +22,9 @@ build:
   script:
     # bundled htslib Makefile hardcodes x86 SIMD flags; strip them off x86 or
     # g++ rejects -msse*/-mpopcnt on arm64/riscv64/loong64
-    - if test "{{hw.arch}}" != "x86-64"; then sed -i.bak 's/-msse4.1//g; s/-mssse3//g; s/-mpopcnt//g' htslib/Makefile; fi
+    - run: sed -i 's/-msse4.1//g; s/-mssse3//g; s/-mpopcnt//g' Makefile
+      working-directory: htslib
+      if: aarch64
     # Makefile hardcodes g++; force the toolchain c++ (Apple clang on darwin)
     - make CXX=c++ LINKER=c++ release
     - install -Dm0755 stringtie "{{prefix}}"/bin/stringtie
@@ -31,6 +33,7 @@ provides:
   - bin/stringtie
 
 test:
-  - run: |
-      (stringtie --version 2>&1 || true) | grep '{{version.raw}}'
-      (stringtie --help 2>&1 || true) | grep 'StringTie v{{version.raw}}'
+  - (stringtie --version 2>&1 || true) | tee out
+  - grep '{{version.raw}}' out
+  - (stringtie --help 2>&1 || true) | tee out
+  - grep 'StringTie v{{version.raw}}' out


### PR DESCRIPTION
StringTie — RNA-seq transcript assembly. C++. Uses the `.offline` release asset (bundles gclib+htslib+xlibs; the plain tarball git-clones mid-build). Strips htslib's x86 SIMD flags off non-x86. gcc14/libstdcxx on linux. Verified linux/arm64: version+help.