### PR TITLE
+govee-tui

### DIFF
--- a/projects/github.com/jhheider/govee-tui/package.yml
+++ b/projects/github.com/jhheider/govee-tui/package.yml
@@ -1,0 +1,23 @@
+distributable:
+  url: https://github.com/jhheider/govee-tui/archive/refs/tags/{{ version.tag }}.tar.gz
+  strip-components: 1
+
+provides:
+  - bin/govee-tui
+
+versions:
+  github: jhheider/govee-tui/tags
+
+build:
+  dependencies:
+    rust-lang.org: '>=1.75'
+    rust-lang.org/cargo: '*'
+  script:
+    - cargo build --release --locked
+    - run:
+        - mkdir -p {{prefix}}/bin
+        - install govee-tui {{prefix}}/bin/
+      working-directory: target/release
+
+test:
+  - govee-tui --version | grep {{version}}


### PR DESCRIPTION
Adds a package for [govee-tui](https://github.com/jhheider/govee-tui), a Rust TUI for controlling Govee smart lights.

- Builds from the GitHub source tarball with the Rust toolchain (`cargo build --release --locked`).
- Installs `bin/govee-tui`.
- License: MIT OR Apache-2.0.
- Test verifies `govee-tui --version` reports the packaged version.