### PR TITLE
+penknife

### DIFF
--- a/projects/crates.io/penknife/package.yml
+++ b/projects/crates.io/penknife/package.yml
@@ -1,0 +1,25 @@
+distributable:
+  url: https://github.com/jhheider/penknife/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/penknife
+
+versions:
+  github: jhheider/penknife
+
+build:
+  dependencies:
+    rust-lang.org: ">=1.85" # edition 2024
+    rust-lang.org/cargo: "*"
+  script: cargo install --locked --path crates/penknife --root {{prefix}}
+
+test:
+  - penknife --version | tee out
+  - grep {{version}} out
+  # render and search are the no-account, no-network surface.
+  - test "$(printf '# Hi' | penknife render -)" = "<h1>Hi</h1>"
+  - run:
+      - printf 'a TODO here\n' > note.md
+      - penknife search TODO . | grep note.md
+      - if penknife search NOPE .; then exit 1; fi


### PR DESCRIPTION
[penknife](https://github.com/jhheider/penknife) is a terminal home for markdown writing: browse and search a folder, share any file as clean rich text, and sync files to GitHub Gists with honest per-file drift status. Rust, published on [crates.io](https://crates.io/crates/penknife).

Builds from the workspace's `crates/penknife`. The test exercises the no-account surface (`render` markdown to HTML, and grep-style `search` with its exit-code contract), so it needs no credentials or network.