### PR TITLE
new(github.com/gpertea/gffcompare): gffcompare 0.12.6

### DIFF
--- a/projects/github.com/gpertea/gffcompare/package.yml
+++ b/projects/github.com/gpertea/gffcompare/package.yml
@@ -1,0 +1,33 @@
+distributable:
+  url: https://github.com/gpertea/gffcompare/releases/download/{{version.tag}}/gffcompare-{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: gpertea/gffcompare
+
+# the release-download tarball bundles a curated gclib/ subset and defaults
+# GCLIB to ./gclib, so no sibling ../gclib clone is needed
+
+dependencies:
+  linux:
+    gnu.org/gcc/libstdcxx: 14
+
+build:
+  dependencies:
+    linux:
+      gnu.org/gcc: 14
+  script:
+    # Makefile hardcodes g++; force the toolchain c++ (Apple clang on darwin)
+    - make CXX=c++ LINKER=c++ release
+    - install -Dm0755 gffcompare "{{prefix}}"/bin/gffcompare
+    - install -Dm0755 trmap "{{prefix}}"/bin/trmap
+
+provides:
+  - bin/gffcompare
+  - bin/trmap
+
+test:
+  - run: |
+      (gffcompare --version 2>&1 || true) | grep '{{version.raw}}'
+      gffcompare -r ref.gtf -o cmp query.gtf
+      grep 'class_code' cmp.annotated.gtf

--- a/projects/github.com/gpertea/gffcompare/package.yml
+++ b/projects/github.com/gpertea/gffcompare/package.yml
@@ -27,7 +27,7 @@ provides:
   - bin/trmap
 
 test:
-  - run: |
-      (gffcompare --version 2>&1 || true) | grep '{{version.raw}}'
-      gffcompare -r ref.gtf -o cmp query.gtf
-      grep 'class_code' cmp.annotated.gtf
+  - (gffcompare --version 2>&1 || true) | tee out
+  - grep '{{version.raw}}' out
+  - gffcompare -r ref.gtf -o cmp query.gtf
+  - grep 'class_code' cmp.annotated.gtf

--- a/projects/github.com/gpertea/gffcompare/query.gtf
+++ b/projects/github.com/gpertea/gffcompare/query.gtf
@@ -1,0 +1,3 @@
+chr1	test	transcript	1000	5000	.	+	.	transcript_id "q1"; gene_id "qg1";
+chr1	test	exon	1000	2000	.	+	.	transcript_id "q1"; gene_id "qg1";
+chr1	test	exon	3000	5000	.	+	.	transcript_id "q1"; gene_id "qg1";

--- a/projects/github.com/gpertea/gffcompare/ref.gtf
+++ b/projects/github.com/gpertea/gffcompare/ref.gtf
@@ -1,0 +1,3 @@
+chr1	test	transcript	1000	5000	.	+	.	transcript_id "r1"; gene_id "g1";
+chr1	test	exon	1000	2000	.	+	.	transcript_id "r1"; gene_id "g1";
+chr1	test	exon	3000	5000	.	+	.	transcript_id "r1"; gene_id "g1";


### PR DESCRIPTION
gffcompare — compare/annotate transcript GTFs (+ `trmap`). C++. Release-download tarball bundles gclib. Ships companion `ref.gtf`/`query.gtf` (real tabs). gcc14/libstdcxx on linux. Verified linux/arm64: -r compare emits annotated GTF.