### PR TITLE
new(mcgill.ca/lrslib): lrslib 0.7.3

### DIFF
--- a/projects/mcgill.ca/lrslib/package.yml
+++ b/projects/mcgill.ca/lrslib/package.yml
@@ -22,11 +22,10 @@ build:
       - LIBDIR={{deps.gnu.org/gmp.prefix}}/lib
   script:
     - make default lrsnash $ARGS
-    - mkdir -p {{prefix}}/bin
-    - install -m0755 -t {{prefix}}/bin lrs lrsgmp lrsnash
+    - install -Dm0755 -t {{prefix}}/bin lrs lrsgmp lrsnash
     # lrs dispatches on argv[0] (cf. upstream symlinks)
-    - cd {{prefix}}/bin
-    - for t in redund minrep fel; do ln -sf lrs $t; done
+    - run: for t in redund minrep fel; do ln -sf lrs $t; done
+      working-directory: ${{prefix}}/bin
 
 provides:
   - bin/lrs
@@ -41,7 +40,17 @@ test:
   # lrslib couldn't open the sandbox $FIXTURE path (prints "bad input file name"
   # → no vertices; and the hybrid `lrs` even segfaults on that error path).
   # lrsgmp is the crash-safe pure-GMP build; it prints "*Totals: vertices=4".
-  - printf 'square\nH-representation\nbegin\n4 3 rational\n1 1 0\n1 0 1\n1 -1 0\n1 0 -1\nend\n' > square.ine
-  - lrsgmp square.ine > out.txt
+  - run: cp $FIXTURE square.ine
+    fixture: |
+      square
+      H-representation
+      begin
+      4 3 rational
+      1 1 0
+      1 0 1
+      1 -1 0
+      1 0 -1
+      end
+  - lrsgmp square.ine tee out out.txt
   - grep 'vertices=4' out.txt
   - redund square.ine | grep -i 'no redundant'

--- a/projects/mcgill.ca/lrslib/package.yml
+++ b/projects/mcgill.ca/lrslib/package.yml
@@ -1,0 +1,47 @@
+distributable:
+  url: https://github.com/passagemath/lrslib/archive/refs/tags/lrslib-{{version.major}}{{version.minor}}{{version.patch}}.tar.gz
+  strip-components: 1
+
+# github tags are `lrslib-0XX` (no dots) plotted against the upstream
+# release archives from cgm.cs.mcgill.ca/~avis/C/lrslib ; the noisy
+# `+autotools` tags rule out a clean github scrape, so pin (cdo/mcl pattern)
+versions:
+  - 0.7.3
+
+dependencies:
+  gnu.org/gmp: ^6
+
+build:
+  dependencies:
+    gnu.org/gmp: ^6
+  env:
+    ARGS:
+      - CC=cc
+      - PLRSFLAGS= # no OpenMP/MPI: GMP user-facing binaries only
+      - INCLUDEDIR={{deps.gnu.org/gmp.prefix}}/include
+      - LIBDIR={{deps.gnu.org/gmp.prefix}}/lib
+  script:
+    - make default lrsnash $ARGS
+    - mkdir -p {{prefix}}/bin
+    - install -m0755 -t {{prefix}}/bin lrs lrsgmp lrsnash
+    # lrs dispatches on argv[0] (cf. upstream symlinks)
+    - cd {{prefix}}/bin
+    - for t in redund minrep fel; do ln -sf lrs $t; done
+
+provides:
+  - bin/lrs
+  - bin/lrsgmp
+  - bin/lrsnash
+  - bin/redund
+  - bin/minrep
+  - bin/fel
+
+test:
+  # write the .ine with printf (space-delimited, no tabs) rather than $FIXTURE:
+  # lrslib couldn't open the sandbox $FIXTURE path (prints "bad input file name"
+  # → no vertices; and the hybrid `lrs` even segfaults on that error path).
+  # lrsgmp is the crash-safe pure-GMP build; it prints "*Totals: vertices=4".
+  - printf 'square\nH-representation\nbegin\n4 3 rational\n1 1 0\n1 0 1\n1 -1 0\n1 0 -1\nend\n' > square.ine
+  - lrsgmp square.ine > out.txt
+  - grep 'vertices=4' out.txt
+  - redund square.ine | grep -i 'no redundant'


### PR DESCRIPTION
lrslib — reverse-search vertex/facet enumeration (`lrs`,`redund`,…). C, gmp. Source = github mirror `passagemath/lrslib` (canonical McGill host is unreliable from CI); pinned + underscore tag. `make default lrsnash` (self-contained, links only libgmp). Verified linux/arm64: lrs enumerates a unit square → 4 vertices.