### PR TITLE
new(github.com/lh3/bioawk): bioawk 1.0

### DIFF
--- a/projects/github.com/lh3/bioawk/package.yml
+++ b/projects/github.com/lh3/bioawk/package.yml
@@ -1,0 +1,33 @@
+distributable:
+  url: https://github.com/lh3/bioawk/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+versions:
+  github: lh3/bioawk/tags
+
+dependencies:
+  zlib.net: 1
+
+build:
+  dependencies:
+    gnu.org/bison: '*'
+  script:
+    - make CC=cc YACC="bison -y"
+    - install -Dm0755 bioawk {{ prefix }}/bin/bioawk
+
+test:
+  - (bioawk 2>&1 || true) | tee out
+  - grep -i 'usage\|bioawk' out
+  # -c fastx exposes $name/$seq; both records are length 4
+  - run: bioawk -c fastx '{print length($seq)}' $FIXTURE | tee out
+    fixture:
+      extname: fa
+      content: |
+        >s1
+        ACGT
+        >s2
+        AAAA
+  - grep 4 out
+
+provides:
+  - bin/bioawk


### PR DESCRIPTION
Adds **bioawk** (Heng Li) — `awk` extended with support for FASTA/FASTQ/SAM/BED/VCF/GFF via `-c`. C (awk fork). Deps: zlib (runtime) + `gnu.org/bison` (build, for the `awkgram.y` grammar); `make CC=cc YACC="bison -y"`. Only one upstream tag (v1.0) and no releases → `versions: …/tags`. Verified linux/arm64: `bioawk -c fastx` reports sequence lengths.