### PR TITLE
refactor: yq-safe toml/pyproject version bumps

### DIFF
--- a/projects/apollographql.com/rover/package.yml
+++ b/projects/apollographql.com/rover/package.yml
@@ -17,11 +17,12 @@ build:
   dependencies:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version field
     linux:
       perl.org: ^5 # openssl mod
   script:
     # missed version bump
-    - sed -i '1,20s/^version = ".*"/version = "{{ version }}"/' Cargo.toml
+    - yq -i '.package.version = "{{ version }}"' Cargo.toml
     - cargo install --locked --path . --root {{prefix}}
 
 test: test "$(rover --version)" = "Rover {{version}}"

--- a/projects/crates.io/drill/package.yml
+++ b/projects/crates.io/drill/package.yml
@@ -15,8 +15,10 @@ build:
   dependencies:
     rust-lang.org: ">=1.56"
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
   script:
-    - sed -i '1,20s/^version = ".*"$/version = "{{version}}"/' Cargo.toml
+    # missed version bump
+    - yq -i '.package.version = "{{version}}"' Cargo.toml
     - cargo install --path . --root {{prefix}}
 
 test:

--- a/projects/crates.io/imessage-exporter/package.yml
+++ b/projects/crates.io/imessage-exporter/package.yml
@@ -16,10 +16,11 @@ build:
   dependencies:
     rust-lang.org: ">=1.95" # since v4.1.0
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
   working-directory: imessage-exporter
   script:
     # version unset
-    - sed -i 's/^version = ".*"$/version = "{{version}}"/' Cargo.toml
+    - yq -i '.package.version = "{{version}}"' Cargo.toml
     - cargo install --locked --path . --root {{prefix}}
 
 test:

--- a/projects/crates.io/omekasy/package.yml
+++ b/projects/crates.io/omekasy/package.yml
@@ -12,9 +12,10 @@ build:
   dependencies:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version field
   script:
     # missed version bump
-    - sed -i '1,20s/^version = ".*"/version = "{{ version }}"/' Cargo.toml
+    - yq -i '.package.version = "{{ version }}"' Cargo.toml
     - cargo install --path . --root {{prefix}}
 
 test:

--- a/projects/crates.io/sd/package.yml
+++ b/projects/crates.io/sd/package.yml
@@ -12,9 +12,10 @@ build:
   dependencies:
     rust-lang.org: ">=1.65"
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
   script:
-    # missed version bump
-    - sed -i 's/^version = ".*"/version = "{{version}}"/' Cargo.toml
+    # missed version bump; workspace.package for >=1.1.0, package for older
+    - yq -i '(.workspace.package // .package).version = "{{version}}"' Cargo.toml
     - run: cargo install --locked --path . --root {{prefix}}
       if: <1.1.0
     - run: cargo install --locked --path sd-cli --root {{prefix}}

--- a/projects/crates.io/silicon/package.yml
+++ b/projects/crates.io/silicon/package.yml
@@ -25,8 +25,10 @@ build:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
     cmake.org: ^3
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version field
   script:
-    - sed -i '1,20s/^version = .*/version = "{{ version }}"/' Cargo.toml
+    # missed version bump
+    - yq -i '.package.version = "{{ version }}"' Cargo.toml
     - cargo install --locked --path . --root {{prefix}}
 
 test: test "$(silicon --version)" = "silicon {{version}}"

--- a/projects/crates.io/spotify_player/package.yml
+++ b/projects/crates.io/spotify_player/package.yml
@@ -19,9 +19,10 @@ build:
   dependencies:
     rust-lang.org: ">=1.60"
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
   script:
     # they shipped v0.0.0 after v0.20.0; but the release is there, so we can build it.
-    - sed -i '1,10s/^version = ".*"/version = "{{version}}"/' spotify_player/Cargo.toml
+    - yq -i '.package.version = "{{version}}"' spotify_player/Cargo.toml
     - cargo install $ARGS
 
     # link to libsixel properly

--- a/projects/crates.io/tabiew/package.yml
+++ b/projects/crates.io/tabiew/package.yml
@@ -15,9 +15,10 @@ dependencies:
 build:
   dependencies:
     rust-lang.org/rustup: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
   script:
     # missed version bump
-    - sed -i 's/^version = .*/version = "{{ version }}"/' Cargo.toml
+    - yq -i '.package.version = "{{ version }}"' Cargo.toml
     # requires nightly as of 0.10.0 for a polars feature
     - run:
         - CHAIN=nightly

--- a/projects/edgedb.com/package.yml
+++ b/projects/edgedb.com/package.yml
@@ -11,6 +11,7 @@ build:
     rust-lang.org: ^1.61
     rust-lang.org/cargo: ^0
     perl.org: ^5
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
   env:
     RUSTFLAGS:
       # Ignore warnings (to focus on errors)
@@ -25,7 +26,7 @@ build:
       working-directory: src
       if: '>=4'
     # missed version bump
-    - run: sed -i '1,40s/^version = .*$/version = "{{version.raw}}"/' Cargo.toml
+    - run: yq -i '.package.version = "{{version.raw}}"' Cargo.toml
     - cargo install --locked --path . --root {{prefix}}
     - run:
         - |

--- a/projects/github.com/peltoche/lsd/package.yml
+++ b/projects/github.com/peltoche/lsd/package.yml
@@ -15,9 +15,10 @@ build:
   dependencies:
     rust-lang.org: '>=1.60'
     rust-lang.org/cargo: '*'
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version field
   script:
     # this was missed in 1.1.0, 1.1.2
-    - sed -i '1,20s/^version = ".*"$/version = "{{version}}"/' Cargo.toml
+    - yq -i '.package.version = "{{version}}"' Cargo.toml
     - cargo install --path . --root {{prefix}}
 
 test:

--- a/projects/github.com/promptexecution/just-mcp/package.yml
+++ b/projects/github.com/promptexecution/just-mcp/package.yml
@@ -10,9 +10,10 @@ description: Production-ready MCP server that exposes Justfile recipes over MCP.
 build:
   dependencies:
     rust-lang.org: '>=1.89'
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version field
   script:
     # missed version bump
-    - sed -i '1,20s/^version = ".*"$/version = "{{version}}"/' Cargo.toml
+    - yq -i '.package.version = "{{version}}"' Cargo.toml
     - cargo install --path . --root {{prefix}}
 
 provides:

--- a/projects/github.com/rustfs/cli/package.yml
+++ b/projects/github.com/rustfs/cli/package.yml
@@ -8,8 +8,10 @@ versions:
 build:
   dependencies:
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
   script:
-    - sed -i 's/^version = ".*"$/version = "{{version}}"/' Cargo.toml
+    # missed version bump; version lives in [workspace.package]
+    - yq -i '.workspace.package.version = "{{version}}"' Cargo.toml
     - cargo install --locked --path crates/cli --root {{prefix}}
 
 provides:

--- a/projects/maturin.rs/package.yml
+++ b/projects/maturin.rs/package.yml
@@ -12,9 +12,10 @@ build:
   dependencies:
     rust-lang.org: ^1.85
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
   script:
     # missing version bump
-    - sed -i '1,10s/^version = ".*"/version = "{{version}}"/' Cargo.toml
+    - yq -i '.package.version = "{{version}}"' Cargo.toml
     - run: EXTRA_ARGS="-Znext-lockfile-bump"
       if: ">=1.10"
     - cargo install --locked --path . --root {{prefix}} $EXTRA_ARGS

--- a/projects/permit.io/cedar-agent/package.yml
+++ b/projects/permit.io/cedar-agent/package.yml
@@ -12,9 +12,10 @@ build:
   dependencies:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version field
   script:
     # missed version bump
-    - sed -i '1,10s/^version = .*/version = "{{ version }}"/' Cargo.toml
+    - yq -i '.package.version = "{{ version }}"' Cargo.toml
     - cargo install --locked --path . --root {{prefix}}
 
 test: test "$(cedar-agent --version)" = "cedar-agent {{version}}"

--- a/projects/priver.dev/geni/package.yml
+++ b/projects/priver.dev/geni/package.yml
@@ -13,11 +13,12 @@ build:
   dependencies:
     rust-lang.org: ">=1.65"
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
     linux:
       gnu.org/gcc: "*" # clang doesn't handle avx512f attributes properly
   script:
     # 0.0.4, 1.0.2 got released without a version bump
-    - run: sed -i -e 's/^version = ".*"/version = "{{version}}"/' Cargo.toml
+    - run: yq -i '.package.version = "{{version}}"' Cargo.toml
     - run: sed -i -e 's/"0\.0\.3"/"{{version}}"/' main.rs
       working-directory: src
       if: =0.0.4

--- a/projects/pypa.io/setuptools/package.yml
+++ b/projects/pypa.io/setuptools/package.yml
@@ -13,9 +13,12 @@ runtime:
     PYTHONPATH: ${{prefix}}/lib/python3.12/site-packages:$PYTHONPATH
 
 build:
-  # 75.3.4 shipped with incorrect version info
-  - sed -i 's/^version = ".*"$/version = "{{version}}"/' pyproject.toml
-  - python -m pip install --prefix={{prefix}} .
+  dependencies:
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
+  script:
+    # 75.3.4 shipped with incorrect version info
+    - yq -i '.project.version = "{{version}}"' pyproject.toml
+    - python -m pip install --prefix={{prefix}} .
 
 test:
   - python -c 'import setuptools; print(setuptools.__version__)' | tee out

--- a/projects/railway.app/package.yml
+++ b/projects/railway.app/package.yml
@@ -10,11 +10,12 @@ build:
   dependencies:
     rust-lang.org: ^1.77
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml version field
     darwin:
       gnu.org/libiconv: "*" # transitive, but we need it here to get it *out*
   script:
     # 3.5.2 didn't bump version
-    - run: sed -i 's/^version = ".*"$/version = "{{version}}"/' Cargo.toml
+    - run: yq -i '.package.version = "{{version}}"' Cargo.toml
     - cargo add proc-macro2
     - cargo install $ARGS
     # something weird is causing it to link in unneeded iconv in 4.27.5

--- a/projects/rome.tools/package.yml
+++ b/projects/rome.tools/package.yml
@@ -14,9 +14,10 @@ build:
   dependencies:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version field
   script:
-    - sed -i.bak 's/version = "0.0.0"/version = "{{version}}"/' Cargo.toml
-    - rm Cargo.toml.bak
+    # shipped with a 0.0.0 placeholder version
+    - yq -i '.package.version = "{{version}}"' Cargo.toml
     - cargo install --locked --path . --root {{prefix}}
 
 test:

--- a/projects/squawkhq.com/package.yml
+++ b/projects/squawkhq.com/package.yml
@@ -14,6 +14,7 @@ build:
     rust-lang.org/cargo: '*'
     openssl.org: '*'
     perl.org: '*'
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version field
   script:
     - run: cd cli
       if: <2
@@ -21,8 +22,8 @@ build:
       if: '>=2<2.2'
     - run: cd crates/squawk
       if: '>=2.2'
-    # missing version bump
-    - sed -i '1,/dependencies/s/version = ".*"/version = "{{ version }}"/' Cargo.toml
+    # missing version bump (cwd set by the cd above, per version)
+    - yq -i '.package.version = "{{ version }}"' Cargo.toml
     - cargo install --path . --root {{prefix}}
   env:
     darwin/x86-64:


### PR DESCRIPTION
Replace fragile sed version-field patches with context-aware yq edits
(.package.version / .workspace.package.version / .project.version) so
dependency-version sub-tables can't be clobbered. Adds github.com/mikefarah/yq
as a build dep for each.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
