### PR TITLE
github.com/buchgr/bazel-remote: new package

### DIFF
--- a/projects/github.com/buchgr/bazel-remote/package.yml
+++ b/projects/github.com/buchgr/bazel-remote/package.yml
@@ -1,0 +1,35 @@
+distributable:
+  url: https://github.com/buchgr/bazel-remote/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: buchgr/bazel-remote/releases
+
+provides:
+  - bin/bazel-remote
+
+build:
+  script: |
+    go build -v -ldflags="$LDFLAGS" -o bazel-remote .
+    mkdir -p "{{prefix}}"/bin
+    mv bazel-remote "{{prefix}}"/bin
+
+    # gocache/gopath are not needed in the bottle
+    chmod -R u+w "$GOPATH" "$GOCACHE"
+    rm -rf "$GOPATH" "$GOCACHE"
+  dependencies:
+    go.dev: ^1.24
+  env:
+    GOPATH: ${{prefix}}/gopath
+    GOCACHE: ${{prefix}}/gocache
+    GOFLAGS: -mod=mod
+    LDFLAGS:
+      - -s -w
+    linux:
+      # -buildmode=pie: match distro Go binaries, avoid a segfault seen with
+      # some glibc/loader combos (docker-library/golang#402)
+      LDFLAGS:
+        - -buildmode=pie
+
+test:
+  bazel-remote --help 2>&1 | grep -q 'remote build cache'


### PR DESCRIPTION
## What

Adds a recipe for [`bazel-remote`](https://github.com/buchgr/bazel-remote) — a remote build cache for Bazel and other REAPI clients (HTTP + gRPC REST cache, disk/S3 backends, GC/quota). It is the de-facto self-hosted cache used to share/resume Bazel build actions across machines and CI runners.

## Build

Pure-Go, built with `go.dev` (module `github.com/buchgr/bazel-remote/v2`). No CGO. Linux uses `-buildmode=pie` (the usual golang#402 workaround), matching other Go recipes in the pantry.

## Validation (local)

- Built `v2.6.2` from the release tarball with the recipe's exact build script → `bazel-remote` binary produced.
- Ran the recipe `test` (`bazel-remote --help` matches `remote build cache`) → passes.
- Recipe validates against the pkgx package schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)