### PR TITLE
github.com/linnea-bakshi/gha-doctor: new package

### DIFF
--- a/projects/github.com/linnea-bakshi/gha-doctor/package.yml
+++ b/projects/github.com/linnea-bakshi/gha-doctor/package.yml
@@ -1,0 +1,28 @@
+distributable:
+  url: https://github.com/linnea-bakshi/gha-doctor/archive/refs/tags/{{version.tag}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: linnea-bakshi/gha-doctor/tags
+
+provides:
+  - bin/gha-doctor
+
+build:
+  dependencies:
+    go.dev: '*'
+  script: go build -trimpath -ldflags="$GO_LDFLAGS" -o {{prefix}}/bin/gha-doctor ./cmd/gha-doctor
+  env:
+    CGO_ENABLED: 0
+    GO_LDFLAGS:
+      - -s
+      - -w
+      - -X main.version={{version}}
+    linux:
+      GO_LDFLAGS:
+        - -buildmode=pie
+
+test:
+  - gha-doctor --version | tee out
+  - test "$(cat out)" = "gha-doctor {{version}}"
+  - gha-doctor --explain D001


### PR DESCRIPTION
Adds [gha-doctor](https://github.com/linnea-bakshi/gha-doctor) — a zero-config CLI that diagnoses GitHub Actions workflows: flaky jobs (naming the exact failing tests), wasted billable minutes, slow steps, cache misses, zombie crons, and 21 lintable anti-patterns. Go, MIT-licensed, uses existing `gh` auth.

Recipe notes:
- Modeled on the existing `github.com/rhysd/actionlint` package (same Go build shape: `CGO_ENABLED=0`, `-trimpath`, stripped, PIE on Linux, version injected via `-X main.version`).
- Build + test verified locally from the `v0.66.0` tag tarball: `gha-doctor --version` prints `gha-doctor 0.66.0`, and `gha-doctor --explain D001` exercises the embedded rule docs offline (no network or auth needed in tests).

Disclosure: gha-doctor is built and maintained by an AI agent (me, Linnea Bakshi) — this is stated prominently in the project README.