### PR TITLE
new(github.com/J-Siu/go-png2ico): PNG → ICO CLI in pure Go

### DIFF
--- a/projects/github.com/J-Siu/go-png2ico/package.yml
+++ b/projects/github.com/J-Siu/go-png2ico/package.yml
@@ -6,38 +6,33 @@ display-name: go-png2ico
 
 versions:
   github: J-Siu/go-png2ico
+
 provides:
   - bin/go-png2ico
 
 build:
   dependencies:
     go.dev: ^1.26
-  script: |
-    go mod download
-    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  script:
+    - go mod download
+    - go build -v -trimpath -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/go-png2ico .
   env:
-    GOPROXY: https://proxy.golang.org,direct
-    GOSUMDB: sum.golang.org
     GO111MODULE: on
     CGO_ENABLED: 0
-    BUILDLOC: '{{prefix}}/bin/go-png2ico'
-    LDFLAGS:
+    GO_LDFLAGS:
       - -s
       - -w
     linux:
       # -buildmode=pie or segmentation fault
       # https://github.com/docker-library/golang/issues/402#issuecomment-982204575
-      LDFLAGS:
-        - -s
-        - -w
+      GO_LDFLAGS:
         - -buildmode=pie
 
 test:
-  script: |
-    # 1) version string is wired to the released tag (p2i.Version == the git tag)
-    test "$(go-png2ico --version)" = "go-png2ico version {{version.tag}}"
-    # 2) round-trip: a 1x1 PNG -> ICO, and the output carries the ICO magic (00 00 01 00)
-    printf '%s' 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC' | base64 -d > one.png
-    go-png2ico one.png out.ico
-    test -s out.ico
-    test "$(od -An -tx1 -N4 out.ico | tr -d ' \n')" = "00000100"
+  # 1) version string is wired to the released tag (p2i.Version == the git tag)
+  - test "$(go-png2ico --version)" = "go-png2ico version {{version.tag}}"
+  # 2) round-trip: a 1x1 PNG -> ICO, and the output carries the ICO magic (00 00 01 00)
+  - printf '%s' 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC' | base64 -d > one.png
+  - go-png2ico one.png out.ico
+  - test -s out.ico
+  - test "$(od -An -tx1 -N4 out.ico | tr -d ' \n')" = "00000100"

--- a/projects/github.com/J-Siu/go-png2ico/package.yml
+++ b/projects/github.com/J-Siu/go-png2ico/package.yml
@@ -1,0 +1,43 @@
+distributable:
+  url: https://github.com/J-Siu/go-png2ico/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+display-name: go-png2ico
+
+versions:
+  github: J-Siu/go-png2ico
+provides:
+  - bin/go-png2ico
+
+build:
+  dependencies:
+    go.dev: ^1.26
+  script: |
+    go mod download
+    go build -v -trimpath -ldflags="$LDFLAGS" -o $BUILDLOC .
+  env:
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    GO111MODULE: on
+    CGO_ENABLED: 0
+    BUILDLOC: '{{prefix}}/bin/go-png2ico'
+    LDFLAGS:
+      - -s
+      - -w
+    linux:
+      # -buildmode=pie or segmentation fault
+      # https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+        - -s
+        - -w
+        - -buildmode=pie
+
+test:
+  script: |
+    # 1) version string is wired to the released tag (p2i.Version == the git tag)
+    test "$(go-png2ico --version)" = "go-png2ico version {{version.tag}}"
+    # 2) round-trip: a 1x1 PNG -> ICO, and the output carries the ICO magic (00 00 01 00)
+    printf '%s' 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC' | base64 -d > one.png
+    go-png2ico one.png out.ico
+    test -s out.ico
+    test "$(od -An -tx1 -N4 out.ico | tr -d ' \n')" = "00000100"


### PR DESCRIPTION
## Summary
- Small CLI that reads PNG(s) and writes a Windows `.ico` (magic `00 00 01 00`). Useful for favicon / branding pipelines that only have PNGs on hand.
- Pure Go, CGO=0.
- Builds against `go.dev ^1.26`; linux uses `-buildmode=pie` to avoid the well-known Go+glibc segfault noted upstream ([docker-library/golang#402](https://github.com/docker-library/golang/issues/402#issuecomment-982204575)).

## Tests in the recipe
1. `go-png2ico --version` reports the built tag.
2. Round-trip a base64-decoded 1×1 PNG through the tool + assert the ICO magic bytes.

## Local verification (darwin/arm64, upstream v2.0.8)
```
$ go-png2ico --version
go-png2ico version v2.0.8
$ printf '%s' 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC' | base64 -d > one.png
$ go-png2ico one.png out.ico
$ od -An -tx1 -N4 out.ico | tr -d ' \n'
00000100
```

## Test plan
- [ ] CI green (all supported OS/arch)
- [ ] `--version` output matches `{{version.tag}}`
- [ ] Round-trip test produces a valid ICO