### PR TITLE
refactor: yq-safe toml dependency/feature surgeries

### DIFF
--- a/projects/crates.io/spider_cli/package.yml
+++ b/projects/crates.io/spider_cli/package.yml
@@ -12,6 +12,7 @@ build:
   dependencies:
     rust-lang.org: ">=1.56"
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit toml deps/features
   env:
     linux/x86-64:
       # -pie: ubuntu requires PIE (passes on debian without it, SIGILL on ubuntu)
@@ -19,14 +20,11 @@ build:
       RUSTFLAGS: -C target-cpu=x86-64 -C link-args=-pie
   script:
     # needs openssl 3 on linux, but our rust locks us to 1.1.1
-    - run: sed -f $PROP -i Cargo.toml
+    - run: yq -i '.dependencies.openssl-sys.version = "*" | .dependencies.openssl-sys.features = ["vendored"]' Cargo.toml
       working-directory: spider_cli
       if: linux
-      prop: |
-        /^serde_json =/a\
-        openssl-sys = { version = "*", features = ["vendored"] }
     # io_uring is default-on but SIGILLs on CI ubuntu runners (since v2.47.22)
-    - run: sed -i -E 's/,? *"io_uring"//' Cargo.toml
+    - run: yq -i '.features.default -= ["io_uring"]' Cargo.toml
       working-directory: spider
       if: linux/x86-64
     # _requires_ spider/serde to build since 2.37.120

--- a/projects/leo-lang.org/package.yml
+++ b/projects/leo-lang.org/package.yml
@@ -15,10 +15,16 @@ build:
     rust-lang.org/cargo: "*"
     cmake.org: ^3 # as of 1.12.0 for libz-ng-sys crate
     git-scm.org: 2 # as of 2.3.1 for the _required_ examples subrepo
+    github.com/mikefarah/yq: '>=4' # context-aware toml version edit
   script:
     - git submodule update --init --recursive
-    # bad version into
-    - run: sed -i 's/4\.0\.1/{{version}}/g' $(find . -name Cargo.toml)
+    # v4.0.2 shipped still pinned to 4.0.1. bump only leo's own crates — the
+    # path-deps in [workspace.dependencies] plus each member's package version —
+    # not a third-party dep that happens to match 4.0.1 (which the old broad
+    # `sed 's/4.0.1/.../g'` across every Cargo.toml would have clobbered).
+    - run:
+        - yq -i '(.workspace.dependencies[] | select(has("path")).version) = "={{version}}"' Cargo.toml
+        - for f in $(find crates -name Cargo.toml); do yq -i '(.package | select(has("version")).version) = "{{version}}"' "$f"; done
       if: =4.0.2
     - run: cargo install --locked --path . --root {{prefix}}
       if: <4

--- a/projects/materialize.com/package.yml
+++ b/projects/materialize.com/package.yml
@@ -21,12 +21,13 @@ build:
     gnu.org/automake: "*"
     gnu.org/autoconf: "*"
     protobuf.dev: 26.1
+    github.com/mikefarah/yq: ">=4" # safe-edit toml features array
     linux:
       git-scm.org: ^2
       llvm.org: <17
   script:
     # the protobuf-src crate isn't building atm
-    - run: sed -i '/^default =/s/"protobuf-src", //' Cargo.toml
+    - run: yq -i '.features.default -= ["protobuf-src"]' Cargo.toml
       working-directory: ../build-tools
       if: ">=0.106"
     - cargo install --locked --path . --root {{prefix}}

--- a/projects/nixpacks.com/package.yml
+++ b/projects/nixpacks.com/package.yml
@@ -9,8 +9,10 @@ build:
   dependencies:
     rust-lang.org: ^1.65
     rust-lang.org/cargo: '*'
+    github.com/mikefarah/yq: '>=4' # conditional toml dep-version pin
   script:
-    - sed -i 's/cargo_toml = "0.13.0"/cargo_toml = "0.14.0"/' Cargo.toml
+    # cargo_toml 0.13.0 fails to build; bump that pin to 0.14.0
+    - yq -i '(.dependencies.cargo_toml | select(. == "0.13.0")) = "0.14.0"' Cargo.toml
     - cargo install $ARGS
   env:
     ARGS:

--- a/projects/quary.dev/sqruff/package.yml
+++ b/projects/quary.dev/sqruff/package.yml
@@ -14,6 +14,7 @@ build:
     rust-lang.org/rustup: '*'
     linux:
       llvm.org: '*' # else toolchain failures in build.rs
+      github.com/mikefarah/yq: '>=4' # safe-delete jemallocator dep
   working-directory: crates/cli
   script:
     # requires nightly features
@@ -25,7 +26,9 @@ build:
 
     # jemalloc breaks linux build
     - run:
-        - sed -i '/jemallocator/{N;N;d;}' cli/Cargo.toml lib/Cargo.toml
+        # per-file: multi-file `yq -i` concatenates toml docs into the first
+        - yq -i 'del(.target[].dependencies.jemallocator)' cli/Cargo.toml
+        - yq -i 'del(.target[].dependencies.jemallocator)' lib/Cargo.toml
         - sed -i -f $PROP cli/src/main.rs
       working-directory: ..
       if: linux

--- a/projects/reacher.email/check-if-email-exists-cli/package.yml
+++ b/projects/reacher.email/check-if-email-exists-cli/package.yml
@@ -17,12 +17,16 @@ build:
     rust-lang.org: '>=1.65'
     rust-lang.org/cargo: '*'
     perl.org: '*'
+    github.com/mikefarah/yq: '>=4' # safe-edit toml version/deps
   script:
-    # forgot to bump the version
-    - run: sed -i -e '1,20s/^version = ".*"/version = "{{version}}"/' core/Cargo.toml cli/Cargo.toml backend/Cargo.toml
+    # forgot to bump the version (per-file: multi-file `yq -i` corrupts toml)
+    - run:
+        - yq -i '.package.version = "{{version}}"' core/Cargo.toml
+        - yq -i '.package.version = "{{version}}"' cli/Cargo.toml
+        - yq -i '.package.version = "{{version}}"' backend/Cargo.toml
       working-directory: ..
     # missing feature needed to build
-    - run: sed -i '/check-if-email-exists =/s/ \}/, features = ["sentry"] \}/' Cargo.toml
+    - run: yq -i '.dependencies["check-if-email-exists"].features = ["sentry"]' Cargo.toml
       if: ^0.10
     - cargo install --path . --root {{prefix}}
 

--- a/projects/rust-lang.org/rustup/package.yml
+++ b/projects/rust-lang.org/rustup/package.yml
@@ -14,10 +14,11 @@ build:
   dependencies:
     rust-lang.org: ^1.85 # edition2024 in v1.28.0
     rust-lang.org/cargo: ^0.86 # edition2024 in v1.28.0
+    github.com/mikefarah/yq: ">=4" # safe-edit toml features array
   script:
     # rust/curl has issues with linking to Apple's libcurl; this manifests in
     # Sonoma every time. Fortunately, rustup will use `reqwest` as a backend.
-    - run: sed -i 's/"curl-backend",//' Cargo.toml
+    - run: yq -i '.features.default -= ["curl-backend"]' Cargo.toml
       if: darwin
     - cargo install --locked --path . --root {{prefix}}
     - run: ln -s rustup-init rustup

--- a/projects/solana.com/package.yml
+++ b/projects/solana.com/package.yml
@@ -15,11 +15,12 @@ build:
     rust-lang.org: '>=1.75<1.78'
     rust-lang.org/cargo: <0.83
     freedesktop.org/pkg-config: ^0.29
+    github.com/mikefarah/yq: '>=4' # conditional toml dep-version pin
     linux:
       systemd.io: '*' # hidapi crate requires libudev
   script:
-    # ahash 0.8.3 got yanked, and 0.8.4 has build failures
-    - sed -i -e 's/^ahash = "=0\.8\.[34]"$/ahash = "=0.8.5"/' Cargo.toml
+    # ahash 0.8.3 got yanked, and 0.8.4 has build failures; pin those to 0.8.5
+    - yq -i '(.workspace.dependencies.ahash | select(. == "=0.8.3" or . == "=0.8.4")) = "=0.8.5"' Cargo.toml
     - |
       for x in \
         cli \


### PR DESCRIPTION
Replace sed edits of Cargo.toml arrays and dep tables with context-aware yq:
- materialize/rustup/spider: drop a feature from .features.default (no comma juggling)
- spider_cli: insert the openssl-sys vendored dep via yq instead of a prop sed
- check-if-email: per-file version bump + add the sentry feature to a dep
- sqruff: del the jemallocator dep via .target[] wildcard instead of a blind
  3-line `{N;N;d}` sed (its main.rs global_allocator edit stays on sed)
- leo: bump only leo's own crates (path-deps in [workspace.dependencies] +
  member package versions) via select(has("path")), instead of a broad
  `sed 's/4.0.1/.../g'` that would also hit any third-party dep at 4.0.1
- solana/nixpacks: conditional dep-version pins via select(. == "x"), targeting
  the exact node instead of a line-anchored sed (no-op on versions past the fix)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
