### PR TITLE
new(howett.net/plist): ply CLI (plist inspector / converter)

### DIFF
--- a/projects/howett.net/plist/package.yml
+++ b/projects/howett.net/plist/package.yml
@@ -1,0 +1,44 @@
+distributable:
+  url: https://github.com/DHowett/go-plist/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+display-name: go-plist
+
+versions:
+  github: DHowett/go-plist/tags
+
+build:
+  dependencies:
+    go.dev: ^1.26
+  env:
+    CGO_ENABLED: 0
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+    LDFLAGS:
+      - -s
+      - -w
+    linux:
+      # -buildmode=pie or segmentation fault on some glibc + Go combos
+      # https://github.com/docker-library/golang/issues/402#issuecomment-982204575
+      LDFLAGS:
+        - -s
+        - -w
+        - -buildmode=pie
+  script:
+    - working-directory: cmd/ply
+      run: go build -v -trimpath -ldflags="${LDFLAGS}" -o "{{ prefix }}"/bin/ply .
+
+provides:
+  - bin/ply
+
+test:
+  # ply has no --version flag (go-flags exits with "unknown flag `version'"),
+  # so a functional round-trip is the honest smoke test: feed it a minimal
+  # XML plist, ask for JSON, assert the exact output.
+  script: |
+    cat > sample.plist <<'PLIST'
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0"><dict><key>k</key><string>v</string></dict></plist>
+    PLIST
+    test "$(ply -c json sample.plist)" = '{"k":"v"}'

--- a/projects/howett.net/plist/package.yml
+++ b/projects/howett.net/plist/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://github.com/DHowett/go-plist/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/DHowett/go-plist/archive/refs/tags/{{version.tag}}.tar.gz
   strip-components: 1
 
 display-name: go-plist
@@ -12,21 +12,16 @@ build:
     go.dev: ^1.26
   env:
     CGO_ENABLED: 0
-    GOPROXY: https://proxy.golang.org,direct
-    GOSUMDB: sum.golang.org
-    LDFLAGS:
+    GO_LDFLAGS:
       - -s
       - -w
     linux:
       # -buildmode=pie or segmentation fault on some glibc + Go combos
       # https://github.com/docker-library/golang/issues/402#issuecomment-982204575
-      LDFLAGS:
-        - -s
-        - -w
+      GO_LDFLAGS:
         - -buildmode=pie
-  script:
-    - working-directory: cmd/ply
-      run: go build -v -trimpath -ldflags="${LDFLAGS}" -o "{{ prefix }}"/bin/ply .
+  working-directory: cmd/ply
+  script: go build -v -trimpath -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/ply .
 
 provides:
   - bin/ply
@@ -35,10 +30,10 @@ test:
   # ply has no --version flag (go-flags exits with "unknown flag `version'"),
   # so a functional round-trip is the honest smoke test: feed it a minimal
   # XML plist, ask for JSON, assert the exact output.
-  script: |
-    cat > sample.plist <<'PLIST'
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0"><dict><key>k</key><string>v</string></dict></plist>
-    PLIST
-    test "$(ply -c json sample.plist)" = '{"k":"v"}'
+  - run: test "$(ply -c json $FIXTURE)" = '{"k":"v"}'
+    fixture:
+      extname: plist
+      content: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict><key>k</key><string>v</string></dict></plist>


### PR DESCRIPTION
## Summary
- Ships `ply`, the CLI from howett.net/plist (a.k.a. [github.com/DHowett/go-plist](https://github.com/DHowett/go-plist)).
- Reads Apple property lists (XML, binary, OpenStep, GNUStep) and converts between those + JSON / YAML / pretty via `-c <format>`.
- Ergonomic single-binary alternative to Apple's `plutil` for non-macOS hosts and CI pipelines.
- Pure Go, `CGO=0`. Builds against `go.dev ^1.26`. Linux uses `-buildmode=pie` per docker-library/golang#402. `-trimpath` for reproducibility.

## Test rationale
`ply` has no `--version` flag (its go-flags parser returns `unknown flag 'version'`), so a functional round-trip is the honest smoke test — feed a minimal XML plist to `ply -c json` and assert the exact JSON output.

## Local verification (darwin/arm64, upstream v1.0.1)
```
$ ply -c json sample.plist
{"k":"v"}
```
Where `sample.plist` is:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0"><dict><key>k</key><string>v</string></dict></plist>
```

## Test plan
- [ ] CI green (all supported OS/arch)
- [ ] `ply -c json sample.plist` outputs `{"k":"v"}` exactly