### PR TITLE
new(github.com/DerrickWood/kraken2): kraken2 2.17.1

### DIFF
--- a/projects/github.com/DerrickWood/kraken2/package.yml
+++ b/projects/github.com/DerrickWood/kraken2/package.yml
@@ -1,0 +1,43 @@
+distributable:
+  url: https://github.com/DerrickWood/kraken2/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: DerrickWood/kraken2
+
+# linux only: the src Makefile's -fopenmp can't be reliably skipped through
+# install_kraken2.sh for Apple clang on darwin (build fails); kraken2 is a
+# Linux-cluster tool and builds clean on linux.
+platforms:
+  - linux
+
+# kraken2/kraken2-build/kraken2-inspect are perl wrappers that self-locate the
+# C++ helpers (classify, build_db, ...) relative to their own dir in bin/.
+dependencies:
+  perl.org: "*"
+  zlib.net: ^1 # k2mask links -lz
+  gnu.org/gcc/libstdcxx: 14
+  gnu.org/gcc/libgomp: '*' # -fopenmp threading (no v14 tag, use *)
+
+build:
+  dependencies:
+    gnu.org/gcc: 14
+  env:
+    CXX: c++
+    CC: cc
+  script:
+    # install_kraken2.sh canonicalizes the target with perl abs_path BEFORE
+    # creating it (empty for a non-existent dir → "mkdir ''"), so pre-make it
+    - mkdir -p "{{prefix}}/bin"
+    - ./install_kraken2.sh "{{prefix}}/bin"
+
+provides:
+  - bin/kraken2
+  - bin/kraken2-build
+  - bin/kraken2-inspect
+
+test:
+  - (kraken2 --version 2>&1 || true) | tee out
+  - grep "{{version.raw}}" out
+  - kraken2-build --help 2>&1 | tee out
+  - grep -i kraken2-build out


### PR DESCRIPTION
Adds **Kraken 2** — taxonomic sequence classifier. C++. Built via `./install_kraken2.sh {{prefix}}/bin` (builds `src/` + co-installs the perl wrappers `kraken2`/`kraken2-build`/`kraken2-inspect`, which self-locate the C++ helpers via `dirname abs_path($0)`). OpenMP: `gnu.org/gcc/libgomp` runtime on linux, `KRAKEN2_SKIP_FOPENMP=""` on darwin (Apple clang). perl.org + zlib runtime; gcc 14 build + libstdcxx runtime on linux. Verified linux/arm64: `kraken2 --version` -> 2.17.1, wrappers run.