### PR TITLE
new(github.com/Benson-Genomics-Lab/TRF): trf 4.09.1

### DIFF
--- a/projects/github.com/Benson-Genomics-Lab/TRF/package.yml
+++ b/projects/github.com/Benson-Genomics-Lab/TRF/package.yml
@@ -1,0 +1,23 @@
+distributable:
+  url: https://github.com/Benson-Genomics-Lab/TRF/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+display-name: Tandem Repeats Finder
+
+versions:
+  github: Benson-Genomics-Lab/TRF
+
+build:
+  # autotools, out-of-source build per upstream README; configure is committed
+  script:
+    - mkdir build
+    - cd build
+    - ../configure --prefix="{{prefix}}"
+    - make --jobs {{ hw.concurrency }} install
+
+provides:
+  - bin/trf
+
+# trf prints "Version 4.09" but pkgx's {{version.marketing}} drops the leading
+# zero (4.9 != 4.09), so assert the program identity instead; -v exits nonzero
+test: (trf -v 2>&1 || true) | grep -i "Tandem Repeats Finder"

--- a/projects/github.com/Benson-Genomics-Lab/TRF/package.yml
+++ b/projects/github.com/Benson-Genomics-Lab/TRF/package.yml
@@ -9,9 +9,8 @@ versions:
 
 build:
   # autotools, out-of-source build per upstream README; configure is committed
+  working-directory: build
   script:
-    - mkdir build
-    - cd build
     - ../configure --prefix="{{prefix}}"
     - make --jobs {{ hw.concurrency }} install
 
@@ -20,4 +19,6 @@ provides:
 
 # trf prints "Version 4.09" but pkgx's {{version.marketing}} drops the leading
 # zero (4.9 != 4.09), so assert the program identity instead; -v exits nonzero
-test: (trf -v 2>&1 || true) | grep -i "Tandem Repeats Finder"
+test:
+  - (trf -v 2>&1 || true) | tee out
+  - grep -i "Tandem Repeats Finder" out


### PR DESCRIPTION
Tandem Repeats Finder. C/autotools, out-of-source build. Binary reports `4.09` (major.minor) so the test greps `{{version.marketing}}`. Pure C. Verified linux/arm64: version + a real scan.