### PR TITLE
fix(llvm.org): ship libc++/libc++abi/libunwind on linux

### DIFF
--- a/projects/llvm.org/package.yml
+++ b/projects/llvm.org/package.yml
@@ -40,9 +40,20 @@ build:
   script:
     # Building compiler-rt on darwin+aarch64 fails for versions less than
     # 14 with the below configuration. FIXME if possible, of course.
+    #
+    # On linux we ALSO build libc++/libc++abi/libunwind as runtimes so the
+    # bottle ships a usable libc++ (headers under include/c++/v1 + the
+    # shared libs). Without it, clang has no libc++ at all on linux — only
+    # gcc's libstdc++ (which stays the default via CLANG_DEFAULT_CXX_STDLIB
+    # below) — so anything requiring `-stdlib=libc++` (e.g. envoyproxy.io,
+    # which dropped gcc/libstdc++ support in 1.21+) fails with
+    # "'iostream'/'string' file not found". This is additive: libstdc++
+    # remains the default; libc++ is now available on request. Darwin gets
+    # libc++ from the SDK, so we only add these on linux.
     - run: |
         RUNTIMES="-DLLVM_ENABLE_RUNTIMES='compiler-rt'"
         if test "{{hw.platform}}" = "linux"; then
+          RUNTIMES="-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind'"
           ARGS="$ARGS $RUNTIMES"
         elif semverator satisfies '>=14' {{version}}; then
           ARGS="$ARGS $RUNTIMES"


### PR DESCRIPTION
## Problem

The linux `llvm.org` bottle builds only `compiler-rt` as a runtime, so it ships clang with **no libc++ at all** — no `libc++.so`, no headers (`include/c++/v1`). Anything requiring `-stdlib=libc++` fails with `'iostream'`/`'string'` file not found.

This blocks **envoyproxy.io** (#13046): Envoy dropped gcc/libstdc++ support in 1.21+ and must be built with libc++, but there's no libc++ in the bottle to build against.

## Fix

Add `libcxx;libcxxabi;libunwind` to `LLVM_ENABLE_RUNTIMES` on **linux** only.

This is **additive**: `CLANG_DEFAULT_CXX_STDLIB=libstdc++` still makes gcc's libstdc++ the default, so existing consumers are unaffected; libc++ is simply now *available* for those who ask (`-stdlib=libc++`). Darwin already gets libc++ from the SDK, so the extra runtimes stay linux-only.

## Verification (x86-64, Debian bullseye)

Built the bottle with this change and confirmed:
- headers install to `include/c++/v1` (e.g. `iostream`)
- `libc++.so.1`, `libc++abi.so.1`, `libunwind.so.1` install under `lib/<triple>/` (the recipe's existing "move linux libs into /lib" step then relocates them to `lib/`)
- the freshly built `clang++ -stdlib=libc++` **compiles, links and runs** a program using `<iostream>`/`<vector>` (exit 0 with libc++ on the loader path)

Unblocks #13046 (Envoy). The Envoy recipe already forwards `-isystem{{deps.llvm.org.prefix}}/include/c++/v1` (matches the header path above) for both target and host/exec configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)