### PR TITLE
fix(gcc/v8): stop cc1 SIGSEGV on every compile (mirror main gcc PIE/no-LTO flags)

### DIFF
--- a/projects/gnu.org/gcc/v8/package.yml
+++ b/projects/gnu.org/gcc/v8/package.yml
@@ -27,8 +27,7 @@ versions:
 # up — users on darwin needing legacy C++ are better off with clang
 # from llvm.org which has its own legacy mode.
 platforms:
-  - linux/x86-64
-  - linux/aarch64
+  - linux
 
 dependencies:
   gnu.org/binutils: '*'
@@ -41,7 +40,6 @@ build:
   dependencies:
     linux:
       gnu.org/gcc: '*'   # bootstrap with current gcc
-    gnu.org/make: '*'
     perl.org: '*'
     gnu.org/patch: '*'
     curl.se: '*'
@@ -57,12 +55,12 @@ build:
     # gcc symlinks expected by some build systems. This recipe lives
     # one level deeper than the main gnu.org/gcc (v8 subdir), so the
     # relative path to binutils needs `../../../../` (4 levels).
-    - run: |
-        cd "{{prefix}}/bin"
-        ln -sf gcc cc
-        ln -sf ../../../../binutils/v\*/bin/ar ar
-        ln -sf ../../../../binutils/v\*/bin/nm nm
-        ln -sf ../../../../binutils/v\*/bin/ranlib ranlib
+    - run:
+        - ln -sf gcc cc
+        - ln -sf ../../../../binutils/v\*/bin/ar ar
+        - ln -sf ../../../../binutils/v\*/bin/nm nm
+        - ln -sf ../../../../binutils/v\*/bin/ranlib ranlib
+      working-directory: "{{prefix}}/bin"
 
   env:
     ARGS:
@@ -95,7 +93,9 @@ build:
       # aarch64.
       CFLAGS: -fPIC -fPIE
       CXXFLAGS: -fPIC -fPIE
-      LDFLAGS: -Wl,-rpath,{{deps.gnu.org/mpc.prefix}}/lib:{{deps.gnu.org/mpfr.prefix}}/lib:{{deps.gnu.org/gmp.prefix}}/lib:{{deps.zlib.net.prefix}}/lib -Wl,-rpath-link,{{deps.gnu.org/mpc.prefix}}/lib:{{deps.gnu.org/mpfr.prefix}}/lib:{{deps.gnu.org/gmp.prefix}}/lib:{{deps.zlib.net.prefix}}/lib
+      LDFLAGS:
+        - -Wl,-rpath,{{deps.gnu.org/mpc.prefix}}/lib:{{deps.gnu.org/mpfr.prefix}}/lib:{{deps.gnu.org/gmp.prefix}}/lib:{{deps.zlib.net.prefix}}/lib
+        - -Wl,-rpath-link,{{deps.gnu.org/mpc.prefix}}/lib:{{deps.gnu.org/mpfr.prefix}}/lib:{{deps.gnu.org/gmp.prefix}}/lib:{{deps.zlib.net.prefix}}/lib
 
 test:
   - gcc --version | grep -q "pkgx GCC {{version}}"
@@ -104,14 +104,19 @@ test:
   # driver: compile, link, AND run both a C and a C++ program. The old
   # version-only test let a bottle whose cc1 SIGSEGV'd on every compile
   # pass CI. This guards against that regression.
-  - |
-    echo 'int main(){return 0;}' > t.c
-    gcc t.c -o t-c && ./t-c
-  - |
-    echo '#include <vector>
-    #include <string>
-    int main(){ std::vector<std::string> v{"a","b"}; return v.size()==2 ? 0 : 1; }' > t.cc
-    g++ t.cc -o t-cc && ./t-cc
+  - run: gcc $FIXTURE -o t-c
+    fixture:
+      extname: c
+      content: int main(){return 0;}
+  - ./t-c
+  - run: g++ $FIXTURE -o t-cc
+    fixture:
+      extname: cc
+      content: |
+        #include <vector>
+        #include <string>
+        int main(){ std::vector<std::string> v{"a","b"}; return v.size()==2 ? 0 : 1; }
+  - ./t-cc
 
 provides:
   - bin/ar

--- a/projects/gnu.org/gcc/v8/package.yml
+++ b/projects/gnu.org/gcc/v8/package.yml
@@ -27,7 +27,8 @@ versions:
 # up — users on darwin needing legacy C++ are better off with clang
 # from llvm.org which has its own legacy mode.
 platforms:
-  - linux
+  - linux/x86-64
+  - linux/aarch64
 
 dependencies:
   gnu.org/binutils: '*'
@@ -40,6 +41,7 @@ build:
   dependencies:
     linux:
       gnu.org/gcc: '*'   # bootstrap with current gcc
+    gnu.org/make: '*'
     perl.org: '*'
     gnu.org/patch: '*'
     curl.se: '*'
@@ -55,12 +57,12 @@ build:
     # gcc symlinks expected by some build systems. This recipe lives
     # one level deeper than the main gnu.org/gcc (v8 subdir), so the
     # relative path to binutils needs `../../../../` (4 levels).
-    - run:
-        - ln -sf gcc cc
-        - ln -sf ../../../../binutils/v\*/bin/ar ar
-        - ln -sf ../../../../binutils/v\*/bin/nm nm
-        - ln -sf ../../../../binutils/v\*/bin/ranlib ranlib
-      working-directory: "{{prefix}}/bin"
+    - run: |
+        cd "{{prefix}}/bin"
+        ln -sf gcc cc
+        ln -sf ../../../../binutils/v\*/bin/ar ar
+        ln -sf ../../../../binutils/v\*/bin/nm nm
+        ln -sf ../../../../binutils/v\*/bin/ranlib ranlib
 
   env:
     ARGS:
@@ -72,14 +74,44 @@ build:
       - --disable-multilib
       - --with-system-zlib
       - --with-bugurl=https://github.com/pkgxdev/pantry/issues
-    linux/x86-64:
-      LDFLAGS: -fPIC
-      CFLAGS: -fPIC
-      CXXFLAGS: -fPIC
+      # PIE + no-LTO/plugin, mirroring the main gnu.org/gcc recipe's linux
+      # handling for old (>=6, <10) gcc. WITHOUT these the compiler
+      # executables (cc1/cc1plus) built by the modern pkgx toolchain come
+      # out linked such that an older glibc loader SIGSEGVs in dl_main
+      # *before the compiler runs* — i.e. cc1 crashed on every single
+      # compile (`gcc: internal compiler error: Segmentation fault ...
+      # cc1`). The old `gcc --version` test never caught it because that
+      # only runs the driver, not cc1. --enable-default-pie is gcc 6+;
+      # --disable-lto/--disable-plugin are needed for gcc <10 (the LTO
+      # plugin dlopens objects that mix the host ld-linux libc with the
+      # bottle's libc at link time).
+      - --enable-default-pie
+      - --disable-lto
+      - --disable-plugin
+    linux:
+      # Build PIC+PIE and bake the gmp/mpfr/mpc/zlib RUNPATHs into the
+      # compiler binaries so cc1/cc1plus are self-contained (no
+      # LD_LIBRARY_PATH needed at runtime). Applies to both x86-64 and
+      # aarch64.
+      CFLAGS: -fPIC -fPIE
+      CXXFLAGS: -fPIC -fPIE
+      LDFLAGS: -Wl,-rpath,{{deps.gnu.org/mpc.prefix}}/lib:{{deps.gnu.org/mpfr.prefix}}/lib:{{deps.gnu.org/gmp.prefix}}/lib:{{deps.zlib.net.prefix}}/lib -Wl,-rpath-link,{{deps.gnu.org/mpc.prefix}}/lib:{{deps.gnu.org/mpfr.prefix}}/lib:{{deps.gnu.org/gmp.prefix}}/lib:{{deps.zlib.net.prefix}}/lib
 
 test:
   - gcc --version | grep -q "pkgx GCC {{version}}"
   - gcc -dumpversion | grep -q "^8\."
+  # Actually exercise the compiler back-ends (cc1/cc1plus), not just the
+  # driver: compile, link, AND run both a C and a C++ program. The old
+  # version-only test let a bottle whose cc1 SIGSEGV'd on every compile
+  # pass CI. This guards against that regression.
+  - |
+    echo 'int main(){return 0;}' > t.c
+    gcc t.c -o t-c && ./t-c
+  - |
+    echo '#include <vector>
+    #include <string>
+    int main(){ std::vector<std::string> v{"a","b"}; return v.size()==2 ? 0 : 1; }' > t.cc
+    g++ t.cc -o t-cc && ./t-cc
 
 provides:
   - bin/ar


### PR DESCRIPTION
## Problem

The merged `gnu.org/gcc/v8` bottle is **unusable**: its `cc1`/`cc1plus` **SIGSEGV in the dynamic loader (`dl_main`) before the compiler even runs**, so *every* compile fails:

```
gcc: internal compiler error: Segmentation fault signal terminated program cc1
```

Reproduced on a real x86-64 box (Debian bullseye, glibc 2.31); gdb shows the crash is in `dl_main` (rtld.c) while starting `cc1`, not in cc1's own code. Downstream consumers (e.g. `mysql.com/v5_7` #13062) die at cmake's `testCCompiler` step because of this.

The recipe's test (`gcc --version`) never caught it — that only runs the *driver*, not `cc1`.

## Root cause

The recipe set only `-fPIC` and **none** of the linkage flags the main `gnu.org/gcc` recipe applies for old (`>=6, <10`) gcc. Built by the modern pkgx toolchain (gcc 16 + binutils 2.46), the compiler executables come out linked such that an older glibc loader can't start them.

## Fix — mirror the main `gnu.org/gcc` recipe's linux handling

- `--enable-default-pie` (gcc 6+)
- `--disable-lto --disable-plugin` (gcc <10 — the LTO plugin dlopens objects that mix the host ld-linux libc with the bottle's libc at link time)
- `CFLAGS`/`CXXFLAGS`: `-fPIC -fPIE`
- bake `gmp`/`mpfr`/`mpc`/`zlib` RUNPATHs so `cc1`/`cc1plus` are self-contained

…and **harden the test** to actually compile + link + **run** both a C and a C++ program, so this class of breakage can't regress unnoticed.

## Verification

Verified end-to-end on x86-64: full build + install, then `gcc`/`g++` compile, link and run C and C++ programs (exit 0), **including in a clean `env -i`** (confirming the RUNPATHs make the compiler self-contained). `cc1 -S` no longer crashes.

Unblocks #13062 (MySQL 5.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)