### PR TITLE
add nora cli

### DIFF
--- a/projects/github.com/solomon2773/nora/package.yml
+++ b/projects/github.com/solomon2773/nora/package.yml
@@ -1,0 +1,28 @@
+distributable:
+  url: https://registry.npmjs.org/@noraai/cli/-/cli-{{version}}.tgz
+  strip-components: 1
+
+display-name: nora
+
+versions:
+  npm: "@noraai/cli"
+
+provides:
+  - bin/nora
+
+dependencies:
+  nodejs.org: ^24
+
+build:
+  dependencies:
+    npmjs.com: "*"
+  script: npm i $ARGS .
+  env:
+    ARGS:
+      - --global
+      - --prefix={{prefix}}
+      - --install-links
+
+test:
+  - run: 'nora --version | grep -q "{{version}}"'
+  - run: 'nora --help | grep -q "Usage: nora"'


### PR DESCRIPTION
## Summary

- What changed: added a reproducible pkgx recipe for the published `@noraai/cli` npm package, exposing the `nora` binary.
- Why: let pkgx users install and run the Nora CLI directly.

## AI Intent

- Prompt or task statement: package the Nora CLI for a reputable public package catalog.
- Scope of AI-assisted changes: one new package recipe plus local build, test, and audit validation.

## Risk Assessment

- Risk level: low
- Primary risks: npm package layout or CLI output could change in a future release.
- Compatibility impact: adds a new package only; no existing recipes are changed.

## Rollback Plan

- Revert path: revert this single recipe addition.
- Forward-fix path (if revert is not possible): update the npm install flags, dependency constraint, or smoke tests.

## Validation

- Local checks run: `bk build github.com/solomon2773/nora`; `bk test github.com/solomon2773/nora`; `bk audit github.com/solomon2773/nora`.
- CI checks expected: pantry recipe validation and package build matrix.

## Internal/Public Boundary Check

- [x] No internal-only data, private URLs, secrets, or private runbooks were added.