### PR TITLE
fix(wails): GOWORK=off for >=2.13 (root go.work lists only v3)

### DIFF
--- a/projects/wails.io/package.yml
+++ b/projects/wails.io/package.yml
@@ -21,6 +21,11 @@ dependencies:
 build:
   working-directory: v2
   script:
+    # 2.13.0 added a root go.work that lists only ./v3; ignore it so `go build`
+    # resolves against the v2 module instead of erroring that v2/cmd/wails isn't
+    # a workspace module.
+    - run: export GOWORK=off
+      if: '>=2.13'
     - go build -v -ldflags="$LDFLAGS" -o wails ./cmd/wails
     - install -D wails {{prefix}}/bin/wails
   env:


### PR DESCRIPTION
2.13.0 introduced a root go.work with `use (./v3)`. The build runs
`go build ./cmd/wails` inside v2, and go picks up that workspace — which
doesn't list the v2 module — failing with 'directory cmd/wails is contained
in a module that is not one of the workspace modules'. The recipe only builds
v2, so disable workspace mode. Gated >=2.13 (go.work first appears there).

Verified locally on darwin: builds, installs, `wails version` -> v2.13.0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
