### PR TITLE
fix(ldns): skip header flattening (shadows system <util.h>)

### DIFF
--- a/projects/nlnetlabs.nl/ldns/package.yml
+++ b/projects/nlnetlabs.nl/ldns/package.yml
@@ -9,6 +9,14 @@ dependencies:
   openssl.org: ^1
 
 build:
+  # ldns's public API is namespaced (`#include <ldns/…>`), so brewkit's default
+  # header flattening (include/ldns/*.h -> include/*.h) buys nothing and instead
+  # drops generically-named headers (util.h, net.h, error.h, parse.h, …) into
+  # the include root. Those land on dependents' CPATH and shadow system headers:
+  # e.g. openssh's `#include <util.h>` resolves to ldns's instead of the SDK's,
+  # loses the openpty() declaration, and fails the darwin build. brewkit only
+  # guards ISO-C stdlib names, not POSIX/BSD ones like util.h — so opt out.
+  skip: flatten-includes
   dependencies:
     gnu.org/autoconf: '*'
     gnu.org/automake: '*'


### PR DESCRIPTION
ldns's API is namespaced (<ldns/...>), but brewkit flattens include/ldns/*.h
into the include root, dropping generically-named headers (util.h, net.h,
error.h, parse.h, ...) that then shadow system headers via dependents' CPATH.
openssh's '#include <util.h>' was resolving to ldns's copy instead of the
macOS SDK's, losing the openpty() declaration and failing the darwin build of
10.4 (modern Apple clang errors on the implicit declaration). brewkit only
guards ISO-C stdlib names, not POSIX/BSD ones like util.h.

Verified locally on darwin/aarch64: ldns rebuilds with a clean include/ (only
include/ldns/), and openssh 10.4 then builds, installs, and reports
OpenSSH_10.4p1.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
