### PR TITLE
new(github.com/cddlib/cddlib): cddlib 0.94n

### DIFF
--- a/projects/github.com/cddlib/cddlib/package.yml
+++ b/projects/github.com/cddlib/cddlib/package.yml
@@ -43,6 +43,6 @@ test:
       1 0 -1
       end
   - scdd_gmp square.ine
-  - grep -q V-representation square.ext
-  - grep -q "4 3 rational" square.ext
-  - grep -q "Version {{version.raw}}" square.ext
+  - grep V-representation square.ext
+  - grep "4 3 rational" square.ext
+  - grep "Version {{version.raw}}" square.ext

--- a/projects/github.com/cddlib/cddlib/package.yml
+++ b/projects/github.com/cddlib/cddlib/package.yml
@@ -1,0 +1,48 @@
+distributable:
+  url: https://github.com/cddlib/cddlib/releases/download/{{version.tag}}/cddlib-{{version.raw}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: cddlib/cddlib
+
+dependencies:
+  gnu.org/gmp: '*'
+
+build:
+  - ./configure --prefix="{{prefix}}"
+  - make --jobs {{hw.concurrency}}
+  - make install
+
+provides:
+  - bin/scdd
+  - bin/scdd_gmp
+  - bin/lcdd
+  - bin/lcdd_gmp
+  - bin/redcheck
+  - bin/redcheck_gmp
+  - bin/adjacency
+  - bin/adjacency_gmp
+  - bin/allfaces
+  - bin/allfaces_gmp
+  - bin/fourier
+  - bin/fourier_gmp
+  - bin/projection
+  - bin/projection_gmp
+  - bin/cddexec
+  - bin/cddexec_gmp
+
+test:
+  - run: cp $FIXTURE square.ine
+    fixture: |
+      H-representation
+      begin
+      4 3 integer
+      1 1 0
+      1 -1 0
+      1 0 1
+      1 0 -1
+      end
+  - scdd_gmp square.ine
+  - grep -q V-representation square.ext
+  - grep -q "4 3 rational" square.ext
+  - grep -q "Version {{version.raw}}" square.ext


### PR DESCRIPTION
cddlib — double-description polyhedra / vertex enumeration. C/autotools, gmp. Letter-suffix version → `{{version.raw}}` asset + `{{version.tag}}` path (pkgx parses 0.94n→0.94.14). Pure C. Verified linux/arm64: scdd_gmp enumerates a square's vertices.