### PR TITLE
refactor: context-aware structured-file edits (json/yaml/rust)

### DIFF
--- a/projects/expo.dev/eas-cli/package.yml
+++ b/projects/expo.dev/eas-cli/package.yml
@@ -14,14 +14,14 @@ build:
   dependencies:
     python.org: ~3.10
     yarnpkg.com: ">=4.12" # per package.json, v18.0.3
+    github.com/mikefarah/yq: ">=4" # safe-edit json version field
     linux:
       gnu.org/gcc: "*"
   script:
     - mkdir -p "{{prefix}}"
 
     # missed version bump
-    - run: |
-        sed -i '1,10s/"version": ".*"/"version": "{{version}}"/' package.json
+    - run: yq -i '.version = "{{version}}"' package.json
       working-directory: packages/eas-cli
 
     - yarn install

--- a/projects/heroku.com/package.yml
+++ b/projects/heroku.com/package.yml
@@ -11,11 +11,12 @@ dependencies:
 build:
   dependencies:
     npmjs.com: '*'
+    github.com/mikefarah/yq: '>=4' # safe-edit json bin field
   script:
     # v11+: bin field points to ./bin/run but file is ./bin/run.js
     - run: |
         if ! test -f bin/run && test -f bin/run.js; then
-          sed -i 's|"./bin/run"|"./bin/run.js"|' package.json
+          yq -i '(.. | select(. == "./bin/run")) = "./bin/run.js"' package.json
         fi
     - npm i $ARGS .
   env:

--- a/projects/microsoft.com/code-cli/package.yml
+++ b/projects/microsoft.com/code-cli/package.yml
@@ -15,10 +15,11 @@ build:
   dependencies:
     rust-lang.org: ^1.81
     rust-lang.org/cargo: "*"
+    github.com/mikefarah/yq: ">=4" # safe-edit json version field
   working-directory: cli
   script:
     # missed version bump
-    - sed -i '1,10s/"version":.*/"version":"{{version}}",/' ../package.json
+    - yq -i '.version = "{{version}}"' ../package.json
     - cargo install --locked --path . --root {{prefix}}
     - run: install_name_tool -change "@rpath/gnu.org/libiconv/v1/lib/libiconv.2.dylib" "/usr/lib/libiconv.2.dylib" code
       working-directory: ${{prefix}}/bin

--- a/projects/opensearch.org/package.yml
+++ b/projects/opensearch.org/package.yml
@@ -17,6 +17,7 @@ build:
     git-scm.org: "*"
     gnu.org/wget: "*"
     gnu.org/gcc: ^11 # for gfortran
+    github.com/mikefarah/yq: ">=4" # set cluster.name in the shipped config (yaml comments survive)
     linux:
       # on mac we use the Accelerate framework instead, on linux this is linked statically
       netlib.org/lapack: "*"
@@ -32,7 +33,9 @@ build:
     - ./gradlew -Dbuild.snapshot=false ":distribution:archives:no-jdk-{{hw.platform}}-tar:assemble"
     - run: tar --strip-components=1 -xf $SRCROOT/distribution/archives/no-jdk-{{hw.platform}}-tar/build/distributions/opensearch-*.tar.gz
       working-directory: ${{prefix}}
-    - run: 'sed -i "s|#\s*cluster.name: .*|cluster.name: opensearch_pkgx|" opensearch.yml'
+    # yq preserves the yaml comments in this user-facing config; the stock
+    # `# cluster.name: my-application` comment stays, the real key is appended
+    - run: yq -i '.["cluster.name"] = "opensearch_pkgx"' opensearch.yml
       working-directory: ${{prefix}}/config
 
     # checkout k-NN plugin

--- a/projects/quary.dev/sqruff/package.yml
+++ b/projects/quary.dev/sqruff/package.yml
@@ -15,6 +15,7 @@ build:
     linux:
       llvm.org: '*' # else toolchain failures in build.rs
       github.com/mikefarah/yq: '>=4' # safe-delete jemallocator dep
+      ast-grep.github.io: '*' # structural rust rewrite of the allocator
   working-directory: crates/cli
   script:
     # requires nightly features
@@ -24,17 +25,20 @@ build:
         - ln -sf $HOME/.rustup/toolchains/*/bin/* .
       working-directory: $HOME/.cargo/bin
 
-    # jemalloc breaks linux build
+    # jemalloc breaks linux build: drop the dep and swap the global allocator
+    # to std's System (a structural rewrite — attributes stay attached; no-op
+    # on modern versions, which use mimalloc)
     - run:
         # per-file: multi-file `yq -i` concatenates toml docs into the first
         - yq -i 'del(.target[].dependencies.jemallocator)' cli/Cargo.toml
         - yq -i 'del(.target[].dependencies.jemallocator)' lib/Cargo.toml
-        - sed -i -f $PROP cli/src/main.rs
+        - >-
+          ast-grep run -l rust
+          -p 'static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;'
+          -r 'static ALLOC: std::alloc::System = std::alloc::System;'
+          -U cli/src/main.rs
       working-directory: ..
       if: linux
-      prop: |
-        s|^\(.*any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64"\)|//\1|
-        /^\#\[global_allocator\]$/ {N; s|^\(#\[global_allocator\]\)\n\(static ALLOC: jemallocator\)|//\1\n//\2|}
 
     # -Ctarget-cpu is breaking darwin/x86-64
     - run: if test -f config.toml; then sed -i '/-Ctarget-cpu=native/d' config.toml; fi


### PR DESCRIPTION
Replace string-anchored seds with structure-aware tools:
- eas-cli/code-cli: package.json .version bump via yq (the code-cli sed baked
  in a trailing comma, breaking if the key order ever changes)
- heroku: conditional bin-path fix via recursive select (no-ops when fixed)
- opensearch: set cluster.name in the shipped config via yq — yq's YAML
  round-trip preserves all the stock comments users read
- sqruff: swap the jemalloc global allocator to std::alloc::System via an
  ast-grep structural rewrite, replacing the two-line comment-out sed that
  relied on exact line adjacency; no-op on modern (mimalloc) versions

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
