### PR TITLE
fix(fbthrift): cast token_.kind switch condition to tok (darwin/clang)

### DIFF
--- a/projects/facebook.com/fbthrift/package.yml
+++ b/projects/facebook.com/fbthrift/package.yml
@@ -49,6 +49,15 @@ build:
       working-directory: thrift/cmake
       if: darwin
 
+    # the compiler's `switch (token_.kind)` (kind is a token_kind, a class type)
+    # relies on its implicit `operator tok()` to pick the switch's adjusted type.
+    # clang mis-selects the class type instead and rejects the `case tok::…`
+    # labels as non-constant (gcc/linux is fine). Cast the condition to force the
+    # intended conversion; no-op on versions predating the token_.kind switches.
+    - run: sed -i 's/switch (token_.kind)/switch (tok(token_.kind))/g' parser_core.h
+      working-directory: thrift/compiler/parse
+      if: darwin
+
     # fmt 12 moved fmt::join to <fmt/ranges.h>; fbthrift doesn't include it
     - run: sed -i -f $PROP RoundRobinRequestPile.h
       prop: |


### PR DESCRIPTION
closes #13723

The compiler's parser gained `switch (token_.kind)` where kind is a
token_kind (class type). The switch relies on token_kind's implicit
`operator tok()` for the condition's adjusted type, but clang instead treats
the adjusted type as the class and rejects each `case tok::…` label as a
non-constant expression (case value is not a constant expression). gcc accepts
it, so only the darwin build breaks. Cast the condition to tok to force the
intended conversion.

Verified locally on darwin/aarch64: the failing thrift/compiler/parse/parser.cc
compiles clean with the cast. Making token_kind(tok) constexpr does NOT help;
-fms-compatibility does but is far too broad.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>