### PR TITLE
Add OutageDeck CLI package

### DIFF
--- a/projects/outagedeck.com/package.yml
+++ b/projects/outagedeck.com/package.yml
@@ -1,0 +1,24 @@
+distributable:
+  url: https://github.com/outagedeck/cli/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: outagedeck/cli
+
+build:
+  dependencies:
+    go.dev: ^1.22
+  script: go build -trimpath -ldflags "$LDFLAGS" -o {{prefix}}/bin/outagedeck ./cmd/outagedeck
+  env:
+    CGO_ENABLED: 0
+    LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+
+provides:
+  - bin/outagedeck
+
+test:
+  - test "$(outagedeck version)" = "{{version}}"
+  - outagedeck --help | grep 'check cloud and SaaS status from official vendor feeds'


### PR DESCRIPTION
## Summary

- What changed: adds a reproducible pkgx recipe for `outagedeck/cli`, built from the tagged source with CGO disabled and the package version injected into the CLI binary.
- Why: makes the zero-key OutageDeck cloud and SaaS status CLI available through pkgx's one-command install and execution flow. I maintain and represent OutageDeck.

## AI Intent

- Prompt or task statement: distribute the OutageDeck CLI through appropriate package-manager channels without changing the product repository.
- Scope of AI-assisted changes: one new `projects/outagedeck.com/package.yml` recipe and its build, audit, test, and CI-matrix validation.

## Risk Assessment

- Risk level: low
- Primary risks: upstream tag/source-layout changes, Go toolchain compatibility, or a version linker variable change could break a future package build.
- Compatibility impact: the recipe uses the pantry's default Linux and macOS matrix on x86-64 and ARM64, builds a static Go binary with `CGO_ENABLED=0`, and introduces no runtime dependencies.

## Rollback Plan

- Revert path: revert this commit or remove `projects/outagedeck.com/package.yml`.
- Forward-fix path (if revert is not possible): pin or adjust the Go dependency range, source layout, linker variable, or tests in the recipe.

## Validation

- Local checks run:
  - `bk build --clean` for OutageDeck CLI v0.1.0: passed from the tagged source
  - `bk audit`: passed
  - `bk test`: passed; verifies the exact version and stable help banner
  - repository CI planner: produced Linux and macOS x86-64/ARM64 jobs
  - `git diff --check`: passed
- CI checks expected: the pantry's standard build, audit, and test matrix for all four default platforms.

## Internal/Public Boundary Check

- [x] No internal-only data, private URLs, secrets, or private runbooks were added.
