### PR TITLE
pallini.di.uniroma1.it/nauty: new package

### DIFF
--- a/projects/pallini.di.uniroma1.it/package.yml
+++ b/projects/pallini.di.uniroma1.it/package.yml
@@ -1,0 +1,58 @@
+distributable:
+  url: https://pallini.di.uniroma1.it/nauty{{version.major}}_{{version.minor}}_{{version.patch}}.tar.gz
+  strip-components: 1
+
+versions:
+  # The homepage is a single page (no directory listing); it links the
+  # current stable tarball as nautyX_Y_Z.tar.gz. Match the stable form only,
+  # excluding betas like nauty2_9_4b5.tar.gz.
+  url: https://pallini.di.uniroma1.it/
+  match: /nauty\d+_\d+_\d+\.tar\.gz/
+  strip:
+    - /nauty/
+    - /\.tar\.gz/
+  # nautyX_Y_Z -> X.Y.Z
+  transform: v => v.replace(/_/g, '.')
+
+build:
+  script:
+    - ./configure $ARGS
+    - make --jobs {{ hw.concurrency }}
+    - make install
+  env:
+    # nauty's makefile defaults to gcc; force the platform cc.
+    CC: cc
+    ARGS:
+      - --prefix={{prefix}}
+      # disable the default -march=native (would bake builder-CPU ISA into
+      # the distributed binaries); keep generic, portable codegen.
+      - --enable-generic
+
+provides:
+  - bin/dreadnaut
+  - bin/geng
+  - bin/gentourng
+  - bin/genrang
+  - bin/genbg
+  - bin/gentreeg
+  - bin/labelg
+  - bin/shortg
+  - bin/amtog
+  - bin/complg
+  - bin/copyg
+  - bin/listg
+  - bin/showg
+  - bin/pickg
+  - bin/countg
+  - bin/directg
+  - bin/multig
+  - bin/planarg
+  - bin/converseg
+  - bin/dretog
+  - bin/uniqg
+
+test: |
+  # 4 vertices => 11 graphs, 5 vertices => 34 graphs (deterministic).
+  geng -u 4 2>&1 | grep "11 graphs generated"
+  geng -u 5 2>&1 | grep "34 graphs generated"
+  test "$(geng 4 2>/dev/null | wc -l)" = "11"

--- a/projects/pallini.di.uniroma1.it/package.yml
+++ b/projects/pallini.di.uniroma1.it/package.yml
@@ -51,8 +51,10 @@ provides:
   - bin/dretog
   - bin/uniqg
 
-test: |
+test:
   # 4 vertices => 11 graphs, 5 vertices => 34 graphs (deterministic).
-  geng -u 4 2>&1 | grep "11 graphs generated"
-  geng -u 5 2>&1 | grep "34 graphs generated"
-  test "$(geng 4 2>/dev/null | wc -l)" = "11"
+  - geng -u 4 2>&1 | tee out
+  - grep "11 graphs generated" out
+  - geng -u 5 2>&1 | tee out
+  - grep "34 graphs generated" out
+  - test "$(geng 4 2>/dev/null | wc -l)" = "11"

--- a/projects/pallini.di.uniroma1.it/package.yml
+++ b/projects/pallini.di.uniroma1.it/package.yml
@@ -60,4 +60,5 @@ test:
   - grep "11 graphs generated" out
   - geng -u 5 2>&1 | tee out
   - grep "34 graphs generated" out
-  - test "$(geng 4 2>/dev/null | wc -l)" = "11"
+  # grep -c (not wc -l: BSD wc pads the count with leading spaces on darwin)
+  - test "$(geng 4 2>/dev/null | grep -c .)" = "11"

--- a/projects/pallini.di.uniroma1.it/package.yml
+++ b/projects/pallini.di.uniroma1.it/package.yml
@@ -6,7 +6,9 @@
 # the github: path DOES honor transform); old-style tags (nauty27r4, *rc*) carry
 # no underscores, fail to parse, and drop out automatically.
 distributable:
-  url: https://github.com/lonnen/nauty/archive/refs/tags/{{version.tag}}.tar.gz
+  # the git tag is nautyX_Y_Z; {{version.tag}} isn't reliable through the
+  # transform path, so reconstruct it from the version components.
+  url: https://github.com/lonnen/nauty/archive/refs/tags/nauty{{version.major}}_{{version.minor}}_{{version.patch}}.tar.gz
   strip-components: 1
 
 versions:

--- a/projects/pallini.di.uniroma1.it/package.yml
+++ b/projects/pallini.di.uniroma1.it/package.yml
@@ -1,16 +1,17 @@
+# nauty/Traces (Brendan McKay & Adolfo Piperno). The authoritative homepage
+# pallini.di.uniroma1.it ships underscore-versioned tarballs (nautyX_Y_Z.tar.gz)
+# from a single page with no directory listing — pkgx's URL-scrape can't turn
+# `2_9_3` into a semver (it has no transform step). So we mirror versions and
+# source from lonnen/nauty (a maintained GitHub mirror of the same release set,
+# the github: path DOES honor transform); old-style tags (nauty27r4, *rc*) carry
+# no underscores, fail to parse, and drop out automatically.
 distributable:
-  url: https://pallini.di.uniroma1.it/nauty{{version.major}}_{{version.minor}}_{{version.patch}}.tar.gz
+  url: https://github.com/lonnen/nauty/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 versions:
-  # The homepage is a single page (no directory listing); it links the
-  # current stable tarball as nautyX_Y_Z.tar.gz. Match the stable form only,
-  # excluding betas like nauty2_9_4b5.tar.gz.
-  url: https://pallini.di.uniroma1.it/
-  match: /nauty\d+_\d+_\d+\.tar\.gz/
-  strip:
-    - /nauty/
-    - /\.tar\.gz/
+  github: lonnen/nauty
+  strip: /^nauty/
   # nautyX_Y_Z -> X.Y.Z
   transform: v => v.replace(/_/g, '.')
 


### PR DESCRIPTION
[nauty and Traces](https://pallini.di.uniroma1.it/) (Brendan McKay & Adolfo Piperno) — tools for computing graph automorphism groups, canonical labelling, and exhaustive graph generation (`geng`, `dreadnaut`, `shortg`, …).

Built from source. The authoritative homepage ships underscore-versioned tarballs (`nautyX_Y_Z.tar.gz`) from a single page with no directory listing, which pkgx's URL-scrape can't turn into a semver — so versions and source are taken from the maintained `lonnen/nauty` GitHub mirror of the same release set (the `github:` path supports `transform`). Portable codegen via `--enable-generic` (no `-march=native` baked into the distributed binaries).